### PR TITLE
talkback: Restructure menu to simplify options, add whisperback

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -145,7 +145,8 @@ Twinkle.talkback.changeTarget = function(e) {
 			var templates = work_area.append({
 				type: 'select',
 				name: 'tbtemplate',
-				label: 'Which talkback template to use:'
+				label: 'Which talkback template to use:',
+				event: Twinkle.talkback.callback.change_template
 			});
 			$.each(Twinkle.talkback.templates.talkbacks, function(value, data) {
 				templates.append({
@@ -166,24 +167,7 @@ Twinkle.talkback.changeTarget = function(e) {
 					{ label: 'Other user\'s talk', value: 'othertalk' },
 					{ label: 'Other page', value: 'other' }
 				],
-				event: function(e) {
-					// Only needed for non-mytalk locations,
-					// but reset tooltip and label for each
-					if (e.target.form.page) {
-						$(Morebits.quickForm.getElementContainer(e.target.form.page)).remove();
-					}
-					if (e.target.value !== 'mytalk') {
-						e.target.parentNode.appendChild(new Morebits.quickForm.element({
-							type: 'input',
-							name: 'page',
-							label: e.target.value === 'othertalk' ? 'Other username' : 'Other page',
-							tooltip: (e.target.value === 'othertalk' ? 'The user on whose talk page' :
-								'Location of other page on which') + '  you left a message. Required.',
-							value: prev_page,
-							required: true
-						}).render());
-					}
-				}
+				event: Twinkle.talkback.callback.change_template
 			});
 
 			work_area.append({
@@ -252,6 +236,38 @@ Twinkle.talkback.changeTarget = function(e) {
 	$('#twinkle-talkback-optout-message').text(Twinkle.talkback.optout);
 };
 
+Twinkle.talkback.callback.change_template = function(e) {
+	var form = e.target.form;
+
+	// whisperback doesn't work with non user talk pages
+	if (form.tbtemplate.value === 'whisperback') {
+		form.location.options[2].disabled = true;
+		// Reset on non-user talk pages
+		if (form.location.options[2].selected) {
+			form.location.options[0].selected = true;
+		}
+	} else {
+		form.location.options[2].disabled = false;
+	}
+
+	// Only needed for non-mytalk locations,
+	// but reset tooltip and label for each
+	if (form.page) {
+		$(Morebits.quickForm.getElementContainer(form.page)).remove();
+	}
+	if (form.location.value !== 'mytalk') {
+		form.location.parentNode.appendChild(new Morebits.quickForm.element({
+			type: 'input',
+			name: 'page',
+			label: form.location.value === 'othertalk' ? 'Other username' : 'Other page',
+			tooltip: (form.location.value === 'othertalk' ? 'The user on whose talk page' : 'Location of other page on which') + '  you left a message. Required.',
+			value: prev_page,
+			required: true
+		}).render());
+	}
+};
+
+
 Twinkle.talkback.templates = {
 	talkbacks: {
 		'talkback': {
@@ -265,7 +281,7 @@ Twinkle.talkback.templates = {
 			editSummary: 'Please check the discussion at'
 		},
 		'whisperback': {
-			label: '{{Whisperback}}: Short user talk message',
+			label: '{{Whisperback}}: Short message (user talk pages only)',
 			text: 'Whisperback|1=$PAGE|2=$SECTION',
 			editSummary: ''
 		}


### PR DESCRIPTION
The layout of the talkback module window is a bit weird, with three talkback locations, then different options.  This collapses the three options into one so there's some coherence in the menu.  It builds on #902 and makes use of an object like c37b7c4/#758.  Includes a fairly heavy-handed normalization for likely mis-entered or erroneous page names to talkspace (project okay).

The first commit adds `{{whisperback}}` as a third talkback template option, as some prefer it and it's weird to have a dropdown with just two options.  The second commit restricts its usage by abusing the menus, and I'm not wild about it.  Should it be included?  If it is, should we let preview inform folks of weird/non-standard behavior?  If we're telling users where not to use it, should other talkback templates be included?

I think the restructure is worth it, but adding templates that don't do well outside of usertalk is a can of worms.