### PR TITLE
Set up use of TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,19 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@types/jquery": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.4.tgz",
+			"integrity": "sha512-//9CHhaUt/rurMJTxGI+I6DmsNHgYU6d8aSLFfO5dB7+10lwLnaWT0z5GY/yY82Q/M+B+0Qh3TixlJ8vmBeqIw==",
+			"requires": {
+				"@types/sizzle": "*"
+			}
+		},
+		"@types/sizzle": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+			"integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+		},
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -868,6 +881,12 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+			"integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
 			"dev": true
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"patchtest": "node dev/patch-test.js",
-	  	"server": "node dev/server.js",
+		"server": "node dev/server.js",
 		"sync": "perl dev/sync.pl",
-		"deployall": "perl dev/sync.pl --mode=deploy --all"
+		"deployall": "perl dev/sync.pl --mode=deploy --all",
+		"build": "npx tsc -p ./tsconfig.json"
 	},
 	"devDependencies": {
-		"eslint": "^7.13.0",
-		"eslint-plugin-es5": "^1.5.0"
+	  "@types/jquery": "^3.5.4",
+	  "eslint": "^7.13.0",
+	  "eslint-plugin-es5": "^1.5.0",
+	  "typescript": "^4.1.2"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,73 @@
+{
+  "compilerOptions": {
+	/* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+	/* Basic Options */
+	// "incremental": true,                   /* Enable incremental compilation */
+	"target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+	"module": "none",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+	"lib": [
+	  "dom",
+	  "es5",
+	  "es2015.collection" // Only Map and Set from this are supported in IE 11.
+	],                    /* Specify library files to be included in the compilation. */
+	// "allowJs": true,                       /* Allow javascript files to be compiled. */
+	// "checkJs": true,                       /* Report errors in .js files. */
+	// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+	// "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+	// "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+	// "sourceMap": true,                     /* Generates corresponding '.map' file. */
+	// "outFile": "./",                       /* Concatenate and emit output to single file. */
+	// "outDir": "./",                        /* Redirect output structure to the directory. */
+	// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+	// "composite": true,                     /* Enable project compilation */
+	// "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+	// "removeComments": true,                /* Do not emit comments to output. */
+	// "noEmit": true,                        /* Do not emit outputs. */
+	// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+	// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+	// "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+	/* Strict Type-Checking Options */
+	//	"strict": true,                       /* Enable all strict type-checking options. */
+	// "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+	// "strictNullChecks": true,              /* Enable strict null checks. */
+	// "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+	// "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+	// "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+	// "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+	// "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+	/* Additional Checks */
+	// "noUnusedLocals": true,                /* Report errors on unused locals. */
+	// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+	// "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+	// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+	/* Module Resolution Options */
+	 "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+	// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+	// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+	// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+	 "typeRoots": ["./types"],                /* List of folders to include type definitions from. */
+	// "types": [],                           /* Type declaration files to be included in compilation. */
+	// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+	// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+	// "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+	/* Source Map Options */
+	// "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+	// "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+	// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+	// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+	/* Experimental Options */
+	// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+	// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+	/* Advanced Options */
+    // "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+	"forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/twinkle.js
+++ b/twinkle.js
@@ -14,516 +14,444 @@
  * every Wikipedian in between. Visit [[WP:TW]] for more information.
  */
 // <nowiki>
-
 /* global Morebits */
-
-(function (window, document, $) { // Wrap with anonymous function
-
 // Check if account is experienced enough to use Twinkle
 if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
-	return;
+    throw new Error('Twinkle: forbidden!');
 }
-
-var Twinkle = {};
-window.Twinkle = Twinkle;  // allow global access
-
-Twinkle.initCallbacks = [];
-/**
- * Adds a callback to execute when Twinkle has loaded.
- * @param {function} func
- * @param {string} [name] - name of module used to check if is disabled.
- * If name is not given, module is loaded unconditionally.
- */
-Twinkle.addInitCallback = function twinkleAddInitCallback(func, name) {
-	Twinkle.initCallbacks.push({ func: func, name: name });
+// TypeScript: var declaration makes Twinkle available in global scope
+var Twinkle = {
+    initCallbacks: [],
+    /**
+     * Adds a callback to execute when Twinkle has loaded.
+     * @param {function} func
+     * @param {string} [name] - name of module used to check if is disabled.
+     * If name is not given, module is loaded unconditionally.
+     */
+    addInitCallback: function (func, name) {
+        Twinkle.initCallbacks.push({ func: func, name: name });
+    },
+    /**
+     * This holds the default set of preferences used by Twinkle.
+     * It is important that all new preferences added here, especially admin-only ones, are also added to
+     * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
+     * For help on the actual preferences, see the comments in twinkleconfig.js.
+     *
+     * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
+     */
+    defaultConfig: {
+        // General
+        userTalkPageMode: 'tab',
+        dialogLargeFont: false,
+        disabledModules: [],
+        disabledSysopModules: [],
+        // Portlet
+        portletArea: null,
+        portletId: null,
+        portletName: null,
+        portletType: null,
+        portletNext: null,
+        // ARV
+        spiWatchReport: 'yes',
+        // Block
+        defaultToPartialBlocks: false,
+        blankTalkpageOnIndefBlock: false,
+        // Fluff (revert and rollback)
+        autoMenuAfterRollback: false,
+        openTalkPage: ['agf', 'norm', 'vand'],
+        openTalkPageOnAutoRevert: false,
+        rollbackInPlace: false,
+        markRevertedPagesAsMinor: ['vand'],
+        watchRevertedPages: ['agf', 'norm', 'vand', 'torev'],
+        watchRevertedExpiry: 'yes',
+        offerReasonOnNormalRevert: true,
+        confirmOnFluff: false,
+        confirmOnMobileFluff: true,
+        showRollbackLinks: ['diff', 'others'],
+        // DI (twinkleimage)
+        notifyUserOnDeli: true,
+        deliWatchPage: 'default',
+        deliWatchUser: 'default',
+        // PROD
+        watchProdPages: 'yes',
+        markProdPagesAsPatrolled: false,
+        prodReasonDefault: '',
+        logProdPages: false,
+        prodLogPageName: 'PROD log',
+        // CSD
+        speedySelectionStyle: 'buttonClick',
+        watchSpeedyPages: ['g3', 'g5', 'g10', 'g11', 'g12'],
+        watchSpeedyExpiry: 'yes',
+        markSpeedyPagesAsPatrolled: false,
+        // these next two should probably be identical by default
+        welcomeUserOnSpeedyDeletionNotification: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        notifyUserOnSpeedyDeletionNomination: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        warnUserOnSpeedyDelete: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        promptForSpeedyDeletionSummary: [],
+        deleteTalkPageOnDelete: true,
+        deleteRedirectsOnDelete: true,
+        deleteSysopDefaultToDelete: false,
+        speedyWindowHeight: 500,
+        speedyWindowWidth: 800,
+        logSpeedyNominations: false,
+        speedyLogPageName: 'CSD log',
+        noLogOnSpeedyNomination: ['u1'],
+        // Unlink
+        unlinkNamespaces: ['0', '10', '100', '118'],
+        // Warn
+        defaultWarningGroup: '1',
+        combinedSingletMenus: false,
+        showSharedIPNotice: true,
+        watchWarnings: 'yes',
+        oldSelect: false,
+        customWarningList: [],
+        // XfD
+        logXfdNominations: false,
+        xfdLogPageName: 'XfD log',
+        noLogOnXfdNomination: [],
+        xfdWatchDiscussion: 'default',
+        xfdWatchList: 'no',
+        xfdWatchPage: 'default',
+        xfdWatchUser: 'default',
+        xfdWatchRelated: 'default',
+        markXfdPagesAsPatrolled: true,
+        // Hidden preferences
+        autolevelStaleDays: 3,
+        revertMaxRevisions: 50,
+        batchMax: 5000,
+        batchChunks: 50,
+        // Deprecated options, as a fallback for add-on scripts/modules
+        summaryAd: ' ([[WP:TW|TW]])',
+        deletionSummaryAd: ' ([[WP:TW|TW]])',
+        protectionSummaryAd: ' ([[WP:TW|TW]])',
+        // Formerly defaultConfig.friendly:
+        // Tag
+        groupByDefault: true,
+        watchTaggedPages: 'yes',
+        watchMergeDiscussions: 'yes',
+        markTaggedPagesAsMinor: false,
+        markTaggedPagesAsPatrolled: true,
+        tagArticleSortOrder: 'cat',
+        customTagList: [],
+        customFileTagList: [],
+        customRedirectTagList: [],
+        // Welcome
+        topWelcomes: false,
+        watchWelcomes: 'yes',
+        welcomeHeading: 'Welcome',
+        insertHeadings: true,
+        insertUsername: true,
+        insertSignature: true,
+        quickWelcomeMode: 'norm',
+        quickWelcomeTemplate: 'welcome',
+        customWelcomeList: [],
+        customWelcomeSignature: true,
+        // Talkback
+        markTalkbackAsMinor: true,
+        insertTalkbackSignature: true,
+        talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
+        mailHeading: "You've got mail!",
+        // Shared
+        markSharedIPAsMinor: true
+    },
+    prefs: undefined,
+    getPref: function (name) {
+        if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
+            return Twinkle.prefs[name];
+        }
+        // Old preferences format, used before twinkleoptions.js was a thing
+        if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
+            return window.TwinkleConfig[name];
+        }
+        if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
+            return window.FriendlyConfig[name];
+        }
+        return Twinkle.defaultConfig[name];
+    },
+    /**
+     * **************** Twinkle.addPortlet() ****************
+     *
+     * Adds a portlet menu to one of the navigation areas on the page.
+     * This is necessarily quite a hack since skins, navigation areas, and
+     * portlet menu types all work slightly different.
+     *
+     * Available navigation areas depend on the skin used.
+     * Vector:
+     *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
+     *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
+     *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
+     *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
+     *  Special layout of p-personal portlet (part of "head") through specialized styles.
+     * Monobook:
+     *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+     *  Special layout of p-cactions and p-personal through specialized styles.
+     * Modern:
+     *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
+     *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+     *
+     * @param {string} navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
+     * @param {string} id -- id of the portlet menu to create, preferably start with "p-".
+     * @param {string} text -- name of the portlet menu to create. Visibility depends on the class used.
+     * @param {string} type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
+     * @param {Node} nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
+     *
+     * @return Node -- the DOM node of the new item (a DIV element) or null
+     */
+    addPortlet: function (navigation, id, text, type, nextnodeid) {
+        // sanity checks, and get required DOM nodes
+        var root = document.getElementById(navigation) || document.querySelector(navigation);
+        if (!root) {
+            return null;
+        }
+        var item = document.getElementById(id);
+        if (item) {
+            if (item.parentNode && item.parentNode === root) {
+                return item;
+            }
+            return null;
+        }
+        var nextnode;
+        if (nextnodeid) {
+            nextnode = document.getElementById(nextnodeid);
+        }
+        // verify/normalize input
+        var skin = mw.config.get('skin');
+        if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
+            type = null; // menu supported only in vector's #left-navigation & #right-navigation
+        }
+        var outerNavClass, innerDivClass;
+        switch (skin) {
+            case 'vector':
+                // XXX: portal doesn't work
+                if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
+                    navigation = 'mw-panel';
+                }
+                outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+                innerDivClass = 'vector-menu-content';
+                break;
+            case 'modern':
+                if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
+                    navigation = 'mw_portlets';
+                }
+                outerNavClass = 'portlet';
+                break;
+            case 'timeless':
+                outerNavClass = 'mw-portlet';
+                innerDivClass = 'mw-portlet-body';
+                break;
+            default:
+                navigation = 'column-one';
+                outerNavClass = 'portlet';
+                break;
+        }
+        // Build the DOM elements.
+        var outerNav = document.createElement('nav');
+        outerNav.setAttribute('aria-labelledby', id + '-label');
+        outerNav.className = outerNavClass + ' emptyPortlet';
+        outerNav.id = id;
+        if (nextnode && nextnode.parentNode === root) {
+            root.insertBefore(outerNav, nextnode);
+        }
+        else {
+            root.appendChild(outerNav);
+        }
+        var h3 = document.createElement('h3');
+        h3.id = id + '-label';
+        var ul = document.createElement('ul');
+        if (skin === 'vector') {
+            ul.className = 'vector-menu-content-list';
+            // add invisible checkbox to keep menu open when clicked
+            // similar to the p-cactions ("More") menu
+            if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
+                var chkbox = document.createElement('input');
+                chkbox.className = 'vector-menu-checkbox';
+                chkbox.setAttribute('type', 'checkbox');
+                chkbox.setAttribute('aria-labelledby', id + '-label');
+                outerNav.appendChild(chkbox);
+                // Vector gets its title in a span; all others except
+                // timeless have no title, and it has no span
+                var span = document.createElement('span');
+                span.appendChild(document.createTextNode(text));
+                h3.appendChild(span);
+                var a = document.createElement('a');
+                a.href = '#';
+                $(a).click(function (e) {
+                    e.preventDefault();
+                });
+                h3.appendChild(a);
+            }
+        }
+        else {
+            // Basically just Timeless
+            h3.appendChild(document.createTextNode(text));
+        }
+        outerNav.appendChild(h3);
+        if (innerDivClass) {
+            var innerDiv = document.createElement('div');
+            innerDiv.className = innerDivClass;
+            innerDiv.appendChild(ul);
+            outerNav.appendChild(innerDiv);
+        }
+        else {
+            outerNav.appendChild(ul);
+        }
+        return outerNav;
+    },
+    /**
+     * **************** Twinkle.addPortletLink() ****************
+     * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
+     * @param task: Either a URL for the portlet link or a function to execute.
+     * @param text
+     * @param id
+     * @param tooltip
+     */
+    addPortletLink: function (task, text, id, tooltip) {
+        if (Twinkle.getPref('portletArea') !== null) {
+            Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
+        }
+        var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
+        $('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+        if (typeof task === 'function') {
+            $(link).click(function (ev) {
+                task();
+                ev.preventDefault();
+            });
+        }
+        if ($.collapsibleTabs) {
+            $.collapsibleTabs.handleResize();
+        }
+        return link;
+    },
+    disabledModules: null,
+    load: function () {
+        // Don't activate on special pages other than those listed here, so
+        // that others load faster, especially the watchlist.
+        var activeSpecialPageList = ['Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked']; // wgRelevantUserName defined for non-sysops on Special:Block
+        if (Morebits.userIsSysop) {
+            activeSpecialPageList = activeSpecialPageList.concat(['DeletedContributions', 'Prefixindex']);
+        }
+        if (mw.config.get('wgNamespaceNumber') === -1 &&
+            activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
+            return;
+        }
+        // Prevent clickjacking
+        if (window.top !== window.self) {
+            return;
+        }
+        // Set custom Api-User-Agent header, for server-side logging purposes
+        Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
+        Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
+        // Redefine addInitCallback so that any modules being loaded now on are directly
+        // initialised rather than added to initCallbacks array
+        Twinkle.addInitCallback = function (func, name) {
+            if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
+                func();
+            }
+        };
+        // Initialise modules that were saved in initCallbacks array
+        Twinkle.initCallbacks.forEach(function (module) {
+            Twinkle.addInitCallback(module.func, module.name);
+        });
+        // Increases text size in Twinkle dialogs, if so configured
+        if (Twinkle.getPref('dialogLargeFont')) {
+            mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
+                '.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
+        }
+        // Hide the lingering space if the TW menu is empty
+        if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
+            $('#p-cactions').css('margin-right', 'initial');
+        }
+    },
+    /**
+     * Twinkle-specific data shared by multiple modules
+     * Likely customized per installation
+     */
+    // Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
+    changeTags: 'twinkle',
+    // Available for actions that don't (yet) support tags
+    // currently: FlaggedRevs and PageTriage
+    summaryAd: ' ([[WP:TW|TW]])',
+    // Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
+    // ensure MOS:ORDER
+    hatnoteRegex: 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)',
+    // Used in XFD and PROD
+    makeFindSourcesDiv: function () {
+        var makeLink = function (href, text) {
+            return $('<a>').attr({ rel: 'nofollow', class: 'external text',
+                target: '_blank', href: href }).text(text);
+        };
+        var title = encodeURIComponent(Morebits.pageNameNorm);
+        return $('<div>')
+            .addClass('plainlinks')
+            .append('(', $('<i>').text('Find sources:'), ' ', makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'), ' (', makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ', makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ', makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ', makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ', makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ', makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'), ')', ' - ', makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ', makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ', makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ', makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'), ')')[0];
+    }
 };
