### PR TITLE
morebits: exclude null values as well as undefined in api querystring

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1762,7 +1762,7 @@ Morebits.wiki.api.prototype = {
 		var queryString = $.map(this.query, function(val, i) {
 			if (Array.isArray(val)) {
 				return encodeURIComponent(i) + '=' + val.map(encodeURIComponent).join('|');
-			} else if (val !== undefined) {
+			} else if (val !== undefined && val !== null) {
 				return encodeURIComponent(i) + '=' + encodeURIComponent(val);
 			}
 		}).join('&').replace(/^(.*?)(\btoken=[^&]*)&(.*)/, '$1$3&$2');


### PR DESCRIPTION
Stems back to 2007 (https://en.wikipedia.org/w/index.php?title=User%3AAzaToth%2Fmorebits.js&diff=prev&oldid=137920973) but the initial intent was to exclude `null` values.  There are a number of places now where we set `null` to `''` so that it's correctly parsed: `{ key: '' }` becoming `key=` rather than `{ key: null }` becoming `key=null`.  This would just leave it off entirely.

----

Is this a good idea?  I haven't tested it at all, so I'm not sure of any negative side effects.  Philosophically, it's mixed; query strings are not a monolith.  `$.param` produces `param=` for `null` values, whereas we're sending `param=null`.  `JSON.stringify` keeps `null` values around, fwiw.