### PR TITLE
tag: extend to talk namespace

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -3,7 +3,6 @@
 
 (function($){
 
-
 /*
  ****************************************
  *** friendlytag.js: Tag module
@@ -31,6 +30,11 @@ Twinkle.tag = function friendlytag() {
 	else if( ( mw.config.get('wgNamespaceNumber') === 0 || mw.config.get('wgNamespaceNumber') === 118 || /^Wikipedia( talk)?:Articles for creation\//.exec(Morebits.pageNameNorm) ) && mw.config.get('wgCurRevisionId') ) {
 		Twinkle.tag.mode = 'article';
 		Twinkle.addPortletLink( Twinkle.tag.callback, "Tag", "friendly-tag", "Add maintenance tags to article" );
+	}
+	// talk page tagging
+	else if(mw.config.get('wgNamespaceNumber') === 1) {
+		Twinkle.tag.mode = 'talk';
+		Twinkle.addPortletLink(Twinkle.tag.callback, "Tag", "friendly-tag", "Add maintenance templates to talk page");
 	}
 };
 
@@ -127,6 +131,37 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 			form.append({ type: 'header', label:'Miscellaneous and administrative redirect templates' });
 			form.append({ type: 'checkbox', name: 'redirectTags', list: Twinkle.tag.administrativeList });
+			break;
+
+		case 'talk':
+			Window.setTitle( "Talk page tagging" );
+			
+			form.append({ type: 'header', label: 'Attribution' });
+			Twinkle.tag.talk.attributionList.forEach(function(el) {
+				form.append({
+					type: 'checkbox',
+					name: 'talkTags',
+					list: [ {
+						value: el,
+						label: Twinkle.tag.talk.tags[el].label,
+						subgroup: Twinkle.tag.talk.tags[el].subgroup 
+					} ]
+				});
+			});
+
+			form.append({ type: 'header', label: 'Other templates' });
+			Twinkle.tag.talk.otherList.forEach(function(el) {
+				form.append({
+					type: 'checkbox',
+					name: 'talkTags',
+					list: [ {
+						value: el,
+						label: Twinkle.tag.talk.tags[el].label,
+						subgroup: Twinkle.tag.talk.tags[el].subgroup 
+					} ]
+				});
+			});
+
 			break;
 
 		default:
@@ -845,6 +880,162 @@ Twinkle.tag.file.replacementList = [
 	{ label: '{{Vector version available}}', value: 'Vector version available' }
 ];
 
+Twinkle.tag.talk = {};
+
+Twinkle.tag.talk.tags = {
+	"Translated page" : {
+		label: '{{Translated page}}: to attribute translations from other language Wikipedias',
+		subgroup: [
+			{
+				name: 'translatedLangcode',
+				type: 'input',
+				label: 'Language code: ',
+				tooltip: 'The ISO 639 language code',
+				required: true
+			},
+			{
+				name: 'translatedSourceArticle',
+				type: 'input',
+				label: 'Source article name: ',
+				tooltip: 'Exact name of the source article (without the interwiki prefix. Non-English characters must be retained.',
+				required: true
+			}
+		]
+	},
+
+	"Copied": {
+		label: '{{Copied}}: ',
+		subgroup: [
+			{
+				type: 'input',
+				name: 'copiedFrom',
+				label: 'From: ',
+				param_name: 'from',
+				required: true
+			},
+			{
+				type: 'input',
+				name: 'copiedFromOldid',
+				param_name: 'from_oldid',
+				label: 'OldId: '
+			},
+			{
+				type: 'input',
+				name: 'copiedTo',
+				label: 'To: ',
+				param_name: 'to',
+				required: true
+			},
+			{
+				type: 'input',
+				name: 'copiedDiff',
+				label: 'Diff: ',
+				tooltip: 'Revision number of the page in which the copied text first appears',
+				param_name: 'diff'
+			},
+			{
+				type: 'input',
+				name: 'copiedDate',
+				label: 'Date: ',
+				param_name: 'date'
+			}
+		]
+	},
+
+	"Merged from": {
+		label: '{{Merged from}}: ',
+		subgroup: [
+			{
+				type: 'input',
+				name: 'mergedfromArticle',
+				label: 'From article: ',
+				required: true
+			},
+			{
+				type: 'input',
+				name: 'mergedfromDate',
+				label: 'Date: '
+			}
+		]
+	},
+
+	"Merged to": {
+		label: '{{Merged to}}: ',
+		subgroup: [
+			{
+				type: 'input',
+				name: 'mergedtoArticle',
+				label: 'To article: ',
+				required: true
+			},
+			{
+				type: 'input',
+				name: 'mergedtoDate',
+				label: 'Date: '
+			}
+		]
+	},
+
+	"Split article": {
+		label: '{{Split article}}: ',
+		subgroup: [
+			{
+				type: 'input',
+				name: 'splitFrom',
+				label: 'From: ',
+				tooltip: 'Name of page from which content was removed',
+				param_name: 'from',
+				required: true
+			},
+			{
+				type: 'input',
+				name: 'splitFromOldid',
+				label: 'From oldid: ',
+				tooltip: 'Permanent link url or revisionid from which the material was copied',
+				param_name: 'from_oldid'
+			},
+			{
+				type: 'input',
+				name: 'splitTo',
+				label: 'To: ',
+				tooltip: 'name of page material was copied to',
+				param_name: 'to'
+			},
+			{
+				type: 'input',
+				name: 'splitDiff',
+				label: 'Diff: ',
+				tooltip: 'URL or either a single revisionid or a diff of two revisionids separated by a slash showing the addition of the material',
+				param_name: 'diff'
+			},
+			{
+				type: 'input',
+				name: 'splitDate',
+				label: 'Date: ',
+				tooltip: 'Date and time material was moved',
+				param_name: 'date'
+			}
+		]
+	},
+
+	"Talkheader": {
+		label: '{{talkheader}}: General intro to a talk page',
+	},
+
+};
+
+Twinkle.tag.talk.attributionList = [
+	"Translated page",
+	"Copied",
+	"Merged from",
+	"Merged to",
+	"Split article"
+];
+
+Twinkle.tag.talk.otherList = [
+	"Talkheader"
+];
+
 
 // Contains those article tags that *do not* work inside {{multiple issues}}.
 Twinkle.tag.multipleIssuesExceptions = [
@@ -1356,6 +1547,42 @@ Twinkle.tag.callbacks = {
 		if( params.patrol ) {
 			pageobj.patrol();
 		}
+	},
+
+	talk: function talkCallback(pageobj) {
+		var params = pageobj.getCallbackParameters();
+		var summary = "Adding ";
+
+		var prependText = '';
+
+		params.tags.forEach( function(tag) {
+			prependText += '{{' + tag;
+
+			// add parameters for tag:
+			var parameters = Twinkle.tag.talk.tags[tag].subgroup;
+			if(parameters) {
+				parameters.forEach(function (it) {
+					if(params[it.name])
+						prependText += '|' + (it.param_name ? (it.param_name + '=') : '' ) + params[it.name];
+				});
+			}
+
+			prependText += '}}';
+
+			summary += '{{[[Template:' + tag + '|' + tag + ']]}}, ';
+		} );
+
+		pageobj.setPrependText(prependText);
+		pageobj.setEditSummary(summary.substring(0, summary.length - 2) + Twinkle.getPref('summaryAd'));
+		pageobj.setWatchlist(Twinkle.getFriendlyPref('watchTaggedPages'));
+		pageobj.setMinorEdit(Twinkle.getFriendlyPref('markTaggedPagesAsMinor'));
+		pageobj.setCreateOption('nocreate');
+		pageobj.prepend();
+
+		if( params.patrol ) {
+			pageobj.patrol();
+		}
+
 	}
 };
 
@@ -1394,6 +1621,36 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 		case 'redirect':
 			params.tags = form.getChecked( 'redirectTags' );
+			break;
+
+		case 'talk':
+			params.tags = form.getChecked('talkTags');
+			
+			// save parameter fields text 
+			$(form).find('input[type=text]').each(function(idx,el) {
+				params[el.name.slice(9)] = form[el.name].value;
+			});
+
+			// Are the required fields filled in?
+			// Validation for browsers that don't support HTML5-based validation
+			if ($("<input />").prop("required") === undefined) {	
+				var flag = true;
+				$.each(params.tags, function(idx, tag) { // not using JS native forEach beacause it can't be broken out of
+					var subgroup = Twinkle.tag.talk.tags[tag].subgroup
+					if(subgroup) {
+						$.each(subgroup, function(idx, p) {	// not using JS native forEach; same as above
+							if(p.required && params[p.name] === '') {
+								alert('Please fill in all required parameters for {{' + tag + '}} template');
+								flag = false; return false;
+							}
+						});
+					}
+					return flag;
+				});
+				if(!flag)
+					return;		// return on encountering the first unfilled required parameter
+			}
+
 			break;
 		default:
 			alert("Twinkle.tag: unknown mode " + Twinkle.tag.mode);
@@ -1443,12 +1700,15 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 		case 'file':
 			wikipedia_page.load(Twinkle.tag.callbacks.file);
 			return;
+		case 'talk':
+			wikipedia_page.load(Twinkle.tag.callbacks.talk);
+			return;
 		default:
 			alert("Twinkle.tag: unknown mode " + Twinkle.tag.mode);
 			break;
 	}
 };
-})(jQuery);
 
+})(jQuery);
 
 //</nowiki>

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -145,7 +145,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 					list: [ {
 						value: el,
 						label: Twinkle.tag.talk.tags[el].label,
-						subgroup: Twinkle.tag.talk.tags[el].subgroup 
+						subgroup: Twinkle.tag.talk.tags[el].subgroup
 					} ]
 				});
 			});
@@ -605,7 +605,7 @@ Twinkle.tag.article.tagCategories = {
 		],
 		"Timeliness": [
 			"current",
-			"update"			
+			"update"
 		],
 		"Neutrality, bias, and factual accuracy": [
 			"autobiography",
@@ -899,8 +899,8 @@ Twinkle.tag.file.replacementList = [
 
 Twinkle.tag.talk = {};
 
-Twinkle.tag.generateAHdiv = function() {
-	
+var generateAHdiv = function() {
+
 	var container = new Morebits.quickForm.element({ type: 'div' });
 
 	var resultHash = {
@@ -917,7 +917,7 @@ Twinkle.tag.generateAHdiv = function() {
 		'AFD': ['kept', 'deleted', 'merged', 'no consensus', 'speedily kept', 'speedily deleted', 'redirected', 'renamed'],
 		'DRV': ['endored', 'relisted', 'overturned', 'no consensus'],
 		'PROD': ['kept', 'deleted', 'afd'],
-		'CSD': ['kept', 'deleted', 'afd', 'prod'] 
+		'CSD': ['kept', 'deleted', 'afd', 'prod']
 	};
 
 	var generateResultsMenu = function(re) {
@@ -929,7 +929,7 @@ Twinkle.tag.generateAHdiv = function() {
 		});
 		$("#tag-AHresult-container").empty().append(menu.render());
 	};
-	
+
 	container.append({
 		type: 'select',
 		name: 'AHaction',
@@ -937,26 +937,26 @@ Twinkle.tag.generateAHdiv = function() {
 		event: generateResultsMenu,
 		list: [
 			{	label: 'Featured content processes',
-				list: [ 
-					{ label: 'FAC: Featured article candidate', value: 'FAC' }, 
-					{ label: 'FAR: Featured article review', value: 'FAR' }, 
-					{ label: 'FLC: Featured list candidate', value: 'FLC' }, 
-					{ label: 'FLR: Featured list removal candidate', value: 'FLR' }, 
-					{ label: 'FTC: Featured topic candidate', value: 'FTC' }, 
+				list: [
+					{ label: 'FAC: Featured article candidate', value: 'FAC' },
+					{ label: 'FAR: Featured article review', value: 'FAR' },
+					{ label: 'FLC: Featured list candidate', value: 'FLC' },
+					{ label: 'FLR: Featured list removal candidate', value: 'FLR' },
+					{ label: 'FTC: Featured topic candidate', value: 'FTC' },
 					{ label: 'FTR: Featured topic removal candidate	', value: 'FTR' } ]
 			},
 			{	label: 'Other review processes',
-				list: [ 
-					{ label: 'GAN: Good article nomination', value: 'GAN' }, 
-					{ label: 'GAR: Good article reassessment', value: 'GAR' }, 
-					{ label: 'PR: Peer review', value: 'PR' }, 
+				list: [
+					{ label: 'GAN: Good article nomination', value: 'GAN' },
+					{ label: 'GAR: Good article reassessment', value: 'GAR' },
+					{ label: 'PR: Peer review', value: 'PR' },
 					{ label: 'WAR: WikiProject A-class review', value: 'WAR' } ]
 			},
 			{	label: 'Deletion processes',
-				list: [ 
-					{ label: 'AFD: Articles for deletion', value: 'AFD' }, 
-					{ label: 'DRV: Deletion review', value: 'DRV' }, 
-					{ label: 'PROD: Proposed deletion', value: 'PROD' }, 
+				list: [
+					{ label: 'AFD: Articles for deletion', value: 'AFD' },
+					{ label: 'DRV: Deletion review', value: 'DRV' },
+					{ label: 'PROD: Proposed deletion', value: 'PROD' },
 					{ label: 'CSD: Speedy deletion', value: 'CSD' } ]
 			}
 		]
@@ -1005,7 +1005,7 @@ Twinkle.tag.talk.tags = {
 			type: 'div',
 			name: 'AHbox',
 			id: 'tag-AHbox',
-			label: Twinkle.tag.generateAHdiv()
+			label: generateAHdiv()
 		}
 	},
 
@@ -1033,36 +1033,24 @@ Twinkle.tag.talk.tags = {
 		label: '{{Copied}}: ',
 		subgroup: [
 			{
-				type: 'input',
-				name: 'copiedFrom',
-				label: 'From: ',
-				param_name: 'from',
-				required: true
+				type: 'input', name: 'copiedFrom', label: 'From: ',
+				param_name: 'from', required: true
 			},
 			{
-				type: 'input',
-				name: 'copiedFromOldid',
-				param_name: 'from_oldid',
-				label: 'OldId: '
+				type: 'input', name: 'copiedFromOldid', label: 'OldId: ',
+				param_name: 'from_oldid'
 			},
 			{
-				type: 'input',
-				name: 'copiedTo',
-				label: 'To: ',
-				param_name: 'to',
-				required: true
+				type: 'input', name: 'copiedTo', label: 'To: ',
+				param_name: 'to', required: true
 			},
 			{
-				type: 'input',
-				name: 'copiedDiff',
-				label: 'Diff: ',
+				type: 'input', name: 'copiedDiff', label: 'Diff: ',
 				tooltip: 'Revision number of the page in which the copied text first appears',
 				param_name: 'diff'
 			},
 			{
-				type: 'date',
-				name: 'copiedDate',
-				label: 'Date: ',
+				type: 'date', name: 'copiedDate', label: 'Date: ',
 				param_name: 'date'
 			}
 		]
@@ -1072,15 +1060,11 @@ Twinkle.tag.talk.tags = {
 		label: '{{Merged from}}: ',
 		subgroup: [
 			{
-				type: 'input',
-				name: 'mergedfromArticle',
-				label: 'From article: ',
+				type: 'input', name: 'mergedfromArticle', label: 'From article: ',
 				required: true
 			},
 			{
-				type: 'date',
-				name: 'mergedfromDate',
-				label: 'Date: '
+				type: 'date', name: 'mergedfromDate', label: 'Date: '
 			}
 		]
 	},
@@ -1089,15 +1073,11 @@ Twinkle.tag.talk.tags = {
 		label: '{{Merged to}}: ',
 		subgroup: [
 			{
-				type: 'input',
-				name: 'mergedtoArticle',
-				label: 'To article: ',
+				type: 'input', name: 'mergedtoArticle', label: 'To article: ',
 				required: true
 			},
 			{
-				type: 'date',
-				name: 'mergedtoDate',
-				label: 'Date: '
+				type: 'date', name: 'mergedtoDate', label: 'Date: '
 			}
 		]
 	},
@@ -1106,38 +1086,27 @@ Twinkle.tag.talk.tags = {
 		label: '{{Split article}}: ',
 		subgroup: [
 			{
-				type: 'input',
-				name: 'splitFrom',
-				label: 'From: ',
-				tooltip: 'Name of page from which content was removed',
-				param_name: 'from',
-				required: true
+				type: 'input', name: 'splitFrom',
+				label: 'From: ', tooltip: 'Name of page from which content was removed',
+				param_name: 'from', required: true
 			},
 			{
-				type: 'input',
-				name: 'splitFromOldid',
-				label: 'From oldid: ',
+				type: 'input', name: 'splitFromOldid', label: 'From oldid: ',
 				tooltip: 'Permanent link url or revisionid from which the material was copied',
 				param_name: 'from_oldid'
 			},
 			{
-				type: 'input',
-				name: 'splitTo',
-				label: 'To: ',
+				type: 'input', name: 'splitTo', label: 'To: ',
 				tooltip: 'name of page material was copied to',
 				param_name: 'to'
 			},
 			{
-				type: 'input',
-				name: 'splitDiff',
-				label: 'Diff: ',
+				type: 'input', name: 'splitDiff', label: 'Diff: ',
 				tooltip: 'URL or either a single revisionid or a diff of two revisionids separated by a slash showing the addition of the material',
 				param_name: 'diff'
 			},
 			{
-				type: 'date',
-				name: 'splitDate',
-				label: 'Date: ',
+				type: 'date', name: 'splitDate', label: 'Date: ',
 				tooltip: 'Date and time material was moved',
 				param_name: 'date'
 			}
@@ -1678,9 +1647,9 @@ Twinkle.tag.callbacks = {
 				}
 			} else {
 				prependText += '\n|action1 = ' + params.AHaction +
-					'\n|action1date = ' + params.AHdate + 
+					'\n|action1date = ' + params.AHdate +
 					'\n|action1link = ' + params.AHlink +
-					'\n|action1result = ' + params.AHresult + 
+					'\n|action1result = ' + params.AHresult +
 					'\n|action1oldid = ' + params.AHoldid + '\n';
 			}
 
@@ -1742,13 +1711,13 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 		case 'talk':
 			params.tags = form.getChecked('talkTags');
-			
-			// save parameter fields text 
+
+			// save parameter fields text
 			$(form).find('input[type=text]').each(function(idx,el) {
 				params[el.name.slice(9)] = form[el.name].value;
 			});
 
-			if(params.tags.includes('Article history')) {
+			if(params.tags.indexOf('Article history') !== -1) {
 				$(form).find('select').each(function(idx,el) {
 					params[el.name] = form[el.name].value;
 				});
@@ -1756,7 +1725,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 
 			// Are the required fields filled in?
 			// Validation for browsers that don't support HTML5-based validation
-			if ($("<input />").prop("required") === undefined) {	
+			if ($("<input />").prop("required") === undefined) {
 				var flag = true;
 				$.each(params.tags, function(idx, tag) { // not using JS native forEach beacause it can't be broken out of
 					var subgroup = Twinkle.tag.talk.tags[tag].subgroup

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -38,6 +38,7 @@ Twinkle.tag = function friendlytag() {
 	}
 };
 
+
 Twinkle.tag.callback = function friendlytagCallback() {
 	var Window = new Morebits.simpleWindow( 630, (Twinkle.tag.mode === "article") ? 500 : 400 );
 	Window.setScriptName( "Twinkle" );
@@ -135,7 +136,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 		case 'talk':
 			Window.setTitle( "Talk page tagging" );
-			
+
 			form.append({ type: 'header', label: 'Attribution' });
 			Twinkle.tag.talk.attributionList.forEach(function(el) {
 				form.append({
@@ -157,7 +158,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 					list: [ {
 						value: el,
 						label: Twinkle.tag.talk.tags[el].label,
-						subgroup: Twinkle.tag.talk.tags[el].subgroup 
+						subgroup: Twinkle.tag.talk.tags[el].subgroup,
 					} ]
 				});
 			});
@@ -668,6 +669,22 @@ Twinkle.tag.article.tagCategories = {
 	]
 };
 
+// Contains those article tags that *do not* work inside {{multiple issues}}.
+Twinkle.tag.multipleIssuesExceptions = [
+	'copypaste',
+	'expand language',
+	'GOCEinuse',
+	'improve categories',
+	'in use',
+	'merge',
+	'merge from',
+	'merge to',
+	'not English',
+	'rough translation',
+	'uncategorized',
+	'under construction'
+];
+
 // Tags for REDIRECTS start here
 
 Twinkle.tag.spellingList = [
@@ -882,8 +899,117 @@ Twinkle.tag.file.replacementList = [
 
 Twinkle.tag.talk = {};
 
+Twinkle.tag.generateAHdiv = function() {
+	
+	var container = new Morebits.quickForm.element({ type: 'div' });
+
+	var resultHash = {
+		'FAC': ['promoted', 'failed'],
+		'FAR': ['kept', 'removed'],
+		'FLC': ['promoted', 'failed'],
+		'FLR': ['kept', 'removed'],
+		'FTC': ['promoted', 'failed'],
+		'FTR': ['kept', 'removed'],
+		'GAN': ['listed', 'failed'],
+		'GAR': ['listed', 'delisted', 'kept'],
+		'PR' : ['reviewed' , 'not reviewed'],
+		'WAR': ['approved', 'failed', 'kept', 'demoted'],
+		'AFD': ['kept', 'deleted', 'merged', 'no consensus', 'speedily kept', 'speedily deleted', 'redirected', 'renamed'],
+		'DRV': ['endored', 'relisted', 'overturned', 'no consensus'],
+		'PROD': ['kept', 'deleted', 'afd'],
+		'CSD': ['kept', 'deleted', 'afd', 'prod'] 
+	};
+
+	var generateResultsMenu = function(re) {
+		var menu = new Morebits.quickForm.element({
+			type: 'select',
+			name: 'AHresult',
+			label: 'Result: ',
+			list: $.map(resultHash[re.target.value], function(el) { return {label: el, value: el}; })
+		});
+		$("#tag-AHresult-container").empty().append(menu.render());
+	};
+	
+	container.append({
+		type: 'select',
+		name: 'AHaction',
+		label: 'Nomination type: ',
+		event: generateResultsMenu,
+		list: [
+			{	label: 'Featured content processes',
+				list: [ 
+					{ label: 'FAC: Featured article candidate', value: 'FAC' }, 
+					{ label: 'FAR: Featured article review', value: 'FAR' }, 
+					{ label: 'FLC: Featured list candidate', value: 'FLC' }, 
+					{ label: 'FLR: Featured list removal candidate', value: 'FLR' }, 
+					{ label: 'FTC: Featured topic candidate', value: 'FTC' }, 
+					{ label: 'FTR: Featured topic removal candidate	', value: 'FTR' } ]
+			},
+			{	label: 'Other review processes',
+				list: [ 
+					{ label: 'GAN: Good article nomination', value: 'GAN' }, 
+					{ label: 'GAR: Good article reassessment', value: 'GAR' }, 
+					{ label: 'PR: Peer review', value: 'PR' }, 
+					{ label: 'WAR: WikiProject A-class review', value: 'WAR' } ]
+			},
+			{	label: 'Deletion processes',
+				list: [ 
+					{ label: 'AFD: Articles for deletion', value: 'AFD' }, 
+					{ label: 'DRV: Deletion review', value: 'DRV' }, 
+					{ label: 'PROD: Proposed deletion', value: 'PROD' }, 
+					{ label: 'CSD: Speedy deletion', value: 'CSD' } ]
+			}
+		]
+	});
+
+	var ahr = container.append({
+		type: 'div',
+		id: 'tag-AHresult-container'
+	});
+	ahr.append({
+		type: 'select',
+		name: 'AHresult',
+		label: 'Result: ',
+		list: [ {label: 'promoted', value: 'promoted'}, {label: 'failed', value: 'failed'} ]
+			// initialize with values corresponding to FAC
+	});
+
+	container.append({
+		type: 'input',
+		name: 'talkTags.AHlink',
+		label: 'Link: ',
+		tooltip: 'Link to the nomination page (skip this for PROD/CSD)'
+	})
+
+	container.append({
+		type: 'date',
+		name: 'talkTags.AHdate',
+		label: 'Date ended: ',
+	});
+
+	container.append({
+		type: 'input',
+		name: 'talkTags.AHoldid',
+		label: 'Oldid',
+		tooltip: 'oldid number of version'
+	});
+
+	return container.render();
+
+};
+
 Twinkle.tag.talk.tags = {
-	"Translated page" : {
+	"Article history": {
+		label: '{{Article history}}: Record of past nominations at XFD/DRV/FAC/GAN/PR etc',
+		subgroup: {
+			type: 'div',
+			name: 'AHbox',
+			id: 'tag-AHbox',
+			label: Twinkle.tag.generateAHdiv()
+		}
+	},
+
+	"Translated page": {
 		label: '{{Translated page}}: to attribute translations from other language Wikipedias',
 		subgroup: [
 			{
@@ -1019,9 +1145,8 @@ Twinkle.tag.talk.tags = {
 	},
 
 	"Talkheader": {
-		label: '{{talkheader}}: General intro to a talk page',
+		label: '{{Talkheader}}: General intro to a talk page',
 	},
-
 };
 
 Twinkle.tag.talk.attributionList = [
@@ -1033,24 +1158,8 @@ Twinkle.tag.talk.attributionList = [
 ];
 
 Twinkle.tag.talk.otherList = [
+	"Article history",
 	"Talkheader"
-];
-
-
-// Contains those article tags that *do not* work inside {{multiple issues}}.
-Twinkle.tag.multipleIssuesExceptions = [
-	'copypaste',
-	'expand language',
-	'GOCEinuse',
-	'improve categories',
-	'in use',
-	'merge',
-	'merge from',
-	'merge to',
-	'not English',
-	'rough translation',
-	'uncategorized',
-	'under construction'
 ];
 
 
@@ -1559,15 +1668,23 @@ Twinkle.tag.callbacks = {
 			prependText += '{{' + tag;
 
 			// add parameters for tag:
-			var parameters = Twinkle.tag.talk.tags[tag].subgroup;
-			if(parameters) {
-				parameters.forEach(function (it) {
-					if(params[it.name])
-						prependText += '|' + (it.param_name ? (it.param_name + '=') : '' ) + params[it.name];
-				});
+			if(tag !== 'Article history') {
+				var parameters = Twinkle.tag.talk.tags[tag].subgroup;
+				if(parameters) {
+					parameters.forEach(function (it) {
+						if(params[it.name])
+							prependText += '|' + (it.param_name ? (it.param_name + '=') : '' ) + params[it.name];
+					});
+				}
+			} else {
+				prependText += '\n|action1 = ' + params.AHaction +
+					'\n|action1date = ' + params.AHdate + 
+					'\n|action1link = ' + params.AHlink +
+					'\n|action1result = ' + params.AHresult + 
+					'\n|action1oldid = ' + params.AHoldid + '\n';
 			}
 
-			prependText += '}}';
+			prependText += '}}\n';
 
 			summary += '{{[[Template:' + tag + '|' + tag + ']]}}, ';
 		} );
@@ -1630,6 +1747,12 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			$(form).find('input[type=text]').each(function(idx,el) {
 				params[el.name.slice(9)] = form[el.name].value;
 			});
+
+			if(params.tags.includes('Article history')) {
+				$(form).find('select').each(function(idx,el) {
+					params[el.name] = form[el.name].value;
+				});
+			}
 
 			// Are the required fields filled in?
 			// Validation for browsers that don't support HTML5-based validation

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -890,7 +890,7 @@ Twinkle.tag.talk.tags = {
 				name: 'translatedLangcode',
 				type: 'input',
 				label: 'Language code: ',
-				tooltip: 'The ISO 639 language code',
+				tooltip: 'The ISO 639 language code, eg. fr, de',
 				required: true
 			},
 			{
@@ -934,7 +934,7 @@ Twinkle.tag.talk.tags = {
 				param_name: 'diff'
 			},
 			{
-				type: 'input',
+				type: 'date',
 				name: 'copiedDate',
 				label: 'Date: ',
 				param_name: 'date'
@@ -952,7 +952,7 @@ Twinkle.tag.talk.tags = {
 				required: true
 			},
 			{
-				type: 'input',
+				type: 'date',
 				name: 'mergedfromDate',
 				label: 'Date: '
 			}
@@ -969,7 +969,7 @@ Twinkle.tag.talk.tags = {
 				required: true
 			},
 			{
-				type: 'input',
+				type: 'date',
 				name: 'mergedtoDate',
 				label: 'Date: '
 			}
@@ -1009,7 +1009,7 @@ Twinkle.tag.talk.tags = {
 				param_name: 'diff'
 			},
 			{
-				type: 'input',
+				type: 'date',
 				name: 'splitDate',
 				label: 'Date: ',
 				tooltip: 'Date and time material was moved',

--- a/morebits.js
+++ b/morebits.js
@@ -431,6 +431,12 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 		if( data.event ) {
 			subnode.addEventListener( 'keyup', data.event, false );
 		}
+		if( data.required ) {
+			subnode.setAttribute( 'required', 'required' );
+			var reqstar = node.appendChild( document.createElement( 'span' ) );
+			reqstar.appendChild( document.createTextNode( " *" ) );
+			reqstar.style = "font-size: 140%;";
+		}
 		break;
 	case 'dyninput':
 		var min = data.min || 1;

--- a/morebits.js
+++ b/morebits.js
@@ -399,6 +399,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			}
 		}
 		break;
+	case 'date' :  // falls through
 	case 'input':
 		node = document.createElement( 'div' );
 		node.setAttribute( 'id', 'div_' + id );
@@ -415,7 +416,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 		}
 		subnode.setAttribute( 'name', data.name );
 		subnode.setAttribute( 'id', id );
-		subnode.setAttribute( 'type', 'text' );
+		subnode.setAttribute( 'type', 'text' ); 
 		if( data.size ) {
 			subnode.setAttribute( 'size', data.size );
 		}
@@ -431,12 +432,28 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 		if( data.event ) {
 			subnode.addEventListener( 'keyup', data.event, false );
 		}
+		if( data.type === 'date' ) {
+			// If type is 'date' rather than 'input', show a icon to pre-fill current date
+			var inputToday = node.appendChild(document.createElement('a'));
+			inputToday.setAttribute('href','#');
+			var img = inputToday.appendChild(document.createElement('img'));
+			img.setAttribute('src','//upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Nuvola_apps_date.svg/20px-Nuvola_apps_date.svg.png');
+			img.setAttribute('alt','Insert current date');
+			img.setAttribute('title','Insert current date');
+			img.onclick = function(e) {
+				var d = new Date();
+				$(e.target).parent().prev().val(d.getDate() + ' ' + d.getMonthName() + ' ' + d.getFullYear());
+			};
+		}
 		if( data.required ) {
-			subnode.setAttribute( 'required', 'required' );
-			var reqstar = node.appendChild( document.createElement( 'span' ) );
-			reqstar.appendChild( document.createTextNode( " *" ) );
+			subnode.setAttribute('required', 'required');	
+			// required field validation is not universally supported (by Safari, some versions of IE),
+			// so your script should provide workarounds for cross-browser support
+			var reqstar = node.appendChild(document.createElement('span'));
+			reqstar.appendChild(document.createTextNode(" *"));
 			reqstar.style = "font-size: 140%;";
 		}
+		
 		break;
 	case 'dyninput':
 		var min = data.min || 1;


### PR DESCRIPTION
Added some common talk namespace templates (esp. attribution-related ones), featuring some new infrastructure for saving parameter field values from form, and for constructing the template text.

We could potentially cover WikiProject banner templates too using a bit of AJAX, as well as other stuff.