-
-Twinkle.defaultConfig = {};
-/**
- * This holds the default set of preferences used by Twinkle.
- * It is important that all new preferences added here, especially admin-only ones, are also added to
- * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
- * For help on the actual preferences, see the comments in twinkleconfig.js.
- *
- * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
- */
-Twinkle.defaultConfig = {
-	// General
-	userTalkPageMode: 'tab',
-	dialogLargeFont: false,
-	disabledModules: [],
-	disabledSysopModules: [],
-
-	// ARV
-	spiWatchReport: 'yes',
-
-	// Block
-	defaultToPartialBlocks: false,
-	blankTalkpageOnIndefBlock: false,
-
-	// Fluff (revert and rollback)
-	autoMenuAfterRollback: false,
-	openTalkPage: [ 'agf', 'norm', 'vand' ],
-	openTalkPageOnAutoRevert: false,
-	rollbackInPlace: false,
-	markRevertedPagesAsMinor: [ 'vand' ],
-	watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
-	watchRevertedExpiry: 'yes',
-	offerReasonOnNormalRevert: true,
-	confirmOnFluff: false,
-	confirmOnMobileFluff: true,
-	showRollbackLinks: [ 'diff', 'others' ],
-
-	// DI (twinkleimage)
-	notifyUserOnDeli: true,
-	deliWatchPage: 'default',
-	deliWatchUser: 'default',
-
-	// PROD
-	watchProdPages: 'yes',
-	markProdPagesAsPatrolled: false,
-	prodReasonDefault: '',
-	logProdPages: false,
-	prodLogPageName: 'PROD log',
-
-	// CSD
-	speedySelectionStyle: 'buttonClick',
-	watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
-	watchSpeedyExpiry: 'yes',
-	markSpeedyPagesAsPatrolled: false,
-
-	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	promptForSpeedyDeletionSummary: [],
-	deleteTalkPageOnDelete: true,
-	deleteRedirectsOnDelete: true,
-	deleteSysopDefaultToDelete: false,
-	speedyWindowHeight: 500,
-	speedyWindowWidth: 800,
-	logSpeedyNominations: false,
-	speedyLogPageName: 'CSD log',
-	noLogOnSpeedyNomination: [ 'u1' ],
-
-	// Unlink
-	unlinkNamespaces: [ '0', '10', '100', '118' ],
-
-	// Warn
-	defaultWarningGroup: '1',
-	combinedSingletMenus: false,
-	showSharedIPNotice: true,
-	watchWarnings: 'yes',
-	oldSelect: false,
-	customWarningList: [],
-
-	// XfD
-	logXfdNominations: false,
-	xfdLogPageName: 'XfD log',
-	noLogOnXfdNomination: [],
-	xfdWatchDiscussion: 'default',
-	xfdWatchList: 'no',
-	xfdWatchPage: 'default',
-	xfdWatchUser: 'default',
-	xfdWatchRelated: 'default',
-	markXfdPagesAsPatrolled: true,
-
-	// Hidden preferences
-	autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
-	revertMaxRevisions: 50, // intentionally limited
-	batchMax: 5000,
-	batchChunks: 50,
-
-	// Deprecated options, as a fallback for add-on scripts/modules
-	summaryAd: ' ([[WP:TW|TW]])',
-	deletionSummaryAd: ' ([[WP:TW|TW]])',
-	protectionSummaryAd: ' ([[WP:TW|TW]])',
-
-	// Formerly defaultConfig.friendly:
-	// Tag
-	groupByDefault: true,
-	watchTaggedPages: 'yes',
-	watchMergeDiscussions: 'yes',
-	markTaggedPagesAsMinor: false,
-	markTaggedPagesAsPatrolled: true,
-	tagArticleSortOrder: 'cat',
-	customTagList: [],
-	customFileTagList: [],
-	customRedirectTagList: [],
-
-	// Welcome
-	topWelcomes: false,
-	watchWelcomes: 'yes',
-	welcomeHeading: 'Welcome',
-	insertHeadings: true,
-	insertUsername: true,
-	insertSignature: true,  // sign welcome templates, where appropriate
-	quickWelcomeMode: 'norm',
-	quickWelcomeTemplate: 'welcome',
-	customWelcomeList: [],
-	customWelcomeSignature: true,
-
-	// Talkback
-	markTalkbackAsMinor: true,
-	insertTalkbackSignature: true,  // always sign talkback templates
-	talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
-	mailHeading: "You've got mail!",
-
-	// Shared
-	markSharedIPAsMinor: true
-};
-
-// now some skin dependent config.
+// Some skin dependent config.
 switch (mw.config.get('skin')) {
-	case 'vector':
-		Twinkle.defaultConfig.portletArea = 'right-navigation';
-		Twinkle.defaultConfig.portletId = 'p-twinkle';
-		Twinkle.defaultConfig.portletName = 'TW';
-		Twinkle.defaultConfig.portletType = 'menu';
-		Twinkle.defaultConfig.portletNext = 'p-search';
-		break;
-	case 'timeless':
-		Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
-		Twinkle.defaultConfig.portletId = 'p-twinkle';
-		Twinkle.defaultConfig.portletName = 'Twinkle';
-		Twinkle.defaultConfig.portletType = null;
-		Twinkle.defaultConfig.portletNext = 'p-userpagetools';
-		break;
-	default:
-		Twinkle.defaultConfig.portletArea = null;
-		Twinkle.defaultConfig.portletId = 'p-cactions';
-		Twinkle.defaultConfig.portletName = null;
-		Twinkle.defaultConfig.portletType = null;
-		Twinkle.defaultConfig.portletNext = null;
+    case 'vector':
+        Twinkle.defaultConfig.portletArea = 'right-navigation';
+        Twinkle.defaultConfig.portletId = 'p-twinkle';
+        Twinkle.defaultConfig.portletName = 'TW';
+        Twinkle.defaultConfig.portletType = 'menu';
+        Twinkle.defaultConfig.portletNext = 'p-search';
+        break;
+    case 'timeless':
+        Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
+        Twinkle.defaultConfig.portletId = 'p-twinkle';
+        Twinkle.defaultConfig.portletName = 'Twinkle';
+        Twinkle.defaultConfig.portletType = null;
+        Twinkle.defaultConfig.portletNext = 'p-userpagetools';
+        break;
+    default:
+        Twinkle.defaultConfig.portletArea = null;
+        Twinkle.defaultConfig.portletId = 'p-cactions';
+        Twinkle.defaultConfig.portletName = null;
+        Twinkle.defaultConfig.portletType = null;
+        Twinkle.defaultConfig.portletNext = null;
 }
