### PR TITLE
morebits: convert Morebits.wiki.page to use promises

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
 	"globals": {
 		"mw": "readonly"
 	},
-	"ignorePatterns": "select2*",
+	"ignorePatterns": ["select2*", "server.js"],
 	"rules": {
 		"no-console": "error",
 		"no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,6 @@
 		"eqeqeq": "error",
 		"guard-for-in": "error",
 		"no-caller": "error",
-		"no-else-return": "error",
 		"no-implicit-coercion": ["error", { "boolean": false }],
 		"no-lone-blocks": "error",
 		"no-multi-spaces": ["error", { "ignoreEOLComments": true }],

--- a/morebits-test-promises.js
+++ b/morebits-test-promises.js
@@ -1,0 +1,259 @@
+/* global Morebits */
+/* eslint-disable no-redeclare, brace-style, no-console */
+
+
+/**
+ * Snippets of testing code that you can copy-paste into the console.
+ * TODO: Convert to unit tests?
+ */
+
+(function() {
+
+// callbacks passed in constructor:
+var successCallback = function() {
+	console.log('callback-onSuccess', this, arguments);
+};
+var failureCallback = function() { console.log('callback-onFailure', this, arguments); };
+
+// promise callbacks:
+var doneCallback = function() { console.log('done', this, arguments); };
+var thenCallback = function() { console.log('then', this, arguments); };
+var failCallback = function() { console.log('fail', this, arguments); };
+var catchCallback = function() { console.log('catch', this, arguments); };
+var alwaysCallback = function() { console.log('always', this, arguments); };
+
+
+/** Creates a simple window that shows Morebits status messages */
+var initStatusWindow = function() {
+	if ($('#morebits-dialog-content').length && !Morebits.status.root) {
+		Morebits.status.init($('#morebits-dialog-content')[0]);
+	} else {
+		var w = new Morebits.simpleWindow(600, 600);
+		w.display();
+		Morebits.status.init(w.content);
+	}
+};
+
+
+// MOREBITS.WIKI.API
+
+initStatusWindow();
+
+/* disable internet from the network tab to trigger the other type of error */
+var apiobj = new Morebits.wiki.api(
+	'',
+	{
+		action: 'query', /* change to something random to make the API return an error */
+		titles: 'Main Page'
+	},
+	successCallback, null, failureCallback
+).post();
+
+apiobj.then(thenCallback);
+apiobj.done(doneCallback);
+apiobj.fail(failCallback);
+apiobj.catch(catchCallback);
+apiobj.always(alwaysCallback);
+
+/**
+ * Chainings: note on jQuery deferred handler types:
+ * .then() and .catch() return *new* promises, that may be resolved or rejected, according to
+ * the return value of the function in the handler
+ * .done() and .fail() simply return the original promise, regardless of what the function within
+ * the handler returns
+ */
+apiobj.then(thenCallback).fail(failCallback).always(alwaysCallback);
+apiobj.catch(catchCallback).then(thenCallback).always(alwaysCallback);
+
+
+// MOREBITS.WIKI.PAGE:
+
+
+/** Load */
+
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm);
+p1.save(successCallback, failureCallback).done(doneCallback).then(function() {
+	console.log(p1.getPageText());
+}).fail(failCallback);
+
+
+var p2 = new Morebits.wiki.page('<scrip'); // invalid page name
+p2.save(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+/** Save */
+
+initStatusWindow();
+
+// save without edit summary
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to save w/o edit sum');
+p1.load().then(function() {
+	var text = p1.getPageText() + '\n\nxxxxxx';
+	p1.setPageText(text);
+	p1.save(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+});
+
+// API error (save on non-existing page with nocreate option)
+// Unrecoverable error
+var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random(), 'Trying save (should give API error)');
+p2.load().then(function() {
+	p2.setPageText(p2.getPageText() + '\n\nxxxx');
+	p2.setEditSummary('test (morebits.js)');
+	p2.setCreateOption('nocreate');
+	p2.save(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+});
+
+// save (should succeed)
+var p3 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Editing current page');
+p3.load().then(function() {
+	var text = p3.getPageText() + '\n\nxxxxxx';
+	p3.setPageText(text);
+	p3.setEditSummary('test (morebits.js)');
+	p3.save(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+});
+
+// to test notoken error, do the above, but after modifying the code:
+// remove the token property in query object in this.save.
+
+
+/** Prepend, Append */
+
+initStatusWindow();
+
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Prepending');
+p1.setPrependText('xxxxx\n\n');
+p1.setEditSummary('test prepend (morebits.js)');
+p1.prepend(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Appending');
+p1.setAppendText('\n\nxxxxx');
+p1.setEditSummary('test append (morebits.js)');
+p1.append(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// try this on protected and non-protected pages to test both code paths in this.append()
+// gives unrecoverable error articleexists
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Appending');
+p1.setAppendText('\n\nxxxxx');
+p1.setCreateOption('createonly');
+p1.setEditSummary('test append (morebits.js)');
+p1.append(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// append with error
+var p1 = new Morebits.wiki.page('Morebits-test/' + Math.random(), 'Appending');
+p1.setAppendText('\n\nxxxxx');
+p1.setCreateOption('nocreate');
+p1.setEditSummary('test append (morebits.js)');
+p1.append(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+
+/** Revert */
+
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Reverting');
+p1.setOldID('410977');
+p1.load().then(function() {
+	p1.setEditSummary('test revert (morebits.js)');
+	p1.revert();
+});
+
+
+/** Lookup creation */
+
+initStatusWindow();
+
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm);
+p1.lookupCreation(function() {
+	console.log('First revision creator', p1.getCreator());
+	console.log('Creation timestamp: ' + p1.getCreationTimestamp());
+});
+var p2 = new Morebits.wiki.page(Morebits.pageNameNorm);
+p2.setLookupNonRedirectCreator(true);
+p2.lookupCreation(function() {
+	console.log('First non-redirect revision creator: ' + p2.getCreator());
+});
+
+
+/** Delete page */
+
+initStatusWindow();
+
+// action fails in this.deletePage
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to delete without edit summary');
+p1.deletePage(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action fails in fnProcessDelete
+var nonExistingPageName = 'Morebits-test/' + Math.random(); // Lord be damned if that page exists
+var p2 = new Morebits.wiki.page(nonExistingPageName, 'Trying to delete non-existent page (delete after fetching token)');
+p2.setEditSummary('test');
+p2.deletePage(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action fails in fnProcessDeleteFailure
+var p3 = new Morebits.wiki.page(nonExistingPageName, 'Trying to delete non-existent page (direct deletion with local token)');
+p3.suppressProtectWarning();
+p3.setEditSummary('test');
+p3.deletePage(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action succeeds
+var testPageName = 'User:Morebits-test/' + Math.random();
+var p4 = new Morebits.wiki.page(testPageName, 'Testing deletion (should succeed)');
+p4.setAppendText('Page for testing deletion by morebits.js'); // create the page first
+p4.setEditSummary('Creating test page for deletion');
+p4.append(function() {
+	p4.setEditSummary('Testing deletion (morebits.js)');
+	p4.deletePage(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+});
+
+
+/** Move page */
+
+initStatusWindow();
+
+// action fails in this.move
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to move page without setting destination');
+p1.move(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action fails in fnProcessMove
+var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random(), 'Trying to move non-existent page');
+p2.setEditSummary('test');
+p2.setMoveDestination('xxxxx');
+p2.move(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action fails server-side
+var p3 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to move (should give API error)');
+p3.setEditSummary('test');
+p3.setMoveDestination('de:xxxxx'); // invalid title to trigger API error
+p3.move(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action succeeds
+var p4 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to move current page (should succeed)');
+p4.setEditSummary('test (morebits.js)');
+p4.setMoveDestination(p3.getPageName() + '/1');
+p4.move(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+/** Protect page */
+
+initStatusWindow();
+
+// action fails in this.protect
+var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Testing protection (without edit sum)');
+p1.protect(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// actions fails in fnProcessProtect
+var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random(), "Testing protection (page doesn't exist");
+p2.setEditSummary('test (morebits.js)');
+p2.setEditProtection('sysop', 'infinite');
+p2.protect(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action fails server-side
+var p3 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Testing protection (API error: past expiry)');
+p3.setEditSummary('test (morebits.js)');
+p3.setEditProtection('sysop', '2012-09-28');
+p3.protect(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+// action succeeds
+var p4 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Testing protection (should succeed)');
+p4.setEditSummary('test (morebits.js)');
+p4.setEditProtection('sysop', 'infinite');
+p4.protect(successCallback, failureCallback).done(doneCallback).fail(failCallback);
+
+
+
+})();

--- a/morebits.js
+++ b/morebits.js
@@ -2742,6 +2742,38 @@ Morebits.wiki.page = function(pageName, currentAction) {
 	};
 
 	/**
+	 * Marks the page as patrolled, if possible
+	 * @returns {jQuery.Promise} - resolved or rejected with the page object, and with errorcode and errortext
+	 * on failure.
+	 */
+	this.patrol = function() {
+		// There's no patrol link on page, so we can't patrol
+		if (!$('.patrollink').length) {
+			return;
+		}
+
+		// Extract the Recentchanges ID (rcid) from the "Mark page as patrolled" link on page
+		var patrolhref = $('.patrollink a').attr('href'),
+			rcid = mw.util.getParamValue('rcid', patrolhref);
+
+		if (rcid) {
+			var patrolstat = new Morebits.status('Marking page as patrolled');
+
+			var wikipedia_api = new Morebits.wiki.api('doing...', {
+				action: 'patrol',
+				rcid: rcid,
+				token: mw.user.tokens.get('patrolToken')
+			});
+			wikipedia_api.setStatusElement(patrolstat);
+			wikipedia_api.setParent(this);
+			return wikipedia_api.post().then(reshapeResolvedPromise).catch(reshapeRejectedPromise);
+
+		} else {
+			return $.Deferred().rejectWith(this, [this, 'missingparam', 'No rcid available']);
+		}
+	};
+
+	/**
 	 * Reverts a page to revertOldID
 	 * @param {Function} [onSuccess] - callback function to run on success (optional)
 	 * @param {Function} [onFailure] - callback function to run on failure (optional)

--- a/morebits.js
+++ b/morebits.js
@@ -2158,6 +2158,16 @@ Morebits.wiki.page = function(pageName, currentAction) {
 
 	var emptyFunction = function() { };
 
+	// Converts a promise resolved with apiobj to a promise resolved with pageobj.
+	var reshapeResolvedPromise = function() {
+		return $.Deferred().resolveWith(this, [this]);
+	};
+
+	// Converts a promise rejected with apiobj to a promise rejected with errorCode, and errorText.
+	var reshapeRejectedPromise = function(apiobj) {
+		return $.Deferred().rejectWith(this, [apiobj.getErrorCode(), apiobj.getErrorText()]);
+	};
+
 	/**
 	 * Loads the text for the page
 	 * @param {Function} onSuccess - callback function which is called when the load has succeeded

--- a/morebits.test.js
+++ b/morebits.test.js
@@ -1,0 +1,463 @@
+/* globals it, describe, before, Morebits */
+
+var expect = window.chai.expect;
+
+describe('Morebits.wiki.api', function() {
+
+	var successApiCallback = function() {
+		expect(this).to.equal(window);
+		expect(arguments).to.be.of.length(1);
+		expect(arguments[0]).to.be.instanceOf(Morebits.wiki.api);
+	};
+
+	var failApiCallback = function() {
+		expect(this).to.equal(window);
+		expect(arguments).to.be.of.length(1);
+		expect(arguments[0]).to.be.instanceOf(Morebits.wiki.api);
+	};
+
+	before(function() {
+		return mw.loader.getScript('http://127.0.0.1:5500/morebits.js');
+	});
+
+	it('success callback works correctly', function(done) {
+		new Morebits.wiki.api('', {action: 'query', titles: 'Main Page'},
+			function onSuccess() {
+				successApiCallback.apply(this, arguments);
+				done();
+			}).post();
+	});
+	it('then promise callback works correctly', function(done) {
+		var apiobj = new Morebits.wiki.api('', {action: 'query', titles: 'Main Page'}).post();
+		apiobj.then(function() {
+			successApiCallback.apply(this, arguments);
+			done();
+		});
+	});
+	it('done promise callback works correctly', function(done) {
+		var apiobj = new Morebits.wiki.api('', {action: 'query', titles: 'Main Page'}).post();
+		apiobj.done(function() {
+			successApiCallback.apply(this, arguments);
+			done();
+		});
+	});
+
+	it('works correctly when both a success callback and a promise callback are given', function(done) {
+
+		// Variable to test execution order. The callback passed in the constructor
+		// executes first, then the promise callbacks
+		var key = 42;
+
+		new Morebits.wiki.api('', {action: 'query', titles: 'Main Page'},
+			function onSuccess() {
+				expect(key).to.equal(42);
+				key = 84;
+				successApiCallback.apply(this, arguments);
+			}).post()
+			.then(function() {
+				expect(key).to.equal(84);
+				successApiCallback.apply(this, arguments);
+				done();
+			});
+	});
+
+	it('works correctly even when a success callback and multiple promise callbacks are given', function(done) {
+		this.timeout(3000);
+
+		new Morebits.wiki.api('', {action: 'query', titles: 'Main Page'},
+			function onSuccess() {
+				successApiCallback.apply(this, arguments);
+			}).post()
+			.then(function() {
+				successApiCallback.apply(this, arguments);
+			})
+			.done(function() {
+				successApiCallback.apply(this, arguments);
+			});
+
+		// Call done after 2 seconds by which time the above should have finished.
+		// I don't know whether then() or done() callback is executed first, or even
+		// if it is deterministic.
+		setTimeout(function() {
+			done();
+		}, 2000);
+	});
+
+	it('failure callback works correctly', function(done) {
+
+		// trigger API error by using unrecognised action
+		new Morebits.wiki.api('', {action: 'qwerrwqer', titles: 'Main Page'}, null, null, function onFailure() {
+			failApiCallback.apply(this, arguments);
+			done();
+		}).post();
+	});
+	it('fail promise callback works correctly', function(done) {
+		new Morebits.wiki.api('', {action: 'qwerrwqer', titles: 'Main Page'}).post()
+			.fail(function() {
+				failApiCallback.apply(this, arguments);
+				done();
+			});
+	});
+	it('catch promise callback works correctly', function(done) {
+		new Morebits.wiki.api('', {action: 'qwerrwqer', titles: 'Main Page'}).post()
+			.catch(function() {
+				failApiCallback.apply(this, arguments);
+				done();
+			});
+	});
+
+	it('works correctly when both a failure callback and a promise callback are given', function(done) {
+
+		// Variable to test execution order. The callback passed in the constructor
+		// executes first, then the promise callbacks
+		var key = 42;
+
+		new Morebits.wiki.api('', {action: 'qwerrwqer', titles: 'Main Page'},
+			null, null,
+			function onFailure() {
+				expect(key).to.equal(42);
+				key = 84;
+				successApiCallback.apply(this, arguments);
+			}).post()
+			.catch(function() {
+				expect(key).to.equal(84);
+				successApiCallback.apply(this, arguments);
+				done();
+			});
+	});
+
+});
+
+// These tests modify the wiki.
+// To skip these, change `describe` below to `describe.skip`
+describe('Morebits.wiki.page', function() {
+	this.timeout(3000);
+
+	var successPageCallback = function() {
+		expect(this).to.be.instanceOf(Morebits.wiki.page);
+		expect(arguments).to.of.length(1);
+		expect(arguments[0]).to.be.instanceOf(Morebits.wiki.page);
+	};
+
+	var failPageCallback = function() {
+		expect(this).to.be.instanceOf(Morebits.wiki.page);
+		expect(arguments).to.of.length(3);
+		expect(arguments[0]).to.be.instanceOf(Morebits.wiki.page);
+		expect(arguments[1]).to.be.a('string');
+		expect(arguments[2]).to.be.a('string');
+	};
+
+	var notExecuted = function() {
+		expect(2 + 2).to.equal(5); // make mocha throw if possible
+		throw new Error('This shouldn\'t have executed, wtf?');
+	};
+
+	before(function() {
+		return mw.loader.getScript('http://127.0.0.1:5500/morebits.js');
+	});
+
+	/** Load */
+
+	it('loads a page', function(done) {
+		var p1 = new Morebits.wiki.page(Morebits.pageNameNorm);
+		p1.load(function() {
+			successPageCallback.apply(this, arguments);
+			done();
+		});
+	});
+
+	it('fails to load a page with bad name', function(done) {
+		var p2 = new Morebits.wiki.page('<scrip'); // invalid page name
+		p2.load(notExecuted, failPageCallback).fail(function() {
+			failPageCallback.apply(this, arguments);
+			done();
+		});
+	});
+
+	/** Save */
+
+	var userSandbox = 'User:' + mw.config.get('wgUserName') + '/sandbox';
+
+	it("can't save without an edit summary", function(done) {
+		var p1 = new Morebits.wiki.page(userSandbox, 'Trying to save w/o edit sum');
+		p1.load().then(function() {
+			var text = p1.getPageText() + '\n\nxxxxxx';
+			p1.setPageText(text);
+			p1.save(notExecuted, failPageCallback)
+				.fail(function(pageobj, errorCode) {
+					expect(errorCode).to.equal('int-noreason');
+					failPageCallback.apply(this, arguments);
+					done();
+				});
+		});
+	});
+
+	it('correctly reports API errors on save', function(done) {
+		// API error (save on non-existing page with nocreate option)
+		// Unrecoverable error
+		var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random(), 'Trying save (should give API error)');
+		p2.load().then(function() {
+			p2.setPageText(p2.getPageText() + '\n\nxxxx');
+			p2.setEditSummary('test (morebits.js)');
+			p2.setCreateOption('nocreate');
+			p2.save(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+				.catch(function(pageobj, errorCode) {
+					expect(errorCode).to.equal('missingtitle');
+					failPageCallback.apply(this, arguments);
+					done();
+				});
+		});
+	});
+
+	it('edits a page (user sandbox)', function(done) {
+		var p3 = new Morebits.wiki.page(userSandbox, 'Editing sandbox');
+		p3.load().then(function() {
+			var text = p3.getPageText() + '\n\nxxxxxx';
+			p3.setPageText(text);
+			p3.setEditSummary('test (morebits.js)');
+			p3.save(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted)
+				.then(function() {
+					done();
+				});
+		});
+	});
+
+
+	/** Prepend, Append */
+
+	it('successfully prepends to a sandbox', function(done) {
+		var p1 = new Morebits.wiki.page(userSandbox, 'Prepending');
+		p1.setPrependText('xxxxx\n\n');
+		p1.setEditSummary('test prepend (morebits.js)');
+		p1.prepend(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted)
+			.then(function() {
+				successPageCallback.apply(this, arguments);
+				done();
+			});
+	});
+
+	it('successfully appends to a sandbox', function(done) {
+		var p1 = new Morebits.wiki.page(userSandbox, 'Appending');
+		p1.setAppendText('xxxxx\n\n');
+		p1.setEditSummary('test append (morebits.js)');
+		p1.append(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted)
+			.then(function() {
+				successPageCallback.apply(this, arguments);
+				done();
+			});
+	});
+
+	it('fails to edit an existing page with createonly=1 (non-protected page)', function(done) {
+		var p1 = new Morebits.wiki.page('Wikipedia:Twinkle/ExampleNonProtectedPage', 'Appending');
+		p1.setAppendText('\n\nxxxxx');
+		p1.setCreateOption('createonly');
+		p1.setEditSummary('test append (morebits.js)');
+		p1.append(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('articleexists');
+				done();
+			});
+	});
+
+	it('fails to edit an existing page with createonly=1 (protected page)', function(done) {
+		var p1 = new Morebits.wiki.page('Wikipedia:Twinkle/ExampleProtectedPage', 'Appending');
+		p1.setAppendText('\n\nxxxxx');
+		p1.setCreateOption('createonly');
+		p1.setEditSummary('test append (morebits.js)');
+		p1.append(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('articleexists');
+				done();
+			});
+	});
+
+	it('fails to create (using append) a page with nocreate=1', function(done) {
+		var p1 = new Morebits.wiki.page('Morebits-test/' + Math.random(), 'Appending');
+		p1.setAppendText('\n\nxxxxx');
+		p1.setCreateOption('nocreate');
+		p1.setEditSummary('test append (morebits.js)');
+		p1.append(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('missingtitle');
+				done();
+			});
+	});
+
+
+	/** Lookup creation */
+
+	it('correctly looks up page creator', function(done) {
+		var p1 = new Morebits.wiki.page('Wikipedia:Twinkle/ExampleNonProtectedPage');
+		p1.lookupCreation(function() {
+			expect(p1.getCreator()).be.a('string');
+			expect(new Date(p1.getCreationTimestamp()).getDate()).to.not.be.NaN;
+			expect(p1.getCreator()).to.equal('SD0001');
+			expect(p1.getCreationTimestamp()).to.equal('2020-04-21T16:42:39Z');
+			done();
+		});
+	});
+
+	it('correctly looks up page creator of page created as redirect', function(done) {
+
+		// do this better
+		var p2 = new Morebits.wiki.page('Main Page');
+		p2.setLookupNonRedirectCreator(true);
+		p2.lookupCreation(function() {
+			expect(p2.getCreator()).to.be.a('string');
+			expect(p2.getCreationTimestamp()).to.be.a('string');
+			done();
+		});
+	});
+
+	/** Delete page */
+
+	it('correctly fails to delete page when no summary is provided', function (done) {
+		var p1 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to delete without edit summary');
+		p1.deletePage(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('int-noreason');
+				done();
+			});
+	});
+
+	it('correctly fails in fnProcessDelete: trying to delete non-existent page (delete after fetching token)', function (done) {
+		var nonExistingPageName = 'Morebits-test/' + Math.random(); // Lord be damned if that page exists
+		var p2 = new Morebits.wiki.page(nonExistingPageName);
+		p2.setEditSummary('test');
+		p2.deletePage(notExecuted, failPageCallback).done(notExecuted)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('missingtitle');
+				done();
+			});
+	});
+
+	it('correctly fails in fnProcessDeleteFailure: trying to delete non-existent page (direct deletion with local token)', function (done) {
+		var nonExistingPageName = 'Morebits-test/' + Math.random();
+		var p3 = new Morebits.wiki.page(nonExistingPageName);
+		p3.suppressProtectWarning(); // trigger alternate code path
+		p3.setEditSummary('test');
+		p3.deletePage(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('missingtitle');
+				done();
+			});
+	});
+
+	it('successfully deletes a page (after creating it)', function(done) {
+		this.timeout(4000); // has 2 api calls
+
+		var p4 = new Morebits.wiki.page('User:Morebits-test/' + Math.random());
+		p4.setAppendText('Page for testing deletion by morebits.js'); // create the page first
+		p4.setEditSummary('Creating test page for deletion');
+		p4.append(function() {
+			p4.setEditSummary('Testing deletion (morebits.js)');
+			p4.deletePage(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted).then(function() {
+				successPageCallback.apply(this, arguments);
+				done();
+			});
+		}, notExecuted);
+	});
+
+
+	/** Move page */
+
+	it('correctly fails to move page without setting destination', function (done) {
+		var p1 = new Morebits.wiki.page(Morebits.pageNameNorm);
+		p1.move(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('int-noreason');
+				done();
+			});
+	});
+
+	it('correctly fails in fnProcessMove: Trying to move non-existent page', function (done) {
+		var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random());
+		p2.setEditSummary('test');
+		p2.setMoveDestination('xxxxx');
+		p2.move(notExecuted, failPageCallback).done(notExecuted)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('missingtitle');
+				done();
+			});
+	});
+
+	it('correcty fails server-side (after API call is sent in fnProcessMove)', function(done) {
+		var p3 = new Morebits.wiki.page(Morebits.pageNameNorm, 'Trying to move (should give API error)');
+		p3.setEditSummary('test');
+		p3.setMoveDestination('de:xxxxx'); // invalid title to trigger API error
+		p3.move(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('invalidtitle');
+				done();
+			});
+	});
+
+	// Used for testing move and protect
+	var testPageName = 'User:Morebits-test/' + Math.random();
+
+	it('successfully move pages', function(done) {
+		this.timeout(4000);
+
+		var p4 = new Morebits.wiki.page(testPageName);
+		p4.setAppendText('Page for testing move by morebits.js'); // create the page first
+		p4.setEditSummary('Creating test page for move');
+		p4.setMoveSuppressRedirect(true);
+		p4.append(function() {
+			p4.setEditSummary('Testing move (morebits.js)');
+			p4.setMoveDestination(p4.getPageName() + '/1');
+			p4.move(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted).then(function() {
+				successPageCallback.apply(this, arguments);
+				testPageName = testPageName + '/1'; // update name for later use
+				done();
+			});
+		}, notExecuted);
+	});
+
+	/** Protect page */
+
+	it('correctly fails to protect without protection settings (failure in this.protect)', function(done) {
+		var p1 = new Morebits.wiki.page(Morebits.pageNameNorm);
+		p1.protect(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('int-nosetting');
+				done();
+			});
+	});
+
+	it('correctly fails to protect a non-existing page (failure in fnProcessProtect', function(done) {
+		var p2 = new Morebits.wiki.page('Morebits-test/' + Math.random(), "Testing protection (page doesn't exist");
+		p2.setEditSummary('test (morebits.js)');
+		p2.setEditProtection('sysop', 'infinite');
+		p2.protect(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('missingtitle');
+				done();
+			});
+	});
+
+	it('correctly fails to protect with already passed expiry date - server-side error after API call sent in fnProcessProtect', function(done) {
+		var p3 = new Morebits.wiki.page('Wikipedia:Twinkle/ExampleNonProtectedPage');
+		p3.setEditSummary('test (morebits.js)');
+		p3.setEditProtection('sysop', '2012-09-28');
+		p3.protect(notExecuted, failPageCallback).done(notExecuted).fail(failPageCallback)
+			.catch(function(pageobj, errorCode) {
+				expect(errorCode).to.equal('pastexpiry');
+				done();
+			});
+	});
+
+	it('successfully protects a page & deletes it to cleanup', function(done) {
+		// depends on testPageName to exist, created above in move testing
+		var p4 = new Morebits.wiki.page(testPageName);
+		p4.setEditSummary('test (morebits.js)');
+		p4.setEditProtection('sysop', 'infinite');
+		p4.protect(successPageCallback, notExecuted).done(successPageCallback).fail(notExecuted)
+			.then(function() {
+				successPageCallback.apply(this, arguments);
+				done();
+				p4.setEditSummary('delete page (morebits.js)');
+				p4.deletePage();
+			});
+	});
+
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "patchtest": "node patch-test.js"
+    "patchtest": "node patch-test.js",
+    "server": "node server.js"
   },
   "devDependencies": {
     "eslint": "^7.8.1",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+/* eslint-env node, es6 */
+
+const http = require('http');
+const fs = require('fs');
+
+const server = http.createServer((request, response) => {
+	const filePath = '.' + request.url;
+	let contentType;
+	if (request.url.endsWith('.js')) {
+		contentType = 'text/javascript';
+	} else if (request.url.endsWith('.css')) {
+		contentType = 'text/css';
+	}
+	fs.readFile(filePath, function(error, content) {
+		if (error) {
+			response.end('Oops, something went wrong: ' + error.code + ' ..\n');
+		} else {
+			response.writeHead(200, { 'Content-Type': contentType });
+			response.end(content, 'utf-8');
+		}
+	});
+});
+
+const hostname = '127.0.0.1';
+const port = 5500;
+
+server.listen(port, hostname, () => {
+	// eslint-disable-next-line no-console
+	console.log(`Server running at http://${hostname}:${port}/`);
+});

--- a/twinkle.testloader.js
+++ b/twinkle.testloader.js
@@ -1,0 +1,40 @@
+/* globals mocha */
+
+$.when(
+	mw.loader.using(['mediawiki.api', 'mediawiki.util', 'mediawiki.user', 'mediawiki.Title']),
+	$.ready
+).then(function() {
+
+	mw.util.$content.prepend(
+		$('<div>').attr('id', 'mocha')
+	);
+
+	mw.loader.load('https://unpkg.com/mocha/mocha.css', 'text/css');
+
+	// Some CSS adjustments for mocha to look better in Wikipedia environment
+	mw.util.addCSS(
+		'#mocha-stats { position: relative }' +
+		'#mocha { margin: 10px 20px 20px 20px }' +
+		'#mocha .test.pass::before, #mocha .test.fail::before, #mocha .test.pending::before { font-size: 20px }'
+	);
+
+	return $.when(
+		// TODO: download these and put in a lib directory
+		mw.loader.getScript('https://unpkg.com/chai/chai.js'),
+		mw.loader.getScript('https://unpkg.com/mocha/mocha.js')
+	);
+
+}).then(function() {
+	mocha.setup('bdd');
+
+	return mw.loader.getScript('http://127.0.0.1:5500/morebits.test.js');
+
+}).then(function() {
+
+	$('#mocha').append(
+		$('<button>').text('Run Twinkle unit tests').click(function() {
+			$(this).remove(); // remove button after being clicked, as it can't be used again
+			mocha.run();
+		})
+	);
+});


### PR DESCRIPTION
Includes the commits of pre-requisite #765.

Closes #783. 

All functions in Morebits.wiki.page are updated to support promises. The existing callback scheme continues to work. Also, fixes the issues with inconsistency in callback arguments as mentioned in #783. 

It's worth noting that after @Amorymeltzer's #712, there is a remarkable structural similarity across most functions.

The `stabilize` function is untested, as FlaggedRevs is not there on the testwiki, so I have no way to test it.

~~I've added "tests" as morebits-test-promises.js (last commit). These tests aren't automated - you've copy paste each code chunk to the console to see that that chunk is working as mentioned. Suitable for running on the testwiki only. Converting these to unit tests shouldn't be that difficult, though I couldn't get it right in an hour and a half.~~ Unit tests added, see https://github.com/azatoth/twinkle/pull/911#issuecomment-617343034