### PR TITLE
Talkback: Go to page footer on reloading

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -352,7 +352,7 @@ var callback_evaluate = function( e ) {
 	Morebits.simpleWindow.setButtonsEnabled( false );
 	Morebits.status.init( e.target );
 
-	Morebits.wiki.actionCompleted.redirect = fullUserTalkPageName;
+	Morebits.wiki.actionCompleted.redirect = fullUserTalkPageName + '#footer';
 	Morebits.wiki.actionCompleted.notice = "Talkback complete; reloading talk page in a few seconds";
 
 	var talkpage = new Morebits.wiki.page(fullUserTalkPageName, "Adding talkback");


### PR DESCRIPTION
Since talkback appends new content, when the page is reloaded the focus should be at the bottom, which can be accessed as "#footer"