-
-
-Twinkle.getPref = function twinkleGetPref(name) {
-	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
-		return Twinkle.prefs[name];
-	}
-	// Old preferences format, used before twinkleoptions.js was a thing
-	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
-		return window.TwinkleConfig[name];
-	}
-	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
-		return window.FriendlyConfig[name];
-	}
-	return Twinkle.defaultConfig[name];
-};
-
-
-/**
- * **************** Twinkle.addPortlet() ****************
- *
- * Adds a portlet menu to one of the navigation areas on the page.
- * This is necessarily quite a hack since skins, navigation areas, and
- * portlet menu types all work slightly different.
- *
- * Available navigation areas depend on the skin used.
- * Vector:
- *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
- *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
- *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
- *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
- *  Special layout of p-personal portlet (part of "head") through specialized styles.
- * Monobook:
- *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *  Special layout of p-cactions and p-personal through specialized styles.
- * Modern:
- *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
- *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *
- * @param String navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
- * @param String id -- id of the portlet menu to create, preferably start with "p-".
- * @param String text -- name of the portlet menu to create. Visibility depends on the class used.
- * @param String type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
- * @param Node nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
- *
- * @return Node -- the DOM node of the new item (a DIV element) or null
- */
-Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
-	// sanity checks, and get required DOM nodes
-	var root = document.getElementById(navigation) || document.querySelector(navigation);
-	if (!root) {
-		return null;
-	}
-
-	var item = document.getElementById(id);
-	if (item) {
-		if (item.parentNode && item.parentNode === root) {
-			return item;
-		}
-		return null;
-	}
-
-	var nextnode;
-	if (nextnodeid) {
-		nextnode = document.getElementById(nextnodeid);
-	}
-
-	// verify/normalize input
-	var skin = mw.config.get('skin');
-	if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
-		type = null; // menu supported only in vector's #left-navigation & #right-navigation
-	}
-	var outerNavClass, innerDivClass;
-	switch (skin) {
-		case 'vector':
-			// XXX: portal doesn't work
-			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
-				navigation = 'mw-panel';
-			}
-			outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
-			innerDivClass = 'vector-menu-content';
-			break;
-		case 'modern':
-			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
-				navigation = 'mw_portlets';
-			}
-			outerNavClass = 'portlet';
-			break;
-		case 'timeless':
-			outerNavClass = 'mw-portlet';
-			innerDivClass = 'mw-portlet-body';
-			break;
-		default:
-			navigation = 'column-one';
-			outerNavClass = 'portlet';
-			break;
-	}
-
-	// Build the DOM elements.
-	var outerNav = document.createElement('nav');
-	outerNav.setAttribute('aria-labelledby', id + '-label');
-	outerNav.className = outerNavClass + ' emptyPortlet';
-	outerNav.id = id;
-	if (nextnode && nextnode.parentNode === root) {
-		root.insertBefore(outerNav, nextnode);
-	} else {
-		root.appendChild(outerNav);
-	}
-
-	var h3 = document.createElement('h3');
-	h3.id = id + '-label';
-	var ul = document.createElement('ul');
-
-	if (skin === 'vector') {
-		ul.className = 'vector-menu-content-list';
-
-		// add invisible checkbox to keep menu open when clicked
-		// similar to the p-cactions ("More") menu
-		if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
-			var chkbox = document.createElement('input');
-			chkbox.className = 'vector-menu-checkbox';
-			chkbox.setAttribute('type', 'checkbox');
-			chkbox.setAttribute('aria-labelledby', id + '-label');
-			outerNav.appendChild(chkbox);
-
-			// Vector gets its title in a span; all others except
-			// timeless have no title, and it has no span
-			var span = document.createElement('span');
-			span.appendChild(document.createTextNode(text));
-			h3.appendChild(span);
-
-			var a = document.createElement('a');
-			a.href = '#';
-
-			$(a).click(function(e) {
-				e.preventDefault();
-			});
-
-			h3.appendChild(a);
-		}
-	} else {
-		// Basically just Timeless
-		h3.appendChild(document.createTextNode(text));
-	}
-
-	outerNav.appendChild(h3);
-
-	if (innerDivClass) {
-		var innerDiv = document.createElement('div');
-		innerDiv.className = innerDivClass;
-		innerDiv.appendChild(ul);
-		outerNav.appendChild(innerDiv);
-	} else {
-		outerNav.appendChild(ul);
-	}
-
-
-	return outerNav;
-
-};
-
-
-/**
- * **************** Twinkle.addPortletLink() ****************
- * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
- * @param task: Either a URL for the portlet link or a function to execute.
- */
-Twinkle.addPortletLink = function(task, text, id, tooltip) {
-	if (Twinkle.getPref('portletArea') !== null) {
-		Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
-	}
-	var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
-	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
-	if (typeof task === 'function') {
-		$(link).click(function (ev) {
-			task();
-			ev.preventDefault();
-		});
-	}
-	if ($.collapsibleTabs) {
-		$.collapsibleTabs.handleResize();
-	}
-	return link;
-};
-
-
 /**
  * **************** General initialization code ****************
  */
