### PR TITLE
arv/shared/xfd: Use prepend/append a bit more

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -155,12 +155,12 @@ Twinkle.shared.callbacks = {
 		text += '}}\n\n';
 
 		var summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
-		pageobj.setPageText(text + pageText);
+		pageobj.setPrependText(text);
 		pageobj.setEditSummary(summaryText);
 		pageobj.setChangeTags(Twinkle.changeTags);
 		pageobj.setMinorEdit(Twinkle.getPref('markSharedIPAsMinor'));
 		pageobj.setCreateOption('recreate');
-		pageobj.save();
+		pageobj.prepend();
 	}
 };
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -571,7 +571,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			if (/[aeiouwyh]/.test(types[0] || '')) { // non 100% correct, but whatever, including 'h' for Cockney
 				article = 'an';
 			}
-			reason = '*{{user-uaa|1=' + uid + '}} &ndash; ';
+			reason = '\n*{{user-uaa|1=' + uid + '}} &ndash; ';
 			if (types.length || hasShared) {
 				reason += 'Violation of the username policy as ' + article + ' ' + types + ' username' +
 					(hasShared ? ' that implies shared use. ' : '. ');
@@ -604,8 +604,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 				uaaPage.getStatusElement().status('Adding new report...');
 				uaaPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].');
 				uaaPage.setChangeTags(Twinkle.changeTags);
-				uaaPage.setPageText(text + '\n' + reason);
-				uaaPage.save();
+				uaaPage.setAppendText(reason);
+				uaaPage.append();
 			});
 			break;
 


### PR DESCRIPTION
- arv: Use append for UAA posting, a la AIV
- shared: Use prepend rather than save
- xfd: Use prepend when tagging MfD, CfD, and CfD/S

----

This is minor, not sure it's really worth it philosophically.  TfD/TfM tagging of the template(s) could use `prepend` as well, but for TfM in particular it seemed like it would add extra complexity not really worth it.  Definitely doable, though, if folks think it worth doing.