-
-var scriptpathbefore = mw.util.wikiScript('index') + '?title=',
-	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
-
+var scriptpathbefore = mw.util.wikiScript('index') + '?title=', scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
 // Retrieve the user's Twinkle preferences
 $.ajax({
-	url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
-	dataType: 'text'
+    url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
+    dataType: 'text'
 })
-	.fail(function () {
-		mw.notify('Could not load your Twinkle preferences', {type: 'error'});
-	})
-	.done(function (optionsText) {
-
-		// Quick pass if user has no options
-		if (optionsText === '') {
-			return;
-		}
-
-		// Twinkle options are basically a JSON object with some comments. Strip those:
-		optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
-
-		// First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
-		if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
-			optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
-		}
-
-		try {
-			var options = JSON.parse(optionsText);
-			if (options) {
-				if (options.twinkle || options.friendly) { // Old preferences format
-					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
-				} else {
-					Twinkle.prefs = options;
-				}
-				// v2 established after unification of Twinkle/Friendly objects
-				Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
-			}
-		} catch (e) {
-			mw.notify('Could not parse your Twinkle preferences', {type: 'error'});
-		}
-	})
-	.always(function () {
-		$(Twinkle.load);
-	});
-
-// Developers: you can import custom Twinkle modules here
-// For example, mw.loader.load(scriptpathbefore + "User:UncleDouggie/morebits-test.js" + scriptpathafter);
-
-Twinkle.load = function () {
-	// Don't activate on special pages other than those listed here, so
-	// that others load faster, especially the watchlist.
-	var activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
-	if (Morebits.userIsSysop) {
-		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
-	}
-	if (mw.config.get('wgNamespaceNumber') === -1 &&
-		activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
-		return;
-	}
-
-	// Prevent clickjacking
-	if (window.top !== window.self) {
-		return;
-	}
-
-	// Set custom Api-User-Agent header, for server-side logging purposes
-	Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
-
-	Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
-
-	// Redefine addInitCallback so that any modules being loaded now on are directly
-	// initialised rather than added to initCallbacks array
-	Twinkle.addInitCallback = function(func, name) {
-		if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
-			func();
-		}
-	};
-	// Initialise modules that were saved in initCallbacks array
-	Twinkle.initCallbacks.forEach(function(module) {
-		Twinkle.addInitCallback(module.func, module.name);
-	});
-
-	// Increases text size in Twinkle dialogs, if so configured
-	if (Twinkle.getPref('dialogLargeFont')) {
-		mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
-			'.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
-	}
-
-	// Hide the lingering space if the TW menu is empty
-	if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
-		$('#p-cactions').css('margin-right', 'initial');
-	}
-};
-
-
-/**
- * Twinkle-specific data shared by multiple modules
- * Likely customized per installation
- */
-
-// Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
-Twinkle.changeTags = 'twinkle';
-// Available for actions that don't (yet) support tags
-// currently: FlaggedRevs and PageTriage
-Twinkle.summaryAd = ' ([[WP:TW|TW]])';
-
-// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
-// ensure MOS:ORDER
-Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)';
-
-// Used in XFD and PROD
-Twinkle.makeFindSourcesDiv = function makeSourcesDiv() {
-	var makeLink = function(href, text) {
-		return $('<a>').attr({ rel: 'nofollow', class: 'external text',
-			target: '_blank', href: href }).text(text);
-	};
-	var title = encodeURIComponent(Morebits.pageNameNorm);
-	return $('<div>')
-		.addClass('plainlinks')
-		.append(
-			'(',
-			$('<i>').text('Find sources:'), ' ',
-			makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'),
-			' (',
-			makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ',
-			makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ',
-			makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ',
-			makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ',
-			makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ',
-			makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'),
-			')', ' - ',
-			makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ',
-			makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ',
-			makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ',
-			makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'),
-			')'
-		)[0];
-};
-
-}(window, document, jQuery)); // End wrap with anonymous function
-
+    .fail(function () {
+    mw.notify('Could not load your Twinkle preferences', { type: 'error' });
+})
+    .done(function (optionsText) {
+    // Quick pass if user has no options
+    if (optionsText === '') {
+        return;
+    }
+    // Twinkle options are basically a JSON object with some comments. Strip those:
+    optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
+    // First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
+    if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
+        optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
+    }
+    try {
+        var options = JSON.parse(optionsText);
+        if (options) {
+            if (options.twinkle || options.friendly) { // Old preferences format
+                Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+            }
+            else {
+                Twinkle.prefs = options;
+            }
+            // v2 established after unification of Twinkle/Friendly objects
+            Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
+        }
+    }
+    catch (e) {
+        mw.notify('Could not parse your Twinkle preferences', { type: 'error' });
+    }
+})
+    .always(function () {
+    $(Twinkle.load);
+});
+window.Twinkle = Twinkle; // allow global access
 // </nowiki>
+//# sourceMappingURL=twinkle.js.map

--- a/twinkle.ts
+++ b/twinkle.ts
@@ -1,0 +1,537 @@
+/**
+ * +-------------------------------------------------------------------------+
+ * |                  === WARNING: GLOBAL GADGET FILE ===                    |
+ * |                Changes to this page affect many users.                  |
+ * |           Please discuss changes at [[WT:TW]] before editing.           |
+ * +-------------------------------------------------------------------------+
+ *
+ * Imported from github [https://github.com/azatoth/twinkle].
+ * All changes should be made in the repository, otherwise they will be lost.
+ *
+ * ----------
+ *
+ * This is AzaToth's Twinkle, the popular script sidekick for newbies, admins, and
+ * every Wikipedian in between. Visit [[WP:TW]] for more information.
+ */
+// <nowiki>
+
+/* global Morebits */
+
+// Check if account is experienced enough to use Twinkle
+if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
+	throw new Error('Twinkle: forbidden!');
+}
+
+// TypeScript: var declaration makes Twinkle available in global scope
+var Twinkle = {
+	initCallbacks: [],
+
+	/**
+	 * Adds a callback to execute when Twinkle has loaded.
+	 * @param {function} func
+	 * @param {string} [name] - name of module used to check if is disabled.
+	 * If name is not given, module is loaded unconditionally.
+	 */
+	addInitCallback(func: (() => void), name: string) {
+		Twinkle.initCallbacks.push({ func: func, name: name });
+	},
+
+	/**
+	 * This holds the default set of preferences used by Twinkle.
+	 * It is important that all new preferences added here, especially admin-only ones, are also added to
+	 * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
+	 * For help on the actual preferences, see the comments in twinkleconfig.js.
+	 *
+	 * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
+	 */
+	defaultConfig:  {
+		// General
+		userTalkPageMode: 'tab',
+		dialogLargeFont: false,
+		disabledModules: [],
+		disabledSysopModules: [],
+
+		// Portlet
+		portletArea: null,
+		portletId: null,
+		portletName: null,
+		portletType: null,
+		portletNext: null,
+
+		// ARV
+		spiWatchReport: 'yes',
+
+		// Block
+		defaultToPartialBlocks: false,
+		blankTalkpageOnIndefBlock: false,
+
+		// Fluff (revert and rollback)
+		autoMenuAfterRollback: false,
+		openTalkPage: [ 'agf', 'norm', 'vand' ],
+		openTalkPageOnAutoRevert: false,
+		rollbackInPlace: false,
+		markRevertedPagesAsMinor: [ 'vand' ],
+		watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
+		watchRevertedExpiry: 'yes',
+		offerReasonOnNormalRevert: true,
+		confirmOnFluff: false,
+		confirmOnMobileFluff: true,
+		showRollbackLinks: [ 'diff', 'others' ],
+
+		// DI (twinkleimage)
+		notifyUserOnDeli: true,
+		deliWatchPage: 'default',
+		deliWatchUser: 'default',
+
+		// PROD
+		watchProdPages: 'yes',
+		markProdPagesAsPatrolled: false,
+		prodReasonDefault: '',
+		logProdPages: false,
+		prodLogPageName: 'PROD log',
+
+		// CSD
+		speedySelectionStyle: 'buttonClick',
+		watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
+		watchSpeedyExpiry: 'yes',
+		markSpeedyPagesAsPatrolled: false,
+
+		// these next two should probably be identical by default
+		welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		promptForSpeedyDeletionSummary: [],
+		deleteTalkPageOnDelete: true,
+		deleteRedirectsOnDelete: true,
+		deleteSysopDefaultToDelete: false,
+		speedyWindowHeight: 500,
+		speedyWindowWidth: 800,
+		logSpeedyNominations: false,
+		speedyLogPageName: 'CSD log',
+		noLogOnSpeedyNomination: [ 'u1' ],
+
+		// Unlink
+		unlinkNamespaces: [ '0', '10', '100', '118' ],
+
+		// Warn
+		defaultWarningGroup: '1',
+		combinedSingletMenus: false,
+		showSharedIPNotice: true,
+		watchWarnings: 'yes',
+		oldSelect: false,
+		customWarningList: [],
+
+		// XfD
+		logXfdNominations: false,
+		xfdLogPageName: 'XfD log',
+		noLogOnXfdNomination: [],
+		xfdWatchDiscussion: 'default',
+		xfdWatchList: 'no',
+		xfdWatchPage: 'default',
+		xfdWatchUser: 'default',
+		xfdWatchRelated: 'default',
+		markXfdPagesAsPatrolled: true,
+
+		// Hidden preferences
+		autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
+		revertMaxRevisions: 50, // intentionally limited
+		batchMax: 5000,
+		batchChunks: 50,
+
+		// Deprecated options, as a fallback for add-on scripts/modules
+		summaryAd: ' ([[WP:TW|TW]])',
+		deletionSummaryAd: ' ([[WP:TW|TW]])',
+		protectionSummaryAd: ' ([[WP:TW|TW]])',
+
+		// Formerly defaultConfig.friendly:
+		// Tag
+		groupByDefault: true,
+		watchTaggedPages: 'yes',
+		watchMergeDiscussions: 'yes',
+		markTaggedPagesAsMinor: false,
+		markTaggedPagesAsPatrolled: true,
+		tagArticleSortOrder: 'cat',
+		customTagList: [],
+		customFileTagList: [],
+		customRedirectTagList: [],
+
+		// Welcome
+		topWelcomes: false,
+		watchWelcomes: 'yes',
+		welcomeHeading: 'Welcome',
+		insertHeadings: true,
+		insertUsername: true,
+		insertSignature: true,  // sign welcome templates, where appropriate
+		quickWelcomeMode: 'norm',
+		quickWelcomeTemplate: 'welcome',
+		customWelcomeList: [],
+		customWelcomeSignature: true,
+
+		// Talkback
+		markTalkbackAsMinor: true,
+		insertTalkbackSignature: true,  // always sign talkback templates
+		talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
+		mailHeading: "You've got mail!",
+
+		// Shared
+		markSharedIPAsMinor: true
+	},
+
+	prefs: undefined,
+
+	getPref(name: string) {
+		if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
+			return Twinkle.prefs[name];
+		}
+		// Old preferences format, used before twinkleoptions.js was a thing
+		if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
+			return window.TwinkleConfig[name];
+		}
+		if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
+			return window.FriendlyConfig[name];
+		}
+		return Twinkle.defaultConfig[name];
+	},
+
+	/**
+	 * **************** Twinkle.addPortlet() ****************
+	 *
+	 * Adds a portlet menu to one of the navigation areas on the page.
+	 * This is necessarily quite a hack since skins, navigation areas, and
+	 * portlet menu types all work slightly different.
+	 *
+	 * Available navigation areas depend on the skin used.
+	 * Vector:
+	 *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
+	 *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
+	 *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
+	 *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
+	 *  Special layout of p-personal portlet (part of "head") through specialized styles.
+	 * Monobook:
+	 *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	 *  Special layout of p-cactions and p-personal through specialized styles.
+	 * Modern:
+	 *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
+	 *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	 *
+	 * @param {string} navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
+	 * @param {string} id -- id of the portlet menu to create, preferably start with "p-".
+	 * @param {string} text -- name of the portlet menu to create. Visibility depends on the class used.
+	 * @param {string} type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
+	 * @param {Node} nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
+	 *
+	 * @return Node -- the DOM node of the new item (a DIV element) or null
+	 */
+	addPortlet(navigation: string, id: string, text: string, type: string, nextnodeid: string): HTMLElement {
+		// sanity checks, and get required DOM nodes
+		var root = document.getElementById(navigation) || document.querySelector(navigation);
+		if (!root) {
+			return null;
+		}
+
+		var item = document.getElementById(id);
+		if (item) {
+			if (item.parentNode && item.parentNode === root) {
+				return item;
+			}
+			return null;
+		}
+
+		var nextnode;
+		if (nextnodeid) {
+			nextnode = document.getElementById(nextnodeid);
+		}
+
+		// verify/normalize input
+		var skin = mw.config.get('skin');
+		if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
+			type = null; // menu supported only in vector's #left-navigation & #right-navigation
+		}
+		var outerNavClass, innerDivClass;
+		switch (skin) {
+			case 'vector':
+				// XXX: portal doesn't work
+				if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
+					navigation = 'mw-panel';
+				}
+				outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+				innerDivClass = 'vector-menu-content';
+				break;
+			case 'modern':
+				if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
+					navigation = 'mw_portlets';
+				}
+				outerNavClass = 'portlet';
+				break;
+			case 'timeless':
+				outerNavClass = 'mw-portlet';
+				innerDivClass = 'mw-portlet-body';
+				break;
+			default:
+				navigation = 'column-one';
+				outerNavClass = 'portlet';
+				break;
+		}
+
+		// Build the DOM elements.
+		var outerNav = document.createElement('nav');
+		outerNav.setAttribute('aria-labelledby', id + '-label');
+		outerNav.className = outerNavClass + ' emptyPortlet';
+		outerNav.id = id;
+		if (nextnode && nextnode.parentNode === root) {
+			root.insertBefore(outerNav, nextnode);
+		} else {
+			root.appendChild(outerNav);
+		}
+
+		var h3 = document.createElement('h3');
+		h3.id = id + '-label';
+		var ul = document.createElement('ul');
+
+		if (skin === 'vector') {
+			ul.className = 'vector-menu-content-list';
+
+			// add invisible checkbox to keep menu open when clicked
+			// similar to the p-cactions ("More") menu
+			if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
+				var chkbox = document.createElement('input');
+				chkbox.className = 'vector-menu-checkbox';
+				chkbox.setAttribute('type', 'checkbox');
+				chkbox.setAttribute('aria-labelledby', id + '-label');
+				outerNav.appendChild(chkbox);
+
+				// Vector gets its title in a span; all others except
+				// timeless have no title, and it has no span
+				var span = document.createElement('span');
+				span.appendChild(document.createTextNode(text));
+				h3.appendChild(span);
+
+				var a = document.createElement('a');
+				a.href = '#';
+
+				$(a).click(function(e) {
+					e.preventDefault();
+				});
+
+				h3.appendChild(a);
+			}
+		} else {
+			// Basically just Timeless
+			h3.appendChild(document.createTextNode(text));
+		}
+
+		outerNav.appendChild(h3);
+
+		if (innerDivClass) {
+			var innerDiv = document.createElement('div');
+			innerDiv.className = innerDivClass;
+			innerDiv.appendChild(ul);
+			outerNav.appendChild(innerDiv);
+		} else {
+			outerNav.appendChild(ul);
+		}
+
+
+		return outerNav;
+
+	},
+
+	/**
+	 * **************** Twinkle.addPortletLink() ****************
+	 * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
+	 * @param task: Either a URL for the portlet link or a function to execute.
+	 * @param text
+	 * @param id
+	 * @param tooltip
+	 */
+	addPortletLink(task: string | (() => void), text: string, id: string, tooltip: string): HTMLLIElement {
+		if (Twinkle.getPref('portletArea') !== null) {
+			Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
+		}
+		var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
+		$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+		if (typeof task === 'function') {
+			$(link).click(function (ev) {
+				task();
+				ev.preventDefault();
+			});
+		}
+		if ($.collapsibleTabs) {
+			$.collapsibleTabs.handleResize();
+		}
+		return link;
+	},
+
+	disabledModules: null,
+
+	load() {
+		// Don't activate on special pages other than those listed here, so
+		// that others load faster, especially the watchlist.
+		var activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+		if (Morebits.userIsSysop) {
+			activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
+		}
+		if (mw.config.get('wgNamespaceNumber') === -1 &&
+			activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
+			return;
+		}
+
+		// Prevent clickjacking
+		if (window.top !== window.self) {
+			return;
+		}
+
+		// Set custom Api-User-Agent header, for server-side logging purposes
+		Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
+
+		Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
+
+		// Redefine addInitCallback so that any modules being loaded now on are directly
+		// initialised rather than added to initCallbacks array
+		Twinkle.addInitCallback = function(func, name) {
+			if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
+				func();
+			}
+		};
+		// Initialise modules that were saved in initCallbacks array
+		Twinkle.initCallbacks.forEach(function(module) {
+			Twinkle.addInitCallback(module.func, module.name);
+		});
+
+		// Increases text size in Twinkle dialogs, if so configured
+		if (Twinkle.getPref('dialogLargeFont')) {
+			mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
+				'.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
+		}
+
+		// Hide the lingering space if the TW menu is empty
+		if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
+			$('#p-cactions').css('margin-right', 'initial');
+		}
+	},
+
+
+	/**
+	 * Twinkle-specific data shared by multiple modules
+	 * Likely customized per installation
+	 */
+
+	// Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
+	changeTags: 'twinkle',
+	// Available for actions that don't (yet) support tags
+	// currently: FlaggedRevs and PageTriage
+	summaryAd: ' ([[WP:TW|TW]])',
+
+	// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
+	// ensure MOS:ORDER
+	hatnoteRegex: 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)',
+
+	// Used in XFD and PROD
+	makeFindSourcesDiv() {
+		var makeLink = function(href: string, text: string) {
+			return $('<a>').attr({ rel: 'nofollow', class: 'external text',
+				target: '_blank', href: href }).text(text);
+		};
+		var title = encodeURIComponent(Morebits.pageNameNorm);
+		return $('<div>')
+			.addClass('plainlinks')
+			.append(
+				'(',
+				$('<i>').text('Find sources:'), ' ',
+				makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'),
+				' (',
+				makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ',
+				makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ',
+				makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ',
+				makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ',
+				makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ',
+				makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'),
+				')', ' - ',
+				makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ',
+				makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ',
+				makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ',
+				makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'),
+				')'
+			)[0];
+	}
+
+}
+
+
+// Some skin dependent config.
+switch (mw.config.get('skin')) {
+	case 'vector':
+		Twinkle.defaultConfig.portletArea = 'right-navigation';
+		Twinkle.defaultConfig.portletId = 'p-twinkle';
+		Twinkle.defaultConfig.portletName = 'TW';
+		Twinkle.defaultConfig.portletType = 'menu';
+		Twinkle.defaultConfig.portletNext = 'p-search';
+		break;
+	case 'timeless':
+		Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
+		Twinkle.defaultConfig.portletId = 'p-twinkle';
+		Twinkle.defaultConfig.portletName = 'Twinkle';
+		Twinkle.defaultConfig.portletType = null;
+		Twinkle.defaultConfig.portletNext = 'p-userpagetools';
+		break;
+	default:
+		Twinkle.defaultConfig.portletArea = null;
+		Twinkle.defaultConfig.portletId = 'p-cactions';
+		Twinkle.defaultConfig.portletName = null;
+		Twinkle.defaultConfig.portletType = null;
+		Twinkle.defaultConfig.portletNext = null;
+}
+
+
+/**
+ * **************** General initialization code ****************
+ */
+
+var scriptpathbefore = mw.util.wikiScript('index') + '?title=',
+	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
+
+// Retrieve the user's Twinkle preferences
+$.ajax({
+	url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
+	dataType: 'text'
+})
+	.fail(function () {
+		mw.notify('Could not load your Twinkle preferences', {type: 'error'});
+	})
+	.done(function (optionsText) {
+
+		// Quick pass if user has no options
+		if (optionsText === '') {
+			return;
+		}
+
+		// Twinkle options are basically a JSON object with some comments. Strip those:
+		optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
+
+		// First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
+		if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
+			optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
+		}
+
+		try {
+			var options = JSON.parse(optionsText);
+			if (options) {
+				if (options.twinkle || options.friendly) { // Old preferences format
+					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+				} else {
+					Twinkle.prefs = options;
+				}
+				// v2 established after unification of Twinkle/Friendly objects
+				Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
+			}
+		} catch (e) {
+			mw.notify('Could not parse your Twinkle preferences', {type: 'error'});
+		}
+	})
+	.always(function () {
+		$(Twinkle.load);
+	});
+
+window.Twinkle = Twinkle;  // allow global access
+
+// </nowiki>

--- a/types/jquery.d.ts
+++ b/types/jquery.d.ts
@@ -1,0 +1,4 @@
+import JQuery from '@types/jquery';
+
+declare const $ = JQuery;
+declare const jQuery = JQuery;

--- a/types/mediawiki.d.ts
+++ b/types/mediawiki.d.ts
@@ -1,0 +1,206 @@
+/**
+ * Type definitions for mediawiki modules
+ */
+
+type title = string | mw.Title
+type namespaceId = number
+
+declare namespace mw {
+
+
+	class Api {
+		constructor(options?: any)
+		abort(): void
+		get(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		post(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+
+		/**
+		 * @private
+		 */
+		preprocessParameters( parameters: any, useUS: boolean ): void
+
+		// index.js
+		ajax(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		postWithToken(tokenType: string, params: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		getToken( type: string, additionalParams?: any | string ): JQuery.Promise<string>
+		badToken(type: string): void
+		getErrorMessage(data: any): JQuery
+
+		// edit.js
+		postWithEditToken(params: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		getEditToken(): JQuery.Promise<string>
+		create(title: title, params: any, content: string): JQuery.Promise<any>
+		edit(title: title, transform: (data: {
+			timestamp: string,
+			content: string
+		}) => any | string): JQuery.Promise<any>
+		newSection(title: title, header: string, message: string, additionalParams?: any): JQuery.Promise<any>
+
+		// user.js
+		getUserInfo(): JQuery.Promise<{
+			groups: string[],
+			rights: string[]
+		}>
+		assertCurrentUser(query: any): JQuery.Promise<{
+			assert: 'anon' | 'user'
+			assertUser: string
+		}>
+
+		// options.js
+		saveOption(name: string, value: string): JQuery.Promise<any>
+		saveOptions(options: {[optionName: string]: string}): JQuery.Promise<any>
+
+		// watch.js
+		watch(pages: title | title[]): JQuery.Promise<{
+			watch: {title: string, watched: boolean} | {title: string, watched: boolean}[]
+		}>
+		unwatch(pages: title | title[]): JQuery.Promise<{
+			watch: {title: string, watched: boolean} | {title: string, watched: boolean}[]
+		}>
+
+		// parse.js
+		parse(content: string | Title, additionalParams?: any): JQuery.Promise<any>
+
+		// messages.js
+		getMessages(messages: string[], options?: any): JQuery.Promise<any>
+		loadMessages(messages: string[], options?: any): JQuery.Promise<any>
+		loadMessagesIfMissing(messages: string[], options?: any): JQuery.Promise<any>
+
+
+		// TODO
+		// category.js
+		// login.js
+		// rollback.js
+		// upload.js
+
+	}
+
+	class Title {
+		constructor(title: string, namespace?: namespaceId)
+		static newFromText(title: string, namespace?: namespaceId): mw.Title | null
+		static makeTitle(title: string, namespace?: namespaceId): mw.Title | null
+		static newFromUserInput(title: string, namespace?: namespaceId, options?: any): mw.Title
+		static newFromFileName(uncleanName: string): mw.Title
+		static newFromImg(img: HTMLElement | JQuery): mw.Title
+		static isTalkNamespace(namespaceId: namespaceId): boolean
+		static wantSignatureNamespace(namespaceId: namespaceId): boolean
+		static exists(title: title): boolean | null
+		static exist: {
+		    pages: {[title: string]: boolean},
+		    set: (titles: string | string[], state?: boolean) => boolean
+		}
+		static normalizeExtension(extension: string): string
+		static phpCharToUpper(chr: string): string
+
+		getNamespaceId(): namespaceId
+		getNamespacePrefix(): string
+		getName(): string
+		getNameText(): string
+		getExtension(): string | null
+		getDotExtension(): string
+		getMain(): string
+		getMainText(): string
+		getPrefixedDb(): string
+		getPrefixedText(): string
+		getRelativeText(namespace: namespaceId): string
+		getFragment(): string | null
+		getUrl(params: any): string
+		isTalkPage(): boolean
+		getTalkPage(): Title | null
+		getSubjectPage(): Title | null
+		canHaveTalkPage(): boolean
+		exists(): boolean | null
+		toString(): string
+		toText(): string
+	}
+
+	namespace util {
+		const $content: JQuery;
+		function rawurlencode(str: string): string;
+		function escapeIdForAttribute(str: string): string;
+		function escapeIdForLink(str: string): string;
+		function debounce(delay: number, callback: Function): (...args: any[]) => void;
+		function wikiUrlencode(str: string): string;
+		function getUrl(pageName: string, params?: {[param: string]: string}): string;
+		function wikiScript(str: string): string;
+		function addCSS(text: string): any;
+		function getParamValue(param: string, url?: string): string;
+		function hidePortlet(portletId: string): void;
+		function isPortletVisible(portletId: string): boolean;
+		function showPortlet(portletId: string): void;
+		function addPortletLink(portletId: string, href: string, text: string, id?: string,
+			tooltip?: string, accesskey?: string, nextnode?: string): HTMLLIElement;
+		function validateEmail(mailtxt: string): boolean;
+		function isIPv4Address(address: string, allowBlock?: boolean): boolean;
+		function isIPv6Address(address: string, allowBlock?: boolean): boolean;
+		function isIPAddress(address: string, allowBlock?: boolean): boolean;
+		function parseImageUrl(url: string): {
+			name: string;
+			width: number | null;
+			resizeUrl: (w: any) => string;
+		} | null;
+		function escapeRegExp(str: string): string;
+	}
+
+	namespace config {
+
+		// get() and set() are actually on mw.Map() but I guess all that isn't necessary to document
+		// here as we'd never use them
+		function get(configKey: string | string[], fallback?: any): any
+		function set(configKey: string, configValue: any): boolean
+		function exists(configKey: string): boolean
+	}
+
+
+	// Not everything is included
+	namespace loader {
+		/**
+		 * Execute a function after one or more modules are ready.
+		 *
+		 * @param dependencies
+		 * @param {Function} ready Callback to execute when all dependencies are
+		 * ready.
+		 * @param {Function} error Callback to execute if one or more dependencies
+		 * failed.
+		 */
+		function using(dependencies: string[] | string, ready?: Function, error?: Function): JQuery.Promise<any>;
+
+		/**
+		 * Load an external script or one or more modules.
+		 *
+		 * @param {string|Array} modules Either the name of a module, array of modules,
+		 *  or a URL of an external script or style
+		 * @param {string} [type='text/javascript'] MIME type to use if calling with a URL of an
+		 *  external script or style; acceptable values are "text/css" and
+		 *  "text/javascript"; if no type is provided, text/javascript is assumed.
+		 * @throws {Error} If type is invalid
+		 */
+		function load(modules: string | string[], type?: string): () => void;
+		/**
+		 * Get the loading state of the module.
+		 * On of 'registered', 'loaded', 'loading', 'ready', 'error', or 'missing'.
+		 *
+		 * @param module
+		 */
+		function getState(module: string): string | null;
+	}
+
+	/**
+	 * Loads the specified i18n message string.
+	 * Shortcut for `mw.message( key, parameters... ).text()`.
+	 *
+	 * @param messageName i18n message name
+	 */
+	function msg(messageName: string | null): string;
+
+	/**
+	 * Notification
+	 * @param {HTMLElement|HTMLElement[]|jQuery|string} message
+	 * @param {Object} [options] See mw.notification#defaults for the defaults.
+	 * @return {jQuery.Promise}
+	 */
+	function notify(message: string | JQuery | HTMLElement | HTMLElement[],
+		options?: { tag?: string, type?: string, title?: string }): JQuery.Promise<any>;
+
+}
+

--- a/types/morebits.d.ts
+++ b/types/morebits.d.ts
@@ -22,18 +22,18 @@ declare namespace Morebits {
 	class quickForm {
 		constructor(event: ((e: FormSubmitEvent) => void), eventType?: string)
 		render(): HTMLFormElement
-		append(quickFormElement): quickFormElement
+		append(data: quickFormElementData): quickFormElement
 		static getInputData(form: HTMLFormElement): Record<string, string>
 		static getElements(form: HTMLFormElement, fieldName: string): HTMLElement[]
 		static getCheckboxOrRadio(elementArray: HTMLInputElement[], value: string): HTMLInputElement
-		static getElementContainer()
-		static getElementLabelObject()
-		static getElementLabel()
-		static setElementLabel()
-		static overrideElementLabel()
-		static resetElementLabel()
-		static setElementVisibility()
-		static setElementTooltipVisibility()
+		static getElementContainer(element: HTMLElement): HTMLElement
+		static getElementLabelObject(element: HTMLElement): HTMLElement
+		static getElementLabel(element: HTMLElement): string
+		static setElementLabel(element: HTMLElement): boolean
+		static overrideElementLabel(element: HTMLElement, temporaryLabelText: string): boolean
+		static resetElementLabel(element: HTMLElement): boolean | null
+		static setElementVisibility(element: HTMLElement | JQuery | string): void
+		static setElementTooltipVisibility(element: HTMLElement | JQuery | string, visibility?: boolean): void
 		static element: typeof quickFormElement
 	}
 
@@ -235,7 +235,6 @@ declare namespace Morebits {
 		setPageList(pageList: T[]): void
 
 		// Overloaded definition
-		setOption(optionName: any, optionValue: any)
 		setOption(optionName: 'chunkSize', optionValue: number)
 		setOption(optionName: 'preserveIndividualStatusLines', optionValue: boolean)
 
@@ -279,9 +278,34 @@ declare namespace Morebits {
 declare class quickFormElement {
 	constructor(data: any)
 	static id: number
-	append(data: quickFormElement): quickFormElement
+	append(data: quickFormElementData): quickFormElement
 	render(): HTMLElement
-	compute(data: any): any
+	private compute(data: quickFormElementData): [HTMLElement, HTMLElement]
 	static generateTooltip(node: HTMLElement, data: any): void
+}
+
+interface quickFormElementData {
+	type?: 'input' | 'textarea' | 'submit' | 'checkbox' | 'radio' | 'select' |
+		'option' | 'optgroup' | 'field' | 'dyninput' | 'hidden' | 'header' |
+		'div' | 'button' | 'fragment'
+	name?: string
+	id?: string
+	className?: string
+	style?: string
+	tooltip?: string
+	extra?: any
+	adminonly?: boolean
+	label?: string | HTMLElement
+	value?: string
+	size?: string // for input
+	multiple?: boolean // for select
+	checked?: boolean
+	disabled?: boolean
+	event?: ((event?: Event) => void)
+	list?: quickFormElementData[]
+	subgroup?: quickFormElementData | quickFormElementData[]
+	required?: boolean // for input, textarea
+	readonly?: boolean // for input, textarea
+	maxlength?: number // for input, textarea
 }
 

--- a/types/morebits.d.ts
+++ b/types/morebits.d.ts
@@ -1,0 +1,287 @@
+/**
+ * Type definitions for morebits.js
+ */
+
+interface FormSubmitEvent extends Event {
+	target: HTMLFormElement
+}
+
+declare namespace Morebits {
+
+	function userIsInGroup(group: string): boolean
+	const userIsSysop: boolean
+
+	function sanitizeIPv6(address: string): string | null
+
+	function isPageRedirect(): boolean
+
+	const pageNameNorm: string
+
+	function pageNameRegex(pageName: string): string
+
+	class quickForm {
+		constructor(event: ((e: FormSubmitEvent) => void), eventType?: string)
+		render(): HTMLFormElement
+		append(quickFormElement): quickFormElement
+		static getInputData(form: HTMLFormElement): Record<string, string>
+		static getElements(form: HTMLFormElement, fieldName: string): HTMLElement[]
+		static getCheckboxOrRadio(elementArray: HTMLInputElement[], value: string): HTMLInputElement
+		static getElementContainer()
+		static getElementLabelObject()
+		static getElementLabel()
+		static setElementLabel()
+		static overrideElementLabel()
+		static resetElementLabel()
+		static setElementVisibility()
+		static setElementTooltipVisibility()
+		static element: typeof quickFormElement
+	}
+
+	namespace string {
+		function toUpperCaseFirstChar(str: string): string
+		function toLowerCaseFirstChar(str: string): string
+		function splitWeightedByKeys(str: string, start: string, end: string, skiplist: string | string[]): string[]
+		function formatReasonText(str: string): string
+		function formatReasonForLog(str: string): string
+		function safeReplace(string: string, pattern: string | RegExp, replacement: string): string
+		function isInfinity(expiry: string): boolean
+		function escapeRegExp(text: string): string
+	}
+
+	namespace array {
+		function uniq<T>(arr: T[]): T[]
+		function dups<T>(arr: T[]): T[]
+		function chunk<T>(arr: T[], size: number): T[][]
+	}
+
+	class unbinder {
+		// has some properties too but they're not supposed to be public
+		unbind(prefix: string, postfix: string): void
+		rebind(): string
+	}
+
+	class date extends Date {
+		private _d: Date
+		isValid(): boolean
+		isBefore(date: Morebits.date | Date): boolean
+		isAfter(date: Morebits.date | Date): boolean
+		getDayName(): string
+		getDayNameAbbrev(): string
+		getUTCDayName(): string
+		getUTCDayNameAbbrev(): string
+		getMonthName(): string
+		getMonthNameAbbrev(): string
+		getUTCMonthName(): string
+		getUTCMonthNameAbbrev(): string
+		add(number: number, unit: string): Morebits.date
+		subtract(number: number, unit: string): Morebits.date
+		format(formatstr: string, zone: number | 'utc' | 'system'): string
+		calendar(zone: number | 'utc' | 'system'): string
+		monthHeaderRegex(): RegExp
+		monthHeader(level?: number): string
+	}
+
+	namespace wiki {
+		let numberOfActionsLeft: number
+		let nbrOfCheckpointsLeft: number
+		let actionCompleted: {
+			(): void
+			event: (() => void)
+			timeout: number
+			redirect: string
+			notice: string
+			followRedirect: boolean
+		}
+		function addCheckpoint(): void
+		function removeCheckpoint(): void
+
+		class api {
+			constructor(currentAction: string, query: any, onSuccess?: ((apiobj: api) => any),
+						statusElement?: string, onFailure?: ((apiobj: api) => any))
+			responseXML: XMLDocument
+			setParent(parent: any): void
+			setStatusElement(statusElement: Morebits.status): void
+			post(callerAjaxParameters?: JQuery.AjaxSettings): JQuery.Promise<api>
+			private returnError(callerAjaxParameters: JQuery.AjaxSettings): JQuery.Promise<api>
+			getStatusElement(): Morebits.status
+			getErrorCode(): string
+			getErrorText(): string
+			getXML(): XMLDocument
+			getResponse(): any
+			static setApiUserAgent(ua: string): void
+			static getToken(): JQuery.Promise<string>
+		}
+
+		class page {
+			constructor(pageName: string, currentAction?: string)
+			load(onSuccess: ((pageobj: page) => void)): void
+			save(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			append(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			prepend(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			newSection(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			getPageName(): string
+			getPageText(): string
+			setPageText(pageText: string)
+			setAppendText(appendText: string)
+			setPrependText(prependText: string)
+			setNewSectionText(newSectionText: string)
+			setNewSectionTitle(newSectionTitle: string)
+			setEditSummary(summary: string): void
+			setChangeTags(tags: string | string[]): void
+			setCreateOption(createOption: string): void
+			setMinorEdit(minorEdit: string): void
+			setBotEdit(botEdit: boolean): void
+			setPageSection(pageSection: string): void
+			setMaxConflictRetries(maxConflictRetries: number): void
+			setMaxRetries(maxRetries: number): void
+			setWatchlist(watchlistOption: string): void
+			setWatchlistExpiry(watchlistExpiry: string): void
+			setWatchlistFromPreferences(watchlistOption: string): void
+			setFollowRedirect(followRedirect, followCrossNsRedirect: string): void
+			setLookupNonRedirectCreator(flag: boolean): void
+			setMoveDestination(destination: string): void
+			setMoveTalkPage(flag: boolean): void
+			setMoveSubpages(flag: boolean): void
+			setMoveSuppressRedirect(flag: boolean): void
+			setEditProtection(level: string, expiry: string): void
+			setMoveProtection(level: string, expiry: string): void
+			setCreateProtection(level: string, expiry: string): void
+			setCascadingProtection(flag: boolean): void
+			suppressProtectWarning(): void
+			setOldID(oldID: string): void
+			getCurrentID(): string
+			getRevisionUser(): string
+			getLastEditTime(): string
+			setCallbackParameters(callbackParameters: any)
+			getCallbackParameters(): any
+			getStatusElement(): Morebits.status
+			setFlaggedRevs(level: string, expiry: string)
+			exists(): boolean
+			getPageID(): string
+			getLoadTime(): string
+			getCreator(): string
+			getCreationTimestamp(): string
+			canEdit(): boolean
+			lookupCreation(onSuccess: ((pageobj: page) => void)): void
+			revert(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			move(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			patrol(): void
+			triage(): void
+			deletePage(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			undeletePage(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			protect(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			stabilize(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+		}
+
+		class preview {
+			constructor(previewbox: HTMLElement)
+			previewbox: HTMLElement
+			beginRender(wikitext: string, pageTitle: string, sectionTitle: string): void
+			closePreview(): void
+		}
+
+	}
+
+	namespace wikitext {
+		function parseTemplate(text: string, start: number): {name: string, parameters: {[key: string]: string}}
+		class page {
+			text: string
+			removeLink(link_target: string)
+			commentOutImage(image: string, reason: string)
+			addToImageComment(image: string, data: string)
+			removeTemplate(template: string)
+			insertAfterTemplates(tag: string, regex: string | string[], flags: string, preRegex: string | string[])
+			getText(): string
+		}
+	}
+
+	class userspaceLogger {
+		initialText: string
+		headerLevel: number
+		changeTags: string | string[]
+		log(logText: string, summaryText: string): void
+	}
+
+
+	class status {
+		textRaw: string
+		text: DocumentFragment
+		type: 'status' | 'info' | 'warn' | 'error'
+		static init(root: HTMLElement): void
+		static root: HTMLElement
+		onError(handler: ((arg: any) => any)): void // XXX: check handler types
+		link(): void
+		unlink(): void
+		codify(obj: (string | HTMLElement)[])
+		update(status: string, type: 'status' | 'info' | 'warn' | 'error')
+		generate(): void
+		render(): void
+		status(status: string)
+		info(status: string)
+		warn(status: string)
+		error(status: string)
+		static info(text: string, status: string): void
+		static warn(text: string, status: string): void
+		static error(text: string, status: string): void
+		static actionCompleted(text: string): void
+		static printUserText(comments: string, message: string)
+	}
+
+	function htmlNode(type: string, content: string, color?: string): HTMLElement
+	function checkboxShiftClickSupport(jQuerySelector: string | JQuery, jQueryContext: string | JQuery)
+
+	class batchOperation<T> {
+		getStatusElement(): Morebits.status
+		setPageList(pageList: T[]): void
+
+		// Overloaded definition
+		setOption(optionName: any, optionValue: any)
+		setOption(optionName: 'chunkSize', optionValue: number)
+		setOption(optionName: 'preserveIndividualStatusLines', optionValue: boolean)
+
+		run(worker: ((item: T) => any), postFinish: (() => any)): void
+		workerSuccess(arg: any): void
+		workerFailure(arg: any): void
+	}
+
+	class taskManager {
+		taskDependencyMap: Map<Function, Function[]>
+		deferreds: Map<Function, JQuery.Deferred<any>[]>
+		allDeferreds: JQuery.Deferred<any>[]
+		add(func: Function, deps: Function[])
+		execute(): JQuery.Promise<void>
+	}
+
+	class simpleWindow {
+		constructor(width: number, height: number)
+		buttons: Array<any>
+		height: number
+		hasFooterLinks: boolean
+		scriptName: string
+		focus(): Morebits.simpleWindow
+		close(event: Event): Morebits.simpleWindow
+		display(): Morebits.simpleWindow
+		setTitle(title: string): Morebits.simpleWindow
+		setScriptName(name: string): Morebits.simpleWindow
+		setWidth(width: number): Morebits.simpleWindow
+		setHeight(height: number): Morebits.simpleWindow
+		setContent(content: HTMLElement): Morebits.simpleWindow
+		addContent(content: HTMLElement): Morebits.simpleWindow
+		purgeContent(): Morebits.simpleWindow
+		addFooterLink(text: string, wikiPage: string, prep?: boolean): Morebits.simpleWindow
+		setModality(modal: boolean): Morebits.simpleWindow
+		static setButtonsEnabled(enabled: boolean)
+	}
+
+}
+
+// TypeScript's handling of nested classes is pathetic ...
+declare class quickFormElement {
+	constructor(data: any)
+	static id: number
+	append(data: quickFormElement): quickFormElement
+	render(): HTMLElement
+	compute(data: any): any
+	static generateTooltip(node: HTMLElement, data: any): void
+}
+


### PR DESCRIPTION
Set up the use of TypeScript. I suppose there's no dearth of information online on why TypeScript is so much better than untyped JavaScript. This will help us nip a lot of bugs at the source, while also allowing the use of all ES2020+ JS features.

I have converted twinkle.js to twinkle.ts. The compiled output is very similar to what we had before. Will work on Tag and XFD hopefully soon, as they anyway need to be entirely restructured (for #1144). 

I have left morebits.js as is and just created the type definition file for it as `types/morebits.d.ts`. It's probably unnecessary and quite difficult to properly migrate morebits to TS, as most of it is morebits.wiki.page whose implementation is far removed from standard TS idiom.

Type definitions for jQuery come from [@types/jquery module](https://www.npmjs.com/package/@types/jquery). Definitions for mw.* modules are in `types/mediawiki.d.ts`, self-written as I couldn't find them online despite extensive searches. I presume we're amongst the first codebases in the mediawiki universe to start using typescript.

Run `npm i typescript` first, then `npm run build` can be used for compiling TS to JS. Compilation does give some errors, but they don't matter (output is generated anyway). The errors can be avoided by adding some `// @ts-ignore`s. 

Cc @MusikAnimal and @Amorymeltzer 