### PR TITLE
tag: WIP: rewrite for localizability 

### DIFF
--- a/modules/tag-data.js
+++ b/modules/tag-data.js
@@ -38,13 +38,15 @@ var redirectTagList = {
                         name: 'altLangFrom',
                         type: 'input',
                         label: 'From language (two-letter code): ',
-                        tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
+                        tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German',
+                        parameter: 'from'
                     },
                     {
                         name: 'altLangTo',
                         type: 'input',
                         label: 'To language (two-letter code): ',
-                        tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
+                        tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German',
+                        parameter: 'to'
                     },
                     {
                         name: 'altLangInfo',
@@ -105,7 +107,8 @@ var redirectTagList = {
                     name: 'doubleRedirectTarget',
                     type: 'input',
                     label: 'Redirect target name',
-                    tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+                    tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect',
+                    parameter: '1'
                 }
             },
             { tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
@@ -185,10 +188,24 @@ var fileTagList = {
     'License and sourcing problem tags': [
         { tag: 'Better source requested', description: 'source info consists of bare image URL/generic base URL only' },
         { tag: 'Non-free reduce', description: 'non-low-resolution fair use image (or too-long audio clip, etc)' },
-        { tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted' }
+        { tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted',
+            subgroup: {
+                type: 'hidden',
+                name: 'OrphanedNonFreeRevisionsDate',
+                parameter: 'date',
+                value: '{{subst:date}}'
+            }
+        }
     ],
     'Wikimedia Commons-related tags': [
-        { tag: 'Copy to Commons', description: 'free media that should be copied to Commons' },
+        { tag: 'Copy to Commons', description: 'free media that should be copied to Commons',
+            subgroup: {
+                type: 'hidden',
+                name: 'CopyToCommonsHuman',
+                parameter: 'human',
+                value: mw.config.get('wgUserName')
+            }
+        },
         { tag: 'Do not move to Commons', description: 'file not suitable for moving to Commons',
             subgroup: [
                 {
@@ -196,13 +213,15 @@ var fileTagList = {
                     name: 'DoNotMoveToCommons_reason',
                     label: 'Reason: ',
                     tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"',
-                    required: true
+                    required: true,
+                    parameter: 'reason'
                 },
                 {
                     type: 'input',
                     name: 'DoNotMoveToCommons_expiry',
                     label: 'Expiration year: ',
-                    tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
+                    tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).',
+                    parameter: 'expiry'
                 }
             ]
         },
@@ -211,7 +230,8 @@ var fileTagList = {
                 type: 'input',
                 name: 'keeplocalName',
                 label: 'Commons image name if different: ',
-                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:',
+                parameter: '1'
             }
         },
         { tag: 'Now Commons', description: 'file has been copied to Commons',
@@ -219,7 +239,8 @@ var fileTagList = {
                 type: 'input',
                 name: 'nowcommonsName',
                 label: 'Commons image name if different: ',
-                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:',
+                parameter: '1'
             }
         }
     ],
@@ -231,14 +252,14 @@ var fileTagList = {
         { tag: 'Bad JPEG', description: 'JPEG that should be PNG or SVG' },
         { tag: 'Bad SVG', description: 'SVG containing raster grahpics' },
         { tag: 'Bad trace', description: 'auto-traced SVG requiring cleanup' },
-        {
-            tag: 'Cleanup image', description: 'general cleanup',
+        { tag: 'Cleanup image', description: 'general cleanup',
             subgroup: {
                 type: 'input',
                 name: 'cleanupimageReason',
                 label: 'Reason: ',
                 tooltip: 'Enter the reason for cleanup (required)',
-                required: true
+                required: true,
+                parameter: '1'
             }
         },
         { tag: 'ClearType', description: 'image (not screenshot) with ClearType anti-aliasing' },
@@ -253,13 +274,15 @@ var fileTagList = {
                     type: 'input',
                     name: 'renamemediaNewname',
                     label: 'New name: ',
-                    tooltip: 'Enter the new name for the image (optional)'
+                    tooltip: 'Enter the new name for the image (optional)',
+                    parameter: '1'
                 },
                 {
                     type: 'input',
                     name: 'renamemediaReason',
                     label: 'Reason: ',
-                    tooltip: 'Enter the reason for the rename (optional)'
+                    tooltip: 'Enter the reason for the rename (optional)',
+                    parameter: '2'
                 }
             ]
         },
@@ -284,13 +307,21 @@ var fileTagList = {
                     { label: '{{Should be SVG|music}}: musical scales, notes, etc.', value: 'music' },
                     { label: '{{Should be SVG|physical}}: "realistic" images of physical objects, people, etc.', value: 'physical' },
                     { label: '{{Should be SVG|symbol}}: miscellaneous symbols, icons, etc.', value: 'symbol' }
-                ]
+                ],
+                parameter: '1'
             }
         },
         { tag: 'Should be text', description: 'image should be represented as text, tables, or math markup' }
     ],
     'Image quality tags': [
-        { tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax' },
+        { tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax',
+            subgroup: {
+                type: 'hidden',
+                name: 'ImageHoaxDate',
+                parameter: 'date',
+                value: '{{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}'
+            }
+        },
         { tag: 'Image-blownout' },
         { tag: 'Image-out-of-focus' },
         { tag: 'Image-Poor-Quality',
@@ -299,7 +330,8 @@ var fileTagList = {
                 name: 'ImagePoorQualityReason',
                 label: 'Reason: ',
                 tooltip: 'Enter the reason why this image is so bad (required)',
-                required: true
+                required: true,
+                parameter: '1'
             }
         },
         { tag: 'Image-underexposure' },
@@ -309,7 +341,8 @@ var fileTagList = {
                 name: 'lowQualityChemReason',
                 label: 'Reason: ',
                 tooltip: 'Enter the reason why the diagram is disputed (required)',
-                required: true
+                required: true,
+                parameter: '1'
             }
         }
     ],
@@ -325,7 +358,8 @@ fileTagList['Replacement tags'].forEach(function (el) {
         label: 'Replacement file: ',
         tooltip: 'Enter the name of the file which replaces this one (required)',
         name: el.tag.replace(/ /g, '_') + 'File',
-        required: true
+        required: true,
+        parameter: '1'
     };
 });
 window.fileTagList = fileTagList;

--- a/modules/tag-data.js
+++ b/modules/tag-data.js
@@ -1,0 +1,332 @@
+var redirectTagList = {
+    'Grammar, punctuation, and spelling': {
+        'Abbreviation': [
+            { tag: 'R from acronym', description: 'redirect from an acronym (e.g. POTUS) to its expanded form' },
+            { tag: 'R from initialism', description: 'redirect from an initialism (e.g. AGF) to its expanded form' },
+            { tag: 'R from MathSciNet abbreviation', description: 'redirect from MathSciNet publication title abbreviation to the unabbreviated title' },
+            { tag: 'R from NLM abbreviation', description: 'redirect from a NLM publication title abbreviation to the unabbreviated title' }
+        ],
+        'Capitalisation': [
+            { tag: 'R from CamelCase', description: 'redirect from a CamelCase title' },
+            { tag: 'R from other capitalisation', description: 'redirect from a title with another method of capitalisation' },
+            { tag: 'R from miscapitalisation', description: 'redirect from a capitalisation error' }
+        ],
+        'Grammar & punctuation': [
+            { tag: 'R from modification', description: 'redirect from a modification of the target\'s title, such as with words rearranged' },
+            { tag: 'R from plural', description: 'redirect from a plural word to the singular equivalent' },
+            { tag: 'R to plural', description: 'redirect from a singular noun to its plural form' }
+        ],
+        'Parts of speech': [
+            { tag: 'R from verb', description: 'redirect from an English-language verb or verb phrase' },
+            { tag: 'R from adjective', description: 'redirect from an adjective (word or phrase that describes a noun)' }
+        ],
+        'Spelling': [
+            { tag: 'R from alternative spelling', description: 'redirect from a title with a different spelling' },
+            { tag: 'R from ASCII-only', description: 'redirect from a title in only basic ASCII to the formal title, with differences that are not diacritical marks or ligatures' },
+            { tag: 'R from diacritic', description: 'redirect from a page name that has diacritical marks (accents, umlauts, etc.)' },
+            { tag: 'R to diacritic', description: 'redirect to the article title with diacritical marks (accents, umlauts, etc.)' },
+            { tag: 'R from misspelling', description: 'redirect from a misspelling or typographical error' }
+        ]
+    },
+    'Alternative names': {
+        'General': [
+            {
+                tag: 'R from alternative language',
+                description: 'redirect from or to a title in another language',
+                subgroup: [
+                    {
+                        name: 'altLangFrom',
+                        type: 'input',
+                        label: 'From language (two-letter code): ',
+                        tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
+                    },
+                    {
+                        name: 'altLangTo',
+                        type: 'input',
+                        label: 'To language (two-letter code): ',
+                        tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
+                    },
+                    {
+                        name: 'altLangInfo',
+                        type: 'div',
+                        label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>')
+                    }
+                ]
+            },
+            { tag: 'R from alternative name', description: 'redirect from a title that is another name, a pseudonym, a nickname, or a synonym' },
+            { tag: 'R from ambiguous sort name', description: 'redirect from an ambiguous sort name to a page or list that disambiguates it' },
+            { tag: 'R from former name', description: 'redirect from a former name or working title' },
+            { tag: 'R from historic name', description: 'redirect from a name with a significant historic past as a region, city, etc. no longer known by that name' },
+            { tag: 'R from incomplete name', description: 'R from incomplete name' },
+            { tag: 'R from incorrect name', description: 'redirect from an erroneus name that is unsuitable as a title' },
+            { tag: 'R from less specific name', description: 'redirect from a less specific title to a more specific, less general one' },
+            { tag: 'R from long name', description: 'redirect from a more complete title' },
+            { tag: 'R from more specific name', description: 'redirect from a more specific title to a less specific, more general one' },
+            { tag: 'R from short name', description: 'redirect from a title that is a shortened form of a person\'s full name, a book title, or other more complete title' },
+            { tag: 'R from sort name', description: 'redirect from the target\'s sort name, such as beginning with their surname rather than given name' },
+            { tag: 'R from synonym', description: 'redirect from a semantic synonym of the target page title' }
+        ],
+        'People': [
+            { tag: 'R from birth name', description: 'redirect from a person\'s birth name to a more common name' },
+            { tag: 'R from given name', description: 'redirect from a person\'s given name' },
+            { tag: 'R from name with title', description: 'redirect from a person\'s name preceded or followed by a title to the name with no title or with the title in parentheses' },
+            { tag: 'R from person', description: 'redirect from a person or persons to a related article' },
+            { tag: 'R from personal name', description: 'redirect from an individual\'s personal name to an article titled with their professional or other better known moniker' },
+            { tag: 'R from pseudonym', description: 'redirect from a pseudonym' },
+            { tag: 'R from surname', description: 'redirect from a title that is a surname' }
+        ],
+        'Technical': [
+            { tag: 'R from drug trade name', description: 'redirect from (or to) the trade name of a drug to (or from) the international nonproprietary name (INN)' },
+            { tag: 'R from filename', description: 'redirect from a title that is a filename of the target' },
+            { tag: 'R from molecular formula', description: 'redirect from a molecular/chemical formula to its technical or trivial name' },
+            { tag: 'R from gene symbol', description: 'redirect from a Human Genome Organisation (HUGO) symbol for a gene to an article about the gene' }
+        ],
+        'Organisms': [
+            { tag: 'R to scientific name', description: 'redirect from the common name to the scientific name' },
+            { tag: 'R from scientific name', description: 'redirect from the scientific name to the common name' },
+            { tag: 'R from alternative scientific name', description: 'redirect from an alternative scientific name to the accepted scientific name' },
+            { tag: 'R from scientific abbreviation', description: 'redirect from a scientific abbreviation' },
+            { tag: 'R to monotypic taxon', description: 'redirect from the only lower-ranking member of a monotypic taxon to its monotypic taxon' },
+            { tag: 'R from monotypic taxon', description: 'redirect from a monotypic taxon to its only lower-ranking member' },
+            { tag: 'R taxon with possibilities', description: 'redirect from a title related to a living organism that potentially could be expanded into an article' }
+        ],
+        'Geography': [
+            { tag: 'R from name and country', description: 'redirect from the specific name to the briefer name' },
+            { tag: 'R from more specific geographic name', description: 'redirect from a geographic location that includes extraneous identifiers such as the county or region of a city' }
+        ]
+    },
+    'Navigation aids': {
+        'Navigation': [
+            { tag: 'R to anchor', description: 'redirect from a topic that does not have its own page to an anchored part of a page on the subject' },
+            {
+                tag: 'R avoided double redirect',
+                description: 'redirect from an alternative title for another redirect',
+                subgroup: {
+                    name: 'doubleRedirectTarget',
+                    type: 'input',
+                    label: 'Redirect target name',
+                    tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+                }
+            },
+            { tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
+            { tag: 'R to list entry', description: 'redirect to a list which contains brief descriptions of subjects not notable enough to have separate articles' },
+            { tag: 'R mentioned in hatnote', description: 'redirect from a title that is mentioned in a hatnote at the redirect target' },
+            { tag: 'R to section', description: 'similar to {{R to list entry}}, but when list is organized in sections, such as list of characters in a fictional universe' },
+            { tag: 'R from shortcut', description: 'redirect from a Wikipedia shortcut' },
+            { tag: 'R from template shortcut', description: 'redirect from a shortcut page name in any namespace to a page in template namespace' }
+        ],
+        'Disambiguation': [
+            { tag: 'R from ambiguous term', description: 'redirect from an ambiguous page name to a page that disambiguates it. This template should never appear on a page that has "(disambiguation)" in its title, use R to disambiguation page instead' },
+            { tag: 'R to disambiguation page', description: 'redirect to a disambiguation page' },
+            { tag: 'R from incomplete disambiguation', description: 'redirect from a page name that is too ambiguous to be the title of an article and should redirect to an appropriate disambiguation page' },
+            { tag: 'R from incorrect disambiguation', description: 'redirect from a page name with incorrect disambiguation due to an error or previous editorial misconception' },
+            { tag: 'R from other disambiguation', description: 'redirect from a page name with an alternative disambiguation qualifier' },
+            { tag: 'R from unnecessary disambiguation', description: 'redirect from a page name that has an unneeded disambiguation qualifier' }
+        ],
+        'Merge, duplicate & move': [
+            { tag: 'R from duplicated article', description: 'redirect to a similar article in order to preserve its edit history' },
+            { tag: 'R with history', description: 'redirect from a page containing substantive page history, kept to preserve content and attributions' },
+            { tag: 'R from move', description: 'redirect from a page that has been moved/renamed' },
+            { tag: 'R from merge', description: 'redirect from a merged page in order to preserve its edit history' }
+        ],
+        'Namespace': [
+            { tag: 'R from remote talk page', description: 'redirect from a talk page in any talk namespace to a corresponding page that is more heavily watched' },
+            { tag: 'R to category namespace', description: 'redirect from a page outside the category namespace to a category page' },
+            { tag: 'R to help namespace', description: 'redirect from any page inside or outside of help namespace to a page in that namespace' },
+            { tag: 'R to main namespace', description: 'redirect from a page outside the main-article namespace to an article in mainspace' },
+            { tag: 'R to portal namespace', description: 'redirect from any page inside or outside of portal space to a page in that namespace' },
+            { tag: 'R to project namespace', description: 'redirect from any page inside or outside of project (Wikipedia: or WP:) space to any page in the project namespace' },
+            { tag: 'R to user namespace', description: 'redirect from a page outside the user namespace to a user page (not to a user talk page)' }
+        ]
+    },
+    'Media': {
+        'General': [
+            { tag: 'R from book', description: 'redirect from a book title to a more general, relevant article' },
+            { tag: 'R from album', description: 'redirect from an album to a related topic such as the recording artist or a list of albums' },
+            { tag: 'R from song', description: 'redirect from a song title to a more general, relevant article' },
+            { tag: 'R from television episode', description: 'redirect from a television episode title to a related work or lists of episodes' }
+        ],
+        'Fiction': [
+            { tag: 'R from fictional character', description: 'redirect from a fictional character to a related fictional work or list of characters' },
+            { tag: 'R from fictional element', description: 'redirect from a fictional element (such as an object or concept) to a related fictional work or list of similar elements' },
+            { tag: 'R from fictional location', description: 'redirect from a fictional location or setting to a related fictional work or list of places' }
+        ]
+    },
+    'Miscellaneous': {
+        'Related information': [
+            { tag: 'R to article without mention', description: 'redirect to an article without any mention of the redirected word or phrase' },
+            { tag: 'R to decade', description: 'redirect from a year to the decade article' },
+            { tag: 'R from domain name', description: 'redirect from a domain name to an article about a website' },
+            { tag: 'R from phrase', description: 'redirect from a phrase to a more general relevant article covering the topic' },
+            { tag: 'R from list topic', description: 'redirect from the topic of a list to the equivalent list' },
+            { tag: 'R from member', description: 'redirect from a member of a group to a related topic such as the group or organization' },
+            { tag: 'R to related topic', description: 'redirect to an article about a similar topic' },
+            { tag: 'R from related word', description: 'redirect from a related word' },
+            { tag: 'R from school', description: 'redirect from a school article that had very little information' },
+            { tag: 'R from subtopic', description: 'redirect from a title that is a subtopic of the target article' },
+            { tag: 'R to subtopic', description: 'redirect to a subtopic of the redirect\'s title' },
+            { tag: 'R from Unicode character', description: 'redirect from a single Unicode character to an article or Wikipedia project page that infers meaning for the symbol' },
+            { tag: 'R from Unicode code', description: 'redirect from a Unicode code point to an article about the character it represents' }
+        ],
+        'With possibilities': [
+            { tag: 'R with possibilities', description: 'redirect from a specific title to a more general, less detailed article (something which can and should be expanded)' }
+        ],
+        'ISO codes': [
+            { tag: 'R from ISO 4 abbreviation', description: 'redirect from an ISO 4 publication title abbreviation to the unabbreviated title' },
+            { tag: 'R from ISO 639 code', description: 'redirect from a title that is an ISO 639 language code to an article about the language' }
+        ],
+        'Printworthiness': [
+            { tag: 'R printworthy', description: 'redirect from a title that would be helpful in a printed or CD/DVD version of Wikipedia' },
+            { tag: 'R unprintworthy', description: 'redirect from a title that would NOT be helpful in a printed or CD/DVD version of Wikipedia' }
+        ]
+    }
+};
+var fileTagList = {
+    'License and sourcing problem tags': [
+        { tag: 'Better source requested', description: 'source info consists of bare image URL/generic base URL only' },
+        { tag: 'Non-free reduce', description: 'non-low-resolution fair use image (or too-long audio clip, etc)' },
+        { tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted' }
+    ],
+    'Wikimedia Commons-related tags': [
+        { tag: 'Copy to Commons', description: 'free media that should be copied to Commons' },
+        { tag: 'Do not move to Commons', description: 'file not suitable for moving to Commons',
+            subgroup: [
+                {
+                    type: 'input',
+                    name: 'DoNotMoveToCommons_reason',
+                    label: 'Reason: ',
+                    tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"',
+                    required: true
+                },
+                {
+                    type: 'input',
+                    name: 'DoNotMoveToCommons_expiry',
+                    label: 'Expiration year: ',
+                    tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
+                }
+            ]
+        },
+        { tag: 'Keep local', description: 'request to keep local copy of a Commons file',
+            subgroup: {
+                type: 'input',
+                name: 'keeplocalName',
+                label: 'Commons image name if different: ',
+                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+            }
+        },
+        { tag: 'Now Commons', description: 'file has been copied to Commons',
+            subgroup: {
+                type: 'input',
+                name: 'nowcommonsName',
+                label: 'Commons image name if different: ',
+                tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+            }
+        }
+    ],
+    'Cleanup tags': [
+        { tag: 'Artifacts', description: 'PNG contains residual compression artifacts' },
+        { tag: 'Bad font', description: 'SVG uses fonts not available on the thumbnail server' },
+        { tag: 'Bad format', description: 'PDF/DOC/... file should be converted to a more useful format' },
+        { tag: 'Bad GIF', description: 'GIF that should be PNG, JPEG, or SVG' },
+        { tag: 'Bad JPEG', description: 'JPEG that should be PNG or SVG' },
+        { tag: 'Bad SVG', description: 'SVG containing raster grahpics' },
+        { tag: 'Bad trace', description: 'auto-traced SVG requiring cleanup' },
+        {
+            tag: 'Cleanup image', description: 'general cleanup',
+            subgroup: {
+                type: 'input',
+                name: 'cleanupimageReason',
+                label: 'Reason: ',
+                tooltip: 'Enter the reason for cleanup (required)',
+                required: true
+            }
+        },
+        { tag: 'ClearType', description: 'image (not screenshot) with ClearType anti-aliasing' },
+        { tag: 'Imagewatermark', description: 'image contains visible or invisible watermarking' },
+        { tag: 'NoCoins', description: 'image using coins to indicate scale' },
+        { tag: 'Overcompressed JPEG', description: 'JPEG with high levels of artifacts' },
+        { tag: 'Opaque', description: 'opaque background should be transparent' },
+        { tag: 'Remove border', description: 'unneeded border, white space, etc.' },
+        { tag: 'Rename media', description: 'file should be renamed according to the criteria at [[WP:FMV]]',
+            subgroup: [
+                {
+                    type: 'input',
+                    name: 'renamemediaNewname',
+                    label: 'New name: ',
+                    tooltip: 'Enter the new name for the image (optional)'
+                },
+                {
+                    type: 'input',
+                    name: 'renamemediaReason',
+                    label: 'Reason: ',
+                    tooltip: 'Enter the reason for the rename (optional)'
+                }
+            ]
+        },
+        { tag: 'Should be PNG', description: 'GIF or JPEG should be lossless' },
+        { tag: 'Should be SVG', description: 'PNG, GIF or JPEG should be vector graphics',
+            subgroup: {
+                name: 'svgCategory',
+                type: 'select',
+                list: [
+                    { label: '{{Should be SVG|other}}', value: 'other' },
+                    { label: '{{Should be SVG|alphabet}}: character images, font examples, etc.', value: 'alphabet' },
+                    { label: '{{Should be SVG|chemical}}: chemical diagrams, etc.', value: 'chemical' },
+                    { label: '{{Should be SVG|circuit}}: electronic circuit diagrams, etc.', value: 'circuit' },
+                    { label: '{{Should be SVG|coat of arms}}: coats of arms', value: 'coat of arms' },
+                    { label: '{{Should be SVG|diagram}}: diagrams that do not fit any other subcategory', value: 'diagram' },
+                    { label: '{{Should be SVG|emblem}}: emblems, free/libre logos, insignias, etc.', value: 'emblem' },
+                    { label: '{{Should be SVG|fair use}}: fair-use images, fair-use logos', value: 'fair use' },
+                    { label: '{{Should be SVG|flag}}: flags', value: 'flag' },
+                    { label: '{{Should be SVG|graph}}: visual plots of data', value: 'graph' },
+                    { label: '{{Should be SVG|logo}}: logos', value: 'logo' },
+                    { label: '{{Should be SVG|map}}: maps', value: 'map' },
+                    { label: '{{Should be SVG|music}}: musical scales, notes, etc.', value: 'music' },
+                    { label: '{{Should be SVG|physical}}: "realistic" images of physical objects, people, etc.', value: 'physical' },
+                    { label: '{{Should be SVG|symbol}}: miscellaneous symbols, icons, etc.', value: 'symbol' }
+                ]
+            }
+        },
+        { tag: 'Should be text', description: 'image should be represented as text, tables, or math markup' }
+    ],
+    'Image quality tags': [
+        { tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax' },
+        { tag: 'Image-blownout' },
+        { tag: 'Image-out-of-focus' },
+        { tag: 'Image-Poor-Quality',
+            subgroup: {
+                type: 'input',
+                name: 'ImagePoorQualityReason',
+                label: 'Reason: ',
+                tooltip: 'Enter the reason why this image is so bad (required)',
+                required: true
+            }
+        },
+        { tag: 'Image-underexposure' },
+        { tag: 'Low quality chem', description: 'disputed chemical structures',
+            subgroup: {
+                type: 'input',
+                name: 'lowQualityChemReason',
+                label: 'Reason: ',
+                tooltip: 'Enter the reason why the diagram is disputed (required)',
+                required: true
+            }
+        }
+    ],
+    'Replacement tags': [
+        { tag: 'Obsolete', description: 'improved version available' },
+        { tag: 'PNG version available' },
+        { tag: 'Vector version available' }
+    ]
+};
+fileTagList['Replacement tags'].forEach(function (el) {
+    el.subgroup = {
+        type: 'input',
+        label: 'Replacement file: ',
+        tooltip: 'Enter the name of the file which replaces this one (required)',
+        name: el.tag.replace(/ /g, '_') + 'File',
+        required: true
+    };
+});
+window.fileTagList = fileTagList;
+window.redirectTagList = redirectTagList;

--- a/modules/tag-data.ts
+++ b/modules/tag-data.ts
@@ -1,11 +1,5 @@
 
-type tagData = {
-	tag: string
-	description: string
-	subgroup?: quickFormElementData | quickFormElementData[]
-}
-
-var redirectTagList: Record<string, Record<string, tagData[]>> = {
+var redirectTagList: tagListType = {
 	'Grammar, punctuation, and spelling': {
 		'Abbreviation': [
 			{ tag: 'R from acronym', description: 'redirect from an acronym (e.g. POTUS) to its expanded form' },
@@ -45,18 +39,20 @@ var redirectTagList: Record<string, Record<string, tagData[]>> = {
 						name: 'altLangFrom',
 						type: 'input',
 						label: 'From language (two-letter code): ',
-						tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
+						tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German',
+						parameter: 'from'
 					},
 					{
 						name: 'altLangTo',
 						type: 'input',
 						label: 'To language (two-letter code): ',
-						tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
+						tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German',
+						parameter: 'to'
 					},
 					{
 						name: 'altLangInfo',
 						type: 'div',
-						label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>')
+						label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>') as HTMLElement
 					}
 				]
 			},
@@ -113,7 +109,8 @@ var redirectTagList: Record<string, Record<string, tagData[]>> = {
 					name: 'doubleRedirectTarget',
 					type: 'input',
 					label: 'Redirect target name',
-					tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+					tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect',
+					parameter: '1'
 				}
 			},
 			{ tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
@@ -194,14 +191,30 @@ var redirectTagList: Record<string, Record<string, tagData[]>> = {
 };
 
 
-var fileTagList: Record<string, Partial<tagData>[]> = {
+
+
+var fileTagList: tagListType = {
 	'License and sourcing problem tags': [
 		{ tag: 'Better source requested', description: 'source info consists of bare image URL/generic base URL only' },
 		{ tag: 'Non-free reduce', description: 'non-low-resolution fair use image (or too-long audio clip, etc)' },
-		{ tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted' }
+		{ tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted',
+			subgroup: {
+				type: 'hidden',
+				name: 'OrphanedNonFreeRevisionsDate',
+				parameter: 'date',
+				value: '{{subst:date}}'
+			}
+		}
 	],
 	'Wikimedia Commons-related tags': [
-		{ tag: 'Copy to Commons', description: 'free media that should be copied to Commons' },
+		{ tag: 'Copy to Commons', description: 'free media that should be copied to Commons',
+			subgroup: {
+				type: 'hidden',
+				name: 'CopyToCommonsHuman',
+				parameter: 'human',
+				value: mw.config.get('wgUserName')
+			}
+		},
 		{ tag: 'Do not move to Commons', description: 'file not suitable for moving to Commons',
 			subgroup: [
 				{
@@ -209,13 +222,15 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 					name: 'DoNotMoveToCommons_reason',
 					label: 'Reason: ',
 					tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"',
-					required: true
+					required: true,
+					parameter: 'reason'
 				},
 				{
 					type: 'input',
 					name: 'DoNotMoveToCommons_expiry',
 					label: 'Expiration year: ',
-					tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
+					tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).',
+					parameter: 'expiry'
 				}
 			]
 		},
@@ -224,7 +239,8 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 				type: 'input',
 				name: 'keeplocalName',
 				label: 'Commons image name if different: ',
-				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:',
+				parameter: '1'
 			}
 		},
 		{ tag: 'Now Commons', description: 'file has been copied to Commons',
@@ -232,7 +248,8 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 				type: 'input',
 				name: 'nowcommonsName',
 				label: 'Commons image name if different: ',
-				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:',
+				parameter: '1'
 			}
 		}
 	],
@@ -244,14 +261,14 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 		{ tag: 'Bad JPEG', description: 'JPEG that should be PNG or SVG' },
 		{ tag: 'Bad SVG', description: 'SVG containing raster grahpics' },
 		{ tag: 'Bad trace', description: 'auto-traced SVG requiring cleanup' },
-		{
-			tag: 'Cleanup image', description: 'general cleanup',
+		{ tag: 'Cleanup image', description: 'general cleanup',
 			subgroup: {
 				type: 'input',
 				name: 'cleanupimageReason',
 				label: 'Reason: ',
 				tooltip: 'Enter the reason for cleanup (required)',
-				required: true
+				required: true,
+				parameter: '1'
 			}
 		},
 		{ tag: 'ClearType', description: 'image (not screenshot) with ClearType anti-aliasing' },
@@ -266,13 +283,15 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 					type: 'input',
 					name: 'renamemediaNewname',
 					label: 'New name: ',
-					tooltip: 'Enter the new name for the image (optional)'
+					tooltip: 'Enter the new name for the image (optional)',
+					parameter: '1'
 				},
 				{
 					type: 'input',
 					name: 'renamemediaReason',
 					label: 'Reason: ',
-					tooltip: 'Enter the reason for the rename (optional)'
+					tooltip: 'Enter the reason for the rename (optional)',
+					parameter: '2'
 				}
 			]
 		},
@@ -297,13 +316,21 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 					{ label: '{{Should be SVG|music}}: musical scales, notes, etc.', value: 'music' },
 					{ label: '{{Should be SVG|physical}}: "realistic" images of physical objects, people, etc.', value: 'physical' },
 					{ label: '{{Should be SVG|symbol}}: miscellaneous symbols, icons, etc.', value: 'symbol' }
-				]
+				],
+				parameter: '1'
 			}
 		},
 		{ tag: 'Should be text', description: 'image should be represented as text, tables, or math markup' }
 	],
 	'Image quality tags': [
-		{ tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax' },
+		{ tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax',
+			subgroup: {
+				type: 'hidden',
+				name: 'ImageHoaxDate',
+				parameter: 'date',
+				value: '{{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}'
+			}
+		},
 		{ tag: 'Image-blownout' },
 		{ tag: 'Image-out-of-focus' },
 		{ tag: 'Image-Poor-Quality',
@@ -312,7 +339,8 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 				name: 'ImagePoorQualityReason',
 				label: 'Reason: ',
 				tooltip: 'Enter the reason why this image is so bad (required)',
-				required: true
+				required: true,
+				parameter: '1'
 			}
 		},
 		{ tag: 'Image-underexposure' },
@@ -322,7 +350,8 @@ var fileTagList: Record<string, Partial<tagData>[]> = {
 				name: 'lowQualityChemReason',
 				label: 'Reason: ',
 				tooltip: 'Enter the reason why the diagram is disputed (required)',
-				required: true
+				required: true,
+				parameter: '1'
 			}
 		}
 	],
@@ -339,10 +368,10 @@ fileTagList['Replacement tags'].forEach(function(el) {
 		label: 'Replacement file: ',
 		tooltip: 'Enter the name of the file which replaces this one (required)',
 		name: el.tag.replace(/ /g, '_') + 'File',
-		required: true
+		required: true,
+		parameter: '1'
 	};
 });
-
 
 window.fileTagList = fileTagList;
 window.redirectTagList = redirectTagList;

--- a/modules/tag-data.ts
+++ b/modules/tag-data.ts
@@ -1,0 +1,349 @@
+
+type tagData = {
+	tag: string
+	description: string
+	subgroup?: quickFormElementData | quickFormElementData[]
+}
+
+var redirectTagList: Record<string, Record<string, tagData[]>> = {
+	'Grammar, punctuation, and spelling': {
+		'Abbreviation': [
+			{ tag: 'R from acronym', description: 'redirect from an acronym (e.g. POTUS) to its expanded form' },
+			{ tag: 'R from initialism', description: 'redirect from an initialism (e.g. AGF) to its expanded form' },
+			{ tag: 'R from MathSciNet abbreviation', description: 'redirect from MathSciNet publication title abbreviation to the unabbreviated title' },
+			{ tag: 'R from NLM abbreviation', description: 'redirect from a NLM publication title abbreviation to the unabbreviated title' }
+		],
+		'Capitalisation': [
+			{ tag: 'R from CamelCase', description: 'redirect from a CamelCase title' },
+			{ tag: 'R from other capitalisation', description: 'redirect from a title with another method of capitalisation' },
+			{ tag: 'R from miscapitalisation', description: 'redirect from a capitalisation error' }
+		],
+		'Grammar & punctuation': [
+			{ tag: 'R from modification', description: 'redirect from a modification of the target\'s title, such as with words rearranged' },
+			{ tag: 'R from plural', description: 'redirect from a plural word to the singular equivalent' },
+			{ tag: 'R to plural', description: 'redirect from a singular noun to its plural form' }
+		],
+		'Parts of speech': [
+			{ tag: 'R from verb', description: 'redirect from an English-language verb or verb phrase' },
+			{ tag: 'R from adjective', description: 'redirect from an adjective (word or phrase that describes a noun)' }
+		],
+		'Spelling': [
+			{ tag: 'R from alternative spelling', description: 'redirect from a title with a different spelling' },
+			{ tag: 'R from ASCII-only', description: 'redirect from a title in only basic ASCII to the formal title, with differences that are not diacritical marks or ligatures' },
+			{ tag: 'R from diacritic', description: 'redirect from a page name that has diacritical marks (accents, umlauts, etc.)' },
+			{ tag: 'R to diacritic', description: 'redirect to the article title with diacritical marks (accents, umlauts, etc.)' },
+			{ tag: 'R from misspelling', description: 'redirect from a misspelling or typographical error' }
+		]
+	},
+	'Alternative names': {
+		'General': [
+			{
+				tag: 'R from alternative language',
+				description: 'redirect from or to a title in another language',
+				subgroup: [
+					{
+						name: 'altLangFrom',
+						type: 'input',
+						label: 'From language (two-letter code): ',
+						tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
+					},
+					{
+						name: 'altLangTo',
+						type: 'input',
+						label: 'To language (two-letter code): ',
+						tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
+					},
+					{
+						name: 'altLangInfo',
+						type: 'div',
+						label: $.parseHTML('<p>For a list of language codes, see <a href="/wiki/Wp:Template_messages/Redirect_language_codes">Wikipedia:Template messages/Redirect language codes</a></p>')
+					}
+				]
+			},
+			{ tag: 'R from alternative name', description: 'redirect from a title that is another name, a pseudonym, a nickname, or a synonym' },
+			{ tag: 'R from ambiguous sort name', description: 'redirect from an ambiguous sort name to a page or list that disambiguates it' },
+			{ tag: 'R from former name', description: 'redirect from a former name or working title' },
+			{ tag: 'R from historic name', description: 'redirect from a name with a significant historic past as a region, city, etc. no longer known by that name' },
+			{ tag: 'R from incomplete name', description: 'R from incomplete name' },
+			{ tag: 'R from incorrect name', description: 'redirect from an erroneus name that is unsuitable as a title' },
+			{ tag: 'R from less specific name', description: 'redirect from a less specific title to a more specific, less general one' },
+			{ tag: 'R from long name', description: 'redirect from a more complete title' },
+			{ tag: 'R from more specific name', description: 'redirect from a more specific title to a less specific, more general one' },
+			{ tag: 'R from short name', description: 'redirect from a title that is a shortened form of a person\'s full name, a book title, or other more complete title' },
+			{ tag: 'R from sort name', description: 'redirect from the target\'s sort name, such as beginning with their surname rather than given name' },
+			{ tag: 'R from synonym', description: 'redirect from a semantic synonym of the target page title' }
+		],
+		'People': [
+			{ tag: 'R from birth name', description: 'redirect from a person\'s birth name to a more common name' },
+			{ tag: 'R from given name', description: 'redirect from a person\'s given name' },
+			{ tag: 'R from name with title', description: 'redirect from a person\'s name preceded or followed by a title to the name with no title or with the title in parentheses' },
+			{ tag: 'R from person', description: 'redirect from a person or persons to a related article' },
+			{ tag: 'R from personal name', description: 'redirect from an individual\'s personal name to an article titled with their professional or other better known moniker' },
+			{ tag: 'R from pseudonym', description: 'redirect from a pseudonym' },
+			{ tag: 'R from surname', description: 'redirect from a title that is a surname' }
+		],
+		'Technical': [
+			{ tag: 'R from drug trade name', description: 'redirect from (or to) the trade name of a drug to (or from) the international nonproprietary name (INN)' },
+			{ tag: 'R from filename', description: 'redirect from a title that is a filename of the target' },
+			{ tag: 'R from molecular formula', description: 'redirect from a molecular/chemical formula to its technical or trivial name' },
+
+			{ tag: 'R from gene symbol', description: 'redirect from a Human Genome Organisation (HUGO) symbol for a gene to an article about the gene' }
+		],
+		'Organisms': [
+			{ tag: 'R to scientific name', description: 'redirect from the common name to the scientific name' },
+			{ tag: 'R from scientific name', description: 'redirect from the scientific name to the common name' },
+			{ tag: 'R from alternative scientific name', description: 'redirect from an alternative scientific name to the accepted scientific name' },
+			{ tag: 'R from scientific abbreviation', description: 'redirect from a scientific abbreviation' },
+			{ tag: 'R to monotypic taxon', description: 'redirect from the only lower-ranking member of a monotypic taxon to its monotypic taxon' },
+			{ tag: 'R from monotypic taxon', description: 'redirect from a monotypic taxon to its only lower-ranking member' },
+			{ tag: 'R taxon with possibilities', description: 'redirect from a title related to a living organism that potentially could be expanded into an article' }
+		],
+		'Geography': [
+			{ tag: 'R from name and country', description: 'redirect from the specific name to the briefer name' },
+			{ tag: 'R from more specific geographic name', description: 'redirect from a geographic location that includes extraneous identifiers such as the county or region of a city' }
+		]
+	},
+	'Navigation aids': {
+		'Navigation': [
+			{ tag: 'R to anchor', description: 'redirect from a topic that does not have its own page to an anchored part of a page on the subject' },
+			{
+				tag: 'R avoided double redirect',
+				description: 'redirect from an alternative title for another redirect',
+				subgroup: {
+					name: 'doubleRedirectTarget',
+					type: 'input',
+					label: 'Redirect target name',
+					tooltip: 'Enter the page this redirect would target if the page wasn\'t also a redirect'
+				}
+			},
+			{ tag: 'R from file metadata link', description: 'redirect of a wikilink created from EXIF, XMP, or other information (i.e. the "metadata" section on some image description pages)' },
+			{ tag: 'R to list entry', description: 'redirect to a list which contains brief descriptions of subjects not notable enough to have separate articles' },
+
+			{ tag: 'R mentioned in hatnote', description: 'redirect from a title that is mentioned in a hatnote at the redirect target' },
+			{ tag: 'R to section', description: 'similar to {{R to list entry}}, but when list is organized in sections, such as list of characters in a fictional universe' },
+			{ tag: 'R from shortcut', description: 'redirect from a Wikipedia shortcut' },
+			{ tag: 'R from template shortcut', description: 'redirect from a shortcut page name in any namespace to a page in template namespace' }
+
+		],
+		'Disambiguation': [
+			{ tag: 'R from ambiguous term', description: 'redirect from an ambiguous page name to a page that disambiguates it. This template should never appear on a page that has "(disambiguation)" in its title, use R to disambiguation page instead' },
+			{ tag: 'R to disambiguation page', description: 'redirect to a disambiguation page' },
+			{ tag: 'R from incomplete disambiguation', description: 'redirect from a page name that is too ambiguous to be the title of an article and should redirect to an appropriate disambiguation page' },
+			{ tag: 'R from incorrect disambiguation', description: 'redirect from a page name with incorrect disambiguation due to an error or previous editorial misconception' },
+			{ tag: 'R from other disambiguation', description: 'redirect from a page name with an alternative disambiguation qualifier' },
+			{ tag: 'R from unnecessary disambiguation', description: 'redirect from a page name that has an unneeded disambiguation qualifier' }
+		],
+		'Merge, duplicate & move': [
+			{ tag: 'R from duplicated article', description: 'redirect to a similar article in order to preserve its edit history' },
+			{ tag: 'R with history', description: 'redirect from a page containing substantive page history, kept to preserve content and attributions' },
+			{ tag: 'R from move', description: 'redirect from a page that has been moved/renamed' },
+			{ tag: 'R from merge', description: 'redirect from a merged page in order to preserve its edit history' }
+		],
+		'Namespace': [
+			{ tag: 'R from remote talk page', description: 'redirect from a talk page in any talk namespace to a corresponding page that is more heavily watched' },
+			{ tag: 'R to category namespace', description: 'redirect from a page outside the category namespace to a category page' },
+			{ tag: 'R to help namespace', description: 'redirect from any page inside or outside of help namespace to a page in that namespace' },
+			{ tag: 'R to main namespace', description: 'redirect from a page outside the main-article namespace to an article in mainspace' },
+			{ tag: 'R to portal namespace', description: 'redirect from any page inside or outside of portal space to a page in that namespace' },
+			{ tag: 'R to project namespace', description: 'redirect from any page inside or outside of project (Wikipedia: or WP:) space to any page in the project namespace' },
+			{ tag: 'R to user namespace', description: 'redirect from a page outside the user namespace to a user page (not to a user talk page)' }
+		]
+	},
+	'Media': {
+		'General': [
+			{ tag: 'R from book', description: 'redirect from a book title to a more general, relevant article' },
+			{ tag: 'R from album', description: 'redirect from an album to a related topic such as the recording artist or a list of albums' },
+			{ tag: 'R from song', description: 'redirect from a song title to a more general, relevant article' },
+			{ tag: 'R from television episode', description: 'redirect from a television episode title to a related work or lists of episodes' }
+		],
+		'Fiction': [
+			{ tag: 'R from fictional character', description: 'redirect from a fictional character to a related fictional work or list of characters' },
+			{ tag: 'R from fictional element', description: 'redirect from a fictional element (such as an object or concept) to a related fictional work or list of similar elements' },
+			{ tag: 'R from fictional location', description: 'redirect from a fictional location or setting to a related fictional work or list of places' }
+
+		]
+	},
+	'Miscellaneous': {
+		'Related information': [
+			{ tag: 'R to article without mention', description: 'redirect to an article without any mention of the redirected word or phrase' },
+			{ tag: 'R to decade', description: 'redirect from a year to the decade article' },
+			{ tag: 'R from domain name', description: 'redirect from a domain name to an article about a website' },
+			{ tag: 'R from phrase', description: 'redirect from a phrase to a more general relevant article covering the topic' },
+			{ tag: 'R from list topic', description: 'redirect from the topic of a list to the equivalent list' },
+			{ tag: 'R from member', description: 'redirect from a member of a group to a related topic such as the group or organization' },
+			{ tag: 'R to related topic', description: 'redirect to an article about a similar topic' },
+			{ tag: 'R from related word', description: 'redirect from a related word' },
+			{ tag: 'R from school', description: 'redirect from a school article that had very little information' },
+			{ tag: 'R from subtopic', description: 'redirect from a title that is a subtopic of the target article' },
+			{ tag: 'R to subtopic', description: 'redirect to a subtopic of the redirect\'s title' },
+			{ tag: 'R from Unicode character', description: 'redirect from a single Unicode character to an article or Wikipedia project page that infers meaning for the symbol' },
+			{ tag: 'R from Unicode code', description: 'redirect from a Unicode code point to an article about the character it represents' }
+		],
+		'With possibilities': [
+			{ tag: 'R with possibilities', description: 'redirect from a specific title to a more general, less detailed article (something which can and should be expanded)' }
+		],
+		'ISO codes': [
+			{ tag: 'R from ISO 4 abbreviation', description: 'redirect from an ISO 4 publication title abbreviation to the unabbreviated title' },
+			{ tag: 'R from ISO 639 code', description: 'redirect from a title that is an ISO 639 language code to an article about the language' }
+		],
+		'Printworthiness': [
+			{ tag: 'R printworthy', description: 'redirect from a title that would be helpful in a printed or CD/DVD version of Wikipedia' },
+			{ tag: 'R unprintworthy', description: 'redirect from a title that would NOT be helpful in a printed or CD/DVD version of Wikipedia' }
+		]
+	}
+};
+
+
+var fileTagList: Record<string, Partial<tagData>[]> = {
+	'License and sourcing problem tags': [
+		{ tag: 'Better source requested', description: 'source info consists of bare image URL/generic base URL only' },
+		{ tag: 'Non-free reduce', description: 'non-low-resolution fair use image (or too-long audio clip, etc)' },
+		{ tag: 'Orphaned non-free revisions', description: 'fair use media with old revisions that need to be deleted' }
+	],
+	'Wikimedia Commons-related tags': [
+		{ tag: 'Copy to Commons', description: 'free media that should be copied to Commons' },
+		{ tag: 'Do not move to Commons', description: 'file not suitable for moving to Commons',
+			subgroup: [
+				{
+					type: 'input',
+					name: 'DoNotMoveToCommons_reason',
+					label: 'Reason: ',
+					tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"',
+					required: true
+				},
+				{
+					type: 'input',
+					name: 'DoNotMoveToCommons_expiry',
+					label: 'Expiration year: ',
+					tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
+				}
+			]
+		},
+		{ tag: 'Keep local', description: 'request to keep local copy of a Commons file',
+			subgroup: {
+				type: 'input',
+				name: 'keeplocalName',
+				label: 'Commons image name if different: ',
+				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+			}
+		},
+		{ tag: 'Now Commons', description: 'file has been copied to Commons',
+			subgroup: {
+				type: 'input',
+				name: 'nowcommonsName',
+				label: 'Commons image name if different: ',
+				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
+			}
+		}
+	],
+	'Cleanup tags': [
+		{ tag: 'Artifacts', description: 'PNG contains residual compression artifacts' },
+		{ tag: 'Bad font', description: 'SVG uses fonts not available on the thumbnail server' },
+		{ tag: 'Bad format', description: 'PDF/DOC/... file should be converted to a more useful format' },
+		{ tag: 'Bad GIF', description: 'GIF that should be PNG, JPEG, or SVG' },
+		{ tag: 'Bad JPEG', description: 'JPEG that should be PNG or SVG' },
+		{ tag: 'Bad SVG', description: 'SVG containing raster grahpics' },
+		{ tag: 'Bad trace', description: 'auto-traced SVG requiring cleanup' },
+		{
+			tag: 'Cleanup image', description: 'general cleanup',
+			subgroup: {
+				type: 'input',
+				name: 'cleanupimageReason',
+				label: 'Reason: ',
+				tooltip: 'Enter the reason for cleanup (required)',
+				required: true
+			}
+		},
+		{ tag: 'ClearType', description: 'image (not screenshot) with ClearType anti-aliasing' },
+		{ tag: 'Imagewatermark', description: 'image contains visible or invisible watermarking' },
+		{ tag: 'NoCoins', description: 'image using coins to indicate scale' },
+		{ tag: 'Overcompressed JPEG', description: 'JPEG with high levels of artifacts' },
+		{ tag: 'Opaque', description: 'opaque background should be transparent' },
+		{ tag: 'Remove border', description: 'unneeded border, white space, etc.' },
+		{ tag: 'Rename media', description: 'file should be renamed according to the criteria at [[WP:FMV]]',
+			subgroup: [
+				{
+					type: 'input',
+					name: 'renamemediaNewname',
+					label: 'New name: ',
+					tooltip: 'Enter the new name for the image (optional)'
+				},
+				{
+					type: 'input',
+					name: 'renamemediaReason',
+					label: 'Reason: ',
+					tooltip: 'Enter the reason for the rename (optional)'
+				}
+			]
+		},
+		{ tag: 'Should be PNG', description: 'GIF or JPEG should be lossless' },
+		{ tag: 'Should be SVG', description: 'PNG, GIF or JPEG should be vector graphics',
+			subgroup: {
+				name: 'svgCategory',
+				type: 'select',
+				list: [
+					{ label: '{{Should be SVG|other}}', value: 'other' },
+					{ label: '{{Should be SVG|alphabet}}: character images, font examples, etc.', value: 'alphabet' },
+					{ label: '{{Should be SVG|chemical}}: chemical diagrams, etc.', value: 'chemical' },
+					{ label: '{{Should be SVG|circuit}}: electronic circuit diagrams, etc.', value: 'circuit' },
+					{ label: '{{Should be SVG|coat of arms}}: coats of arms', value: 'coat of arms' },
+					{ label: '{{Should be SVG|diagram}}: diagrams that do not fit any other subcategory', value: 'diagram' },
+					{ label: '{{Should be SVG|emblem}}: emblems, free/libre logos, insignias, etc.', value: 'emblem' },
+					{ label: '{{Should be SVG|fair use}}: fair-use images, fair-use logos', value: 'fair use' },
+					{ label: '{{Should be SVG|flag}}: flags', value: 'flag' },
+					{ label: '{{Should be SVG|graph}}: visual plots of data', value: 'graph' },
+					{ label: '{{Should be SVG|logo}}: logos', value: 'logo' },
+					{ label: '{{Should be SVG|map}}: maps', value: 'map' },
+					{ label: '{{Should be SVG|music}}: musical scales, notes, etc.', value: 'music' },
+					{ label: '{{Should be SVG|physical}}: "realistic" images of physical objects, people, etc.', value: 'physical' },
+					{ label: '{{Should be SVG|symbol}}: miscellaneous symbols, icons, etc.', value: 'symbol' }
+				]
+			}
+		},
+		{ tag: 'Should be text', description: 'image should be represented as text, tables, or math markup' }
+	],
+	'Image quality tags': [
+		{ tag: 'Image hoax', description: 'Image may be manipulated or constitute a hoax' },
+		{ tag: 'Image-blownout' },
+		{ tag: 'Image-out-of-focus' },
+		{ tag: 'Image-Poor-Quality',
+			subgroup: {
+				type: 'input',
+				name: 'ImagePoorQualityReason',
+				label: 'Reason: ',
+				tooltip: 'Enter the reason why this image is so bad (required)',
+				required: true
+			}
+		},
+		{ tag: 'Image-underexposure' },
+		{ tag: 'Low quality chem', description: 'disputed chemical structures',
+			subgroup: {
+				type: 'input',
+				name: 'lowQualityChemReason',
+				label: 'Reason: ',
+				tooltip: 'Enter the reason why the diagram is disputed (required)',
+				required: true
+			}
+		}
+	],
+	'Replacement tags': [
+		{ tag: 'Obsolete', description: 'improved version available' },
+		{ tag: 'PNG version available' },
+		{ tag: 'Vector version available' }
+	]
+};
+
+fileTagList['Replacement tags'].forEach(function(el) {
+	el.subgroup = {
+		type: 'input',
+		label: 'Replacement file: ',
+		tooltip: 'Enter the name of the file which replaces this one (required)',
+		name: el.tag.replace(/ /g, '_') + 'File',
+		required: true
+	};
+});
+
+
+window.fileTagList = fileTagList;
+window.redirectTagList = redirectTagList;
+

--- a/modules/tag.js
+++ b/modules/tag.js
@@ -1,0 +1,368 @@
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (Object.prototype.hasOwnProperty.call(b, p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var TwinkleModule = /** @class */ (function () {
+    function TwinkleModule() {
+    }
+    TwinkleModule.prototype.addMenu = function () {
+        Twinkle.addPortletLink(this.makeWindow, this.portletName, this.portletId, this.portletTooltip);
+    };
+    return TwinkleModule;
+}());
+var Tag = /** @class */ (function (_super) {
+    __extends(Tag, _super);
+    function Tag() {
+        var _this = _super.call(this) || this;
+        _this.makeWindow = function () {
+            var Window = new Morebits.simpleWindow(630, 500);
+            Window.setScriptName('Twinkle');
+            // anyone got a good policy/guideline/info page/instructional page link??
+            Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
+            _this.mode.makeForm(Window);
+            _this.mode.formRender();
+            _this.mode.postRender();
+        };
+        for (var _i = 0, _a = Tag.modeList; _i < _a.length; _i++) {
+            var mode = _a[_i];
+            if (mode.isActive()) {
+                // @ts-ignore
+                _this.mode = new mode();
+                break;
+            }
+        }
+        _this.portletName = 'Tag';
+        _this.portletId = 'friendly-tag';
+        _this.portletTooltip = _this.mode.getMenuTooltip();
+        _this.addMenu();
+        return _this;
+    }
+    return Tag;
+}(TwinkleModule));
+var TagMode = /** @class */ (function () {
+    function TagMode() {
+    }
+    TagMode.isActive = function () {
+        return false;
+    };
+    Object.defineProperty(TagMode.prototype, "canRemove", {
+        get: function () {
+            return false;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    TagMode.prototype.getMenuTooltip = function () {
+        return 'Add maintenance tags to the page';
+    };
+    TagMode.prototype.getWindowTitle = function () {
+        return 'Add maintenance tags';
+    };
+    TagMode.prototype.makeForm = function (Window) {
+        var _this = this;
+        this.Window = Window;
+        this.Window.setTitle(this.getWindowTitle());
+        this.form = new Morebits.quickForm(function () { _this.evaluate(); });
+        this.formAppendQuickFilter();
+        return this.form;
+    };
+    TagMode.prototype.formAppendQuickFilter = function () {
+        this.form.append({
+            type: 'input',
+            label: 'Filter tag list: ',
+            name: 'quickfilter',
+            size: '30px',
+            event: QuickFilter.onInputChange
+        });
+    };
+    TagMode.prototype.formAppendPatrolLink = function () {
+        if (!document.getElementsByClassName('patrollink').length) {
+            return;
+        }
+        this.form.append({
+            type: 'checkbox',
+            list: [{
+                    label: 'Mark the page as patrolled/reviewed',
+                    value: 'patrol',
+                    name: 'patrol',
+                    checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
+                }]
+        });
+    };
+    TagMode.prototype.formAppendSubmitButton = function () {
+        this.form.append({
+            type: 'submit',
+            className: 'tw-tag-submit'
+        });
+    };
+    TagMode.prototype.formRender = function () {
+        this.result = this.form.render();
+        this.Window.setContent(this.result);
+        this.Window.display();
+        QuickFilter.init(this.result);
+    };
+    TagMode.prototype.postRender = function () {
+        Morebits.quickForm.getElements(this.result, 'tags').forEach(generateLinks);
+    };
+    TagMode.prototype.evaluate = function () {
+        this.captureFormData();
+        if (this.validateInput()) {
+            this.action();
+        }
+    };
+    TagMode.prototype.captureFormData = function () {
+        this.params = Morebits.quickForm.getInputData(this.result);
+    };
+    TagMode.prototype.validateInput = function () {
+        // File/redirect: return if no tags selected
+        // Article: return if no tag is selected and no already present tag is deselected
+        if (this.params.tags.length === 0 && (this.name !== 'article' || this.params.tagsToRemove.length === 0)) {
+            alert('You must select at least one tag!');
+            return false;
+        }
+        return true;
+    };
+    // Lousy name. This function is for the actions that take place when the form is submitted,
+    // assuming the validations are all clear.
+    // Should be extended in the child classes, needless to say.
+    TagMode.prototype.action = function () {
+        Morebits.simpleWindow.setButtonsEnabled(false);
+        Morebits.status.init(this.result);
+        Morebits.wiki.actionCompleted.redirect = Morebits.pageNameNorm;
+        Morebits.wiki.actionCompleted.notice = 'Tagging complete, reloading article in a few seconds';
+        if (this.name === 'redirect') {
+            Morebits.wiki.actionCompleted.followRedirect = false;
+        }
+    };
+    return TagMode;
+}());
+/**
+ * Adds a link to each template's description page
+ * @param {Morebits.quickForm.element} checkbox  associated with the template
+ */
+function generateLinks(checkbox) {
+    var link = Morebits.htmlNode('a', '>');
+    link.setAttribute('class', 'tag-template-link');
+    var tagname = checkbox.values;
+    link.setAttribute('href', mw.util.getUrl((tagname.indexOf(':') === -1 ? 'Template:' : '') +
+        (tagname.indexOf('|') === -1 ? tagname : tagname.slice(0, tagname.indexOf('|')))));
+    link.setAttribute('target', '_blank');
+    $(checkbox).parent().append(['\u00A0', link]);
+}
+var QuickFilter = /** @class */ (function () {
+    function QuickFilter() {
+    }
+    QuickFilter.init = function (result) {
+        QuickFilter.$allCheckboxDivs = $(result).find('[name$=tags]').parent();
+        QuickFilter.$allHeaders = $(result).find('h5');
+        result.quickfilter.focus(); // place cursor in the quick filter field as soon as window is opened
+        result.quickfilter.autocomplete = 'off'; // disable browser suggestions
+        result.quickfilter.addEventListener('keypress', function (e) {
+            if (e.keyCode === 13) { // prevent enter key from accidentally submitting the form
+                e.preventDefault();
+                return false;
+            }
+        });
+    };
+    QuickFilter.onInputChange = function () {
+        // flush the DOM of all existing underline spans
+        QuickFilter.$allCheckboxDivs.find('.search-hit').each(function (i, e) {
+            var label_element = e.parentElement;
+            // This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
+            // to <label>Hello world</label>
+            label_element.innerHTML = label_element.textContent;
+        });
+        if (this.value) {
+            QuickFilter.$allCheckboxDivs.hide();
+            QuickFilter.$allHeaders.hide();
+            var searchString = this.value;
+            var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
+            QuickFilter.$allCheckboxDivs.find('label').each(function () {
+                var label_text = this.textContent;
+                var searchHit = searchRegex.exec(label_text);
+                if (searchHit) {
+                    var range = document.createRange();
+                    var textnode = this.childNodes[0];
+                    range.selectNodeContents(textnode);
+                    range.setStart(textnode, searchHit.index);
+                    range.setEnd(textnode, searchHit.index + searchString.length);
+                    var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+                    range.surroundContents(underline_span);
+                    this.parentElement.style.display = 'block'; // show
+                }
+            });
+        }
+        else {
+            QuickFilter.$allCheckboxDivs.show();
+            QuickFilter.$allHeaders.show();
+        }
+    };
+    return QuickFilter;
+}());
+var RedirectMode = /** @class */ (function (_super) {
+    __extends(RedirectMode, _super);
+    function RedirectMode() {
+        var _this = _super !== null && _super.apply(this, arguments) || this;
+        _this.name = 'redirect';
+        return _this;
+    }
+    RedirectMode.isActive = function () {
+        return Morebits.isPageRedirect();
+    };
+    RedirectMode.prototype.getMenuTooltip = function () {
+        return 'Tag redirect';
+    };
+    RedirectMode.prototype.getWindowTitle = function () {
+        return 'Redirect tagging';
+    };
+    RedirectMode.prototype.makeForm = function (Window) {
+        var form = _super.prototype.makeForm.call(this, Window);
+        var i = 1;
+        $.each(RedirectMode.redirectList, function (groupName, group) {
+            form.append({
+                type: 'header',
+                id: 'tagHeader' + i,
+                label: groupName
+            });
+            var subdiv = form.append({
+                type: 'div',
+                id: 'tagSubdiv' + i++
+            });
+            $.each(group, function (subgroupName, subgroup) {
+                subdiv.append({
+                    type: 'div',
+                    label: [Morebits.htmlNode('b', subgroupName)]
+                });
+                subdiv.append({
+                    type: 'checkbox',
+                    name: 'tags',
+                    list: subgroup.map(function (item) {
+                        return {
+                            value: item.tag,
+                            label: '{{' + item.tag + '}}: ' + item.description,
+                            subgroup: item.subgroup
+                        };
+                    })
+                });
+            });
+        });
+        if (Twinkle.getPref('customRedirectTagList').length) {
+            form.append({
+                type: 'header',
+                label: 'Custom tags'
+            });
+            form.append({
+                type: 'checkbox',
+                name: 'tags',
+                list: Twinkle.getPref('customRedirectTagList')
+            });
+        }
+        this.formAppendPatrolLink();
+        this.formAppendSubmitButton();
+        return this.form;
+    };
+    RedirectMode.prototype.captureFormData = function () {
+        _super.prototype.captureFormData.call(this);
+    };
+    RedirectMode.prototype.action = function () {
+        var _this = this;
+        _super.prototype.action.call(this);
+        var wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + this.name);
+        wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
+        wikipedia_page.load(function (pageobj) {
+            var pageText = pageobj.getPageText(), tagRe, tagText = '', summaryText = 'Added', tags = [], i;
+            for (i = 0; i < _this.params.tags.length; i++) {
+                tagRe = new RegExp('(\\{\\{' + _this.params.tags[i] + '(\\||\\}\\}))', 'im');
+                if (!tagRe.exec(pageText)) {
+                    tags.push(_this.params.tags[i]);
+                }
+                else {
+                    Morebits.status.warn('Info', 'Found {{' + _this.params.tags[i] +
+                        '}} on the redirect already...excluding');
+                }
+            }
+            var addTag = function (tagIndex, tagName) {
+                tagText += '\n{{' + tagName;
+                if (tagName === 'R from alternative language') {
+                    if (_this.params.altLangFrom) {
+                        tagText += '|from=' + _this.params.altLangFrom;
+                    }
+                    if (_this.params.altLangTo) {
+                        tagText += '|to=' + _this.params.altLangTo;
+                    }
+                }
+                else if (tagName === 'R avoided double redirect' && _this.params.doubleRedirectTarget) {
+                    tagText += '|1=' + _this.params.doubleRedirectTarget;
+                }
+                tagText += '}}';
+                if (tagIndex > 0) {
+                    if (tagIndex === (tags.length - 1)) {
+                        summaryText += ' and';
+                    }
+                    else if (tagIndex < (tags.length - 1)) {
+                        summaryText += ',';
+                    }
+                }
+                summaryText += ' {{[[:' + (tagName.indexOf(':') !== -1 ? tagName : 'Template:' + tagName + '|' + tagName) + ']]}}';
+            };
+            if (!tags.length) {
+                Morebits.status.warn('Info', 'No tags remaining to apply');
+            }
+            tags.sort();
+            $.each(tags, addTag);
+            // Check for all Rcat shell redirects (from #433)
+            if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
+                // Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
+                var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
+                pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
+            }
+            else {
+                // Fold any pre-existing Rcats into taglist and under Rcatshell
+                var pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
+                var oldPageTags = '';
+                if (pageTags) {
+                    pageTags.forEach(function (pageTag) {
+                        var pageRe = new RegExp(pageTag, 'img');
+                        pageText = pageText.replace(pageRe, '');
+                        pageTag = pageTag.trim();
+                        oldPageTags += '\n' + pageTag;
+                    });
+                }
+                pageText += '\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
+            }
+            summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
+            // avoid truncated summaries
+            if (summaryText.length > 499) {
+                summaryText = summaryText.replace(/\[\[[^|]+\|([^\]]+)\]\]/g, '$1');
+            }
+            pageobj.setPageText(pageText);
+            pageobj.setEditSummary(summaryText);
+            pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+            pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
+            pageobj.setCreateOption('nocreate');
+            pageobj.save();
+            if (_this.params.patrol) {
+                pageobj.triage();
+            }
+        });
+    };
+    RedirectMode.redirectList = redirectTagList;
+    return RedirectMode;
+}(TagMode));
+// Override to change modes available,
+// each mode is a class extending TagMode
+Tag.modeList = [
+    // ArticleMode,
+    RedirectMode,
+];
+Twinkle.addInitCallback(function () { new Tag(); }, 'Tag');
+//# sourceMappingURL=tag.js.map

--- a/modules/tag.ts
+++ b/modules/tag.ts
@@ -1,0 +1,380 @@
+
+class TwinkleModule {
+	moduleName: string
+	portletName: string
+	portletId: string
+	portletTooltip: string
+	makeWindow: string | (() => void)
+	addMenu() {
+		Twinkle.addPortletLink(this.makeWindow, this.portletName, this.portletId,
+			this.portletTooltip)
+	}
+}
+
+class Tag extends TwinkleModule {
+	mode: TagMode
+	static modeList: (typeof TagMode)[]
+
+	constructor() {
+		super();
+		for (let mode of Tag.modeList) {
+			if (mode.isActive()) {
+				// @ts-ignore
+				this.mode = new mode();
+				break;
+			}
+		}
+		this.portletName = 'Tag';
+		this.portletId = 'friendly-tag';
+		this.portletTooltip = this.mode.getMenuTooltip();
+		this.addMenu();
+	}
+	makeWindow = () => {
+		var Window = new Morebits.simpleWindow(630, 500);
+		Window.setScriptName('Twinkle');
+		// anyone got a good policy/guideline/info page/instructional page link??
+		Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
+		this.mode.makeForm(Window);
+		this.mode.formRender();
+		this.mode.postRender();
+	}
+}
+
+abstract class TagMode {
+	abstract name: string
+	Window: Morebits.simpleWindow
+	form: Morebits.quickForm
+	result: HTMLFormElement
+	params: Record<string, any>
+
+	static isActive() { // must be overridden
+		return false;
+	}
+	get canRemove() {
+		return false;
+	}
+	getMenuTooltip() {
+		return 'Add maintenance tags to the page';
+	}
+	getWindowTitle() {
+		return 'Add maintenance tags';
+	}
+	makeForm(Window) {
+		this.Window = Window;
+		this.Window.setTitle(this.getWindowTitle());
+		this.form = new Morebits.quickForm(() => { this.evaluate() });
+		this.formAppendQuickFilter();
+		return this.form;
+	}
+	formAppendQuickFilter() {
+		this.form.append({
+			type: 'input',
+			label: 'Filter tag list: ',
+			name: 'quickfilter',
+			size: '30px',
+			event: QuickFilter.onInputChange
+		});
+	}
+	formAppendPatrolLink() {
+		if (!document.getElementsByClassName('patrollink').length) {
+			return;
+		}
+		this.form.append({
+			type: 'checkbox',
+			list: [{
+				label: 'Mark the page as patrolled/reviewed',
+				value: 'patrol',
+				name: 'patrol',
+				checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
+			}]
+		});
+	}
+	formAppendSubmitButton() {
+		this.form.append({
+			type: 'submit',
+			className: 'tw-tag-submit'
+		});
+	}
+	formRender() {
+		this.result = this.form.render();
+		this.Window.setContent(this.result);
+		this.Window.display();
+		QuickFilter.init(this.result);
+
+	}
+	postRender() {
+		Morebits.quickForm.getElements(this.result, 'tags').forEach(generateLinks);
+	}
+	evaluate() {
+		this.captureFormData();
+		if (this.validateInput()) {
+			this.action();
+		}
+	}
+	captureFormData() {
+		this.params = Morebits.quickForm.getInputData(this.result);
+	}
+	validateInput(): boolean {
+		// File/redirect: return if no tags selected
+		// Article: return if no tag is selected and no already present tag is deselected
+		if (this.params.tags.length === 0 && (this.name !== 'article' || this.params.tagsToRemove.length === 0)) {
+			alert('You must select at least one tag!');
+			return false;
+		}
+		return true;
+	}
+
+	// Lousy name. This function is for the actions that take place when the form is submitted,
+	// assuming the validations are all clear.
+	// Should be extended in the child classes, needless to say.
+	action() {
+		Morebits.simpleWindow.setButtonsEnabled(false);
+		Morebits.status.init(this.result);
+
+		Morebits.wiki.actionCompleted.redirect = Morebits.pageNameNorm;
+		Morebits.wiki.actionCompleted.notice = 'Tagging complete, reloading article in a few seconds';
+		if (this.name === 'redirect') {
+			Morebits.wiki.actionCompleted.followRedirect = false;
+		}
+	}
+}
+
+/**
+ * Adds a link to each template's description page
+ * @param {Morebits.quickForm.element} checkbox  associated with the template
+ */
+function generateLinks(checkbox) {
+	var link = Morebits.htmlNode('a', '>');
+	link.setAttribute('class', 'tag-template-link');
+	var tagname = checkbox.values;
+	link.setAttribute('href', mw.util.getUrl(
+		(tagname.indexOf(':') === -1 ? 'Template:' : '') +
+		(tagname.indexOf('|') === -1 ? tagname : tagname.slice(0, tagname.indexOf('|')))
+	));
+	link.setAttribute('target', '_blank');
+	$(checkbox).parent().append(['\u00A0', link]);
+}
+
+class QuickFilter {
+	static $allCheckboxDivs: JQuery
+	static $allHeaders: JQuery
+
+	static init(result: HTMLFormElement) {
+		QuickFilter.$allCheckboxDivs = $(result).find('[name$=tags]').parent();
+		QuickFilter.$allHeaders = $(result).find('h5');
+		result.quickfilter.focus(); // place cursor in the quick filter field as soon as window is opened
+		result.quickfilter.autocomplete = 'off'; // disable browser suggestions
+		result.quickfilter.addEventListener('keypress', function (e) {
+			if (e.keyCode === 13) { // prevent enter key from accidentally submitting the form
+				e.preventDefault();
+				return false;
+			}
+		});
+	}
+	static onInputChange(this: HTMLInputElement) {
+		// flush the DOM of all existing underline spans
+		QuickFilter.$allCheckboxDivs.find('.search-hit').each(function (i, e) {
+			var label_element = e.parentElement;
+			// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
+			// to <label>Hello world</label>
+			label_element.innerHTML = label_element.textContent;
+		});
+
+		if (this.value) {
+			QuickFilter.$allCheckboxDivs.hide();
+			QuickFilter.$allHeaders.hide();
+			var searchString = this.value;
+			var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
+
+			QuickFilter.$allCheckboxDivs.find('label').each(function () {
+				var label_text = this.textContent;
+				var searchHit = searchRegex.exec(label_text);
+				if (searchHit) {
+					var range = document.createRange();
+					var textnode = this.childNodes[0];
+					range.selectNodeContents(textnode);
+					range.setStart(textnode, searchHit.index);
+					range.setEnd(textnode, searchHit.index + searchString.length);
+					var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+					range.surroundContents(underline_span);
+					this.parentElement.style.display = 'block'; // show
+				}
+			});
+		} else {
+			QuickFilter.$allCheckboxDivs.show();
+			QuickFilter.$allHeaders.show();
+		}
+	}
+}
+
+
+class RedirectMode extends TagMode {
+	name = 'redirect';
+	static isActive() {
+		return Morebits.isPageRedirect();
+	}
+	static redirectList = redirectTagList
+	getMenuTooltip() {
+		return 'Tag redirect';
+	}
+	getWindowTitle() {
+		return 'Redirect tagging';
+	}
+	makeForm(Window) {
+		let form = super.makeForm(Window);
+		var i = 1;
+		$.each(RedirectMode.redirectList, function (groupName, group) {
+			form.append({
+				type: 'header',
+				id: 'tagHeader' + i,
+				label: groupName
+			});
+			var subdiv = form.append({
+				type: 'div',
+				id: 'tagSubdiv' + i++
+			});
+			$.each(group, function (subgroupName: string, subgroup: any[]) {
+				subdiv.append({
+					type: 'div',
+					label: [Morebits.htmlNode('b', subgroupName)]
+				});
+				subdiv.append({
+					type: 'checkbox',
+					name: 'tags',
+					list: subgroup.map(function (item) {
+						return {
+							value: item.tag,
+							label: '{{' + item.tag + '}}: ' + item.description,
+							subgroup: item.subgroup
+						};
+					})
+				});
+			});
+		});
+
+		if (Twinkle.getPref('customRedirectTagList').length) {
+			form.append({
+				type: 'header',
+				label: 'Custom tags'
+			});
+			form.append({
+				type: 'checkbox',
+				name: 'tags',
+				list: Twinkle.getPref('customRedirectTagList')
+			});
+		}
+
+		this.formAppendPatrolLink();
+		this.formAppendSubmitButton();
+		return this.form;
+	}
+
+	public captureFormData() {
+		super.captureFormData();
+	}
+
+	action() {
+		super.action();
+
+		var wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + this.name);
+		wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
+		wikipedia_page.load((pageobj) => {
+			var pageText = pageobj.getPageText(),
+				tagRe, tagText = '', summaryText = 'Added',
+				tags = [], i;
+
+			for (i = 0; i < this.params.tags.length; i++) {
+				tagRe = new RegExp('(\\{\\{' + this.params.tags[i] + '(\\||\\}\\}))', 'im');
+				if (!tagRe.exec(pageText)) {
+					tags.push(this.params.tags[i]);
+				} else {
+					Morebits.status.warn('Info', 'Found {{' + this.params.tags[i] +
+						'}} on the redirect already...excluding');
+				}
+			}
+
+			var addTag = (tagIndex, tagName) => {
+				tagText += '\n{{' + tagName;
+				if (tagName === 'R from alternative language') {
+					if (this.params.altLangFrom) {
+						tagText += '|from=' + this.params.altLangFrom;
+					}
+					if (this.params.altLangTo) {
+						tagText += '|to=' + this.params.altLangTo;
+					}
+				} else if (tagName === 'R avoided double redirect' && this.params.doubleRedirectTarget) {
+					tagText += '|1=' + this.params.doubleRedirectTarget;
+				}
+				tagText += '}}';
+
+				if (tagIndex > 0) {
+					if (tagIndex === (tags.length - 1)) {
+						summaryText += ' and';
+					} else if (tagIndex < (tags.length - 1)) {
+						summaryText += ',';
+					}
+				}
+
+				summaryText += ' {{[[:' + (tagName.indexOf(':') !== -1 ? tagName : 'Template:' + tagName + '|' + tagName) + ']]}}';
+			};
+
+			if (!tags.length) {
+				Morebits.status.warn('Info', 'No tags remaining to apply');
+			}
+
+			tags.sort();
+			$.each(tags, addTag);
+
+			// Check for all Rcat shell redirects (from #433)
+			if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
+				// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
+				var oldTags = pageText.match(/(\s*{{[A-Za-z ]+\|)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
+				pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
+			} else {
+				// Fold any pre-existing Rcats into taglist and under Rcatshell
+				var pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
+				var oldPageTags = '';
+				if (pageTags) {
+					pageTags.forEach(function(pageTag) {
+						var pageRe = new RegExp(pageTag, 'img');
+						pageText = pageText.replace(pageRe, '');
+						pageTag = pageTag.trim();
+						oldPageTags += '\n' + pageTag;
+					});
+				}
+				pageText += '\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
+			}
+
+			summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
+
+			// avoid truncated summaries
+			if (summaryText.length > 499) {
+				summaryText = summaryText.replace(/\[\[[^|]+\|([^\]]+)\]\]/g, '$1');
+			}
+
+			pageobj.setPageText(pageText);
+			pageobj.setEditSummary(summaryText);
+			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
+			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
+			pageobj.setCreateOption('nocreate');
+			pageobj.save();
+
+			if (this.params.patrol) {
+				pageobj.triage();
+			}
+
+		});
+	}
+
+}
+
+
+// Override to change modes available,
+// each mode is a class extending TagMode
+Tag.modeList = [
+	// ArticleMode,
+	RedirectMode,
+	// FileMode
+];
+
+Twinkle.addInitCallback(function() { new Tag(); }, 'Tag');

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,19 @@
 				"strip-json-comments": "^3.1.1"
 			}
 		},
+		"@types/jquery": {
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.4.tgz",
+			"integrity": "sha512-//9CHhaUt/rurMJTxGI+I6DmsNHgYU6d8aSLFfO5dB7+10lwLnaWT0z5GY/yY82Q/M+B+0Qh3TixlJ8vmBeqIw==",
+			"requires": {
+				"@types/sizzle": "*"
+			}
+		},
+		"@types/sizzle": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
+			"integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+		},
 		"acorn": {
 			"version": "7.4.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
@@ -868,6 +881,12 @@
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+			"dev": true
+		},
+		"typescript": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+			"integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
 			"dev": true
 		},
 		"uri-js": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,15 @@
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"patchtest": "node dev/patch-test.js",
-	  	"server": "node dev/server.js",
+		"server": "node dev/server.js",
 		"sync": "perl dev/sync.pl",
-		"deployall": "perl dev/sync.pl --mode=deploy --all"
+		"deployall": "perl dev/sync.pl --mode=deploy --all",
+		"build": "npx tsc -p ./tsconfig.json"
 	},
 	"devDependencies": {
-		"eslint": "^7.13.0",
-		"eslint-plugin-es5": "^1.5.0"
+	  "@types/jquery": "^3.5.4",
+	  "eslint": "^7.13.0",
+	  "eslint-plugin-es5": "^1.5.0",
+	  "typescript": "^4.1.2"
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,73 @@
+{
+  "compilerOptions": {
+	/* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+	/* Basic Options */
+	// "incremental": true,                   /* Enable incremental compilation */
+	"target": "ES5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+	"module": "none",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+	"lib": [
+	  "dom",
+	  "es5",
+	  "es2015.collection" // Only Map and Set from this are supported in IE 11.
+	],                    /* Specify library files to be included in the compilation. */
+	// "allowJs": true,                       /* Allow javascript files to be compiled. */
+	// "checkJs": true,                       /* Report errors in .js files. */
+	// "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+	// "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+	// "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+	// "sourceMap": true,                     /* Generates corresponding '.map' file. */
+	// "outFile": "./",                       /* Concatenate and emit output to single file. */
+	// "outDir": "./",                        /* Redirect output structure to the directory. */
+	// "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+	// "composite": true,                     /* Enable project compilation */
+	// "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+	// "removeComments": true,                /* Do not emit comments to output. */
+	// "noEmit": true,                        /* Do not emit outputs. */
+	// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+	// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+	// "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+	/* Strict Type-Checking Options */
+	//	"strict": true,                       /* Enable all strict type-checking options. */
+	// "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+	// "strictNullChecks": true,              /* Enable strict null checks. */
+	// "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+	// "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+	// "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+	// "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+	// "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+	/* Additional Checks */
+	// "noUnusedLocals": true,                /* Report errors on unused locals. */
+	// "noUnusedParameters": true,            /* Report errors on unused parameters. */
+	// "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+	// "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+	/* Module Resolution Options */
+	 "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+	// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+	// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+	// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+	 "typeRoots": ["./types"],                /* List of folders to include type definitions from. */
+	// "types": [],                           /* Type declaration files to be included in compilation. */
+	// "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+	// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+	// "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+	/* Source Map Options */
+	// "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+	// "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+	// "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+	// "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+	/* Experimental Options */
+	// "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+	// "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+	/* Advanced Options */
+    // "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+	"forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}

--- a/twinkle.js
+++ b/twinkle.js
@@ -454,4 +454,3 @@ $.ajax({
 });
 window.Twinkle = Twinkle; // allow global access
 // </nowiki>
-//# sourceMappingURL=twinkle.js.map

--- a/twinkle.js
+++ b/twinkle.js
@@ -14,516 +14,444 @@
  * every Wikipedian in between. Visit [[WP:TW]] for more information.
  */
 // <nowiki>
-
 /* global Morebits */
-
-(function (window, document, $) { // Wrap with anonymous function
-
 // Check if account is experienced enough to use Twinkle
 if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
-	return;
+    throw new Error('Twinkle: forbidden!');
 }
-
-var Twinkle = {};
-window.Twinkle = Twinkle;  // allow global access
-
-Twinkle.initCallbacks = [];
-/**
- * Adds a callback to execute when Twinkle has loaded.
- * @param {function} func
- * @param {string} [name] - name of module used to check if is disabled.
- * If name is not given, module is loaded unconditionally.
- */
-Twinkle.addInitCallback = function twinkleAddInitCallback(func, name) {
-	Twinkle.initCallbacks.push({ func: func, name: name });
+// TypeScript: var declaration makes Twinkle available in global scope
+var Twinkle = {
+    initCallbacks: [],
+    /**
+     * Adds a callback to execute when Twinkle has loaded.
+     * @param {function} func
+     * @param {string} [name] - name of module used to check if is disabled.
+     * If name is not given, module is loaded unconditionally.
+     */
+    addInitCallback: function (func, name) {
+        Twinkle.initCallbacks.push({ func: func, name: name });
+    },
+    /**
+     * This holds the default set of preferences used by Twinkle.
+     * It is important that all new preferences added here, especially admin-only ones, are also added to
+     * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
+     * For help on the actual preferences, see the comments in twinkleconfig.js.
+     *
+     * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
+     */
+    defaultConfig: {
+        // General
+        userTalkPageMode: 'tab',
+        dialogLargeFont: false,
+        disabledModules: [],
+        disabledSysopModules: [],
+        // Portlet
+        portletArea: null,
+        portletId: null,
+        portletName: null,
+        portletType: null,
+        portletNext: null,
+        // ARV
+        spiWatchReport: 'yes',
+        // Block
+        defaultToPartialBlocks: false,
+        blankTalkpageOnIndefBlock: false,
+        // Fluff (revert and rollback)
+        autoMenuAfterRollback: false,
+        openTalkPage: ['agf', 'norm', 'vand'],
+        openTalkPageOnAutoRevert: false,
+        rollbackInPlace: false,
+        markRevertedPagesAsMinor: ['vand'],
+        watchRevertedPages: ['agf', 'norm', 'vand', 'torev'],
+        watchRevertedExpiry: 'yes',
+        offerReasonOnNormalRevert: true,
+        confirmOnFluff: false,
+        confirmOnMobileFluff: true,
+        showRollbackLinks: ['diff', 'others'],
+        // DI (twinkleimage)
+        notifyUserOnDeli: true,
+        deliWatchPage: 'default',
+        deliWatchUser: 'default',
+        // PROD
+        watchProdPages: 'yes',
+        markProdPagesAsPatrolled: false,
+        prodReasonDefault: '',
+        logProdPages: false,
+        prodLogPageName: 'PROD log',
+        // CSD
+        speedySelectionStyle: 'buttonClick',
+        watchSpeedyPages: ['g3', 'g5', 'g10', 'g11', 'g12'],
+        watchSpeedyExpiry: 'yes',
+        markSpeedyPagesAsPatrolled: false,
+        // these next two should probably be identical by default
+        welcomeUserOnSpeedyDeletionNotification: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        notifyUserOnSpeedyDeletionNomination: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        warnUserOnSpeedyDelete: ['db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2'],
+        promptForSpeedyDeletionSummary: [],
+        deleteTalkPageOnDelete: true,
+        deleteRedirectsOnDelete: true,
+        deleteSysopDefaultToDelete: false,
+        speedyWindowHeight: 500,
+        speedyWindowWidth: 800,
+        logSpeedyNominations: false,
+        speedyLogPageName: 'CSD log',
+        noLogOnSpeedyNomination: ['u1'],
+        // Unlink
+        unlinkNamespaces: ['0', '10', '100', '118'],
+        // Warn
+        defaultWarningGroup: '1',
+        combinedSingletMenus: false,
+        showSharedIPNotice: true,
+        watchWarnings: 'yes',
+        oldSelect: false,
+        customWarningList: [],
+        // XfD
+        logXfdNominations: false,
+        xfdLogPageName: 'XfD log',
+        noLogOnXfdNomination: [],
+        xfdWatchDiscussion: 'default',
+        xfdWatchList: 'no',
+        xfdWatchPage: 'default',
+        xfdWatchUser: 'default',
+        xfdWatchRelated: 'default',
+        markXfdPagesAsPatrolled: true,
+        // Hidden preferences
+        autolevelStaleDays: 3,
+        revertMaxRevisions: 50,
+        batchMax: 5000,
+        batchChunks: 50,
+        // Deprecated options, as a fallback for add-on scripts/modules
+        summaryAd: ' ([[WP:TW|TW]])',
+        deletionSummaryAd: ' ([[WP:TW|TW]])',
+        protectionSummaryAd: ' ([[WP:TW|TW]])',
+        // Formerly defaultConfig.friendly:
+        // Tag
+        groupByDefault: true,
+        watchTaggedPages: 'yes',
+        watchMergeDiscussions: 'yes',
+        markTaggedPagesAsMinor: false,
+        markTaggedPagesAsPatrolled: true,
+        tagArticleSortOrder: 'cat',
+        customTagList: [],
+        customFileTagList: [],
+        customRedirectTagList: [],
+        // Welcome
+        topWelcomes: false,
+        watchWelcomes: 'yes',
+        welcomeHeading: 'Welcome',
+        insertHeadings: true,
+        insertUsername: true,
+        insertSignature: true,
+        quickWelcomeMode: 'norm',
+        quickWelcomeTemplate: 'welcome',
+        customWelcomeList: [],
+        customWelcomeSignature: true,
+        // Talkback
+        markTalkbackAsMinor: true,
+        insertTalkbackSignature: true,
+        talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
+        mailHeading: "You've got mail!",
+        // Shared
+        markSharedIPAsMinor: true
+    },
+    prefs: undefined,
+    getPref: function (name) {
+        if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
+            return Twinkle.prefs[name];
+        }
+        // Old preferences format, used before twinkleoptions.js was a thing
+        if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
+            return window.TwinkleConfig[name];
+        }
+        if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
+            return window.FriendlyConfig[name];
+        }
+        return Twinkle.defaultConfig[name];
+    },
+    /**
+     * **************** Twinkle.addPortlet() ****************
+     *
+     * Adds a portlet menu to one of the navigation areas on the page.
+     * This is necessarily quite a hack since skins, navigation areas, and
+     * portlet menu types all work slightly different.
+     *
+     * Available navigation areas depend on the skin used.
+     * Vector:
+     *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
+     *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
+     *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
+     *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
+     *  Special layout of p-personal portlet (part of "head") through specialized styles.
+     * Monobook:
+     *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+     *  Special layout of p-cactions and p-personal through specialized styles.
+     * Modern:
+     *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
+     *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+     *
+     * @param {string} navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
+     * @param {string} id -- id of the portlet menu to create, preferably start with "p-".
+     * @param {string} text -- name of the portlet menu to create. Visibility depends on the class used.
+     * @param {string} type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
+     * @param {Node} nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
+     *
+     * @return Node -- the DOM node of the new item (a DIV element) or null
+     */
+    addPortlet: function (navigation, id, text, type, nextnodeid) {
+        // sanity checks, and get required DOM nodes
+        var root = document.getElementById(navigation) || document.querySelector(navigation);
+        if (!root) {
+            return null;
+        }
+        var item = document.getElementById(id);
+        if (item) {
+            if (item.parentNode && item.parentNode === root) {
+                return item;
+            }
+            return null;
+        }
+        var nextnode;
+        if (nextnodeid) {
+            nextnode = document.getElementById(nextnodeid);
+        }
+        // verify/normalize input
+        var skin = mw.config.get('skin');
+        if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
+            type = null; // menu supported only in vector's #left-navigation & #right-navigation
+        }
+        var outerNavClass, innerDivClass;
+        switch (skin) {
+            case 'vector':
+                // XXX: portal doesn't work
+                if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
+                    navigation = 'mw-panel';
+                }
+                outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+                innerDivClass = 'vector-menu-content';
+                break;
+            case 'modern':
+                if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
+                    navigation = 'mw_portlets';
+                }
+                outerNavClass = 'portlet';
+                break;
+            case 'timeless':
+                outerNavClass = 'mw-portlet';
+                innerDivClass = 'mw-portlet-body';
+                break;
+            default:
+                navigation = 'column-one';
+                outerNavClass = 'portlet';
+                break;
+        }
+        // Build the DOM elements.
+        var outerNav = document.createElement('nav');
+        outerNav.setAttribute('aria-labelledby', id + '-label');
+        outerNav.className = outerNavClass + ' emptyPortlet';
+        outerNav.id = id;
+        if (nextnode && nextnode.parentNode === root) {
+            root.insertBefore(outerNav, nextnode);
+        }
+        else {
+            root.appendChild(outerNav);
+        }
+        var h3 = document.createElement('h3');
+        h3.id = id + '-label';
+        var ul = document.createElement('ul');
+        if (skin === 'vector') {
+            ul.className = 'vector-menu-content-list';
+            // add invisible checkbox to keep menu open when clicked
+            // similar to the p-cactions ("More") menu
+            if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
+                var chkbox = document.createElement('input');
+                chkbox.className = 'vector-menu-checkbox';
+                chkbox.setAttribute('type', 'checkbox');
+                chkbox.setAttribute('aria-labelledby', id + '-label');
+                outerNav.appendChild(chkbox);
+                // Vector gets its title in a span; all others except
+                // timeless have no title, and it has no span
+                var span = document.createElement('span');
+                span.appendChild(document.createTextNode(text));
+                h3.appendChild(span);
+                var a = document.createElement('a');
+                a.href = '#';
+                $(a).click(function (e) {
+                    e.preventDefault();
+                });
+                h3.appendChild(a);
+            }
+        }
+        else {
+            // Basically just Timeless
+            h3.appendChild(document.createTextNode(text));
+        }
+        outerNav.appendChild(h3);
+        if (innerDivClass) {
+            var innerDiv = document.createElement('div');
+            innerDiv.className = innerDivClass;
+            innerDiv.appendChild(ul);
+            outerNav.appendChild(innerDiv);
+        }
+        else {
+            outerNav.appendChild(ul);
+        }
+        return outerNav;
+    },
+    /**
+     * **************** Twinkle.addPortletLink() ****************
+     * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
+     * @param task: Either a URL for the portlet link or a function to execute.
+     * @param text
+     * @param id
+     * @param tooltip
+     */
+    addPortletLink: function (task, text, id, tooltip) {
+        if (Twinkle.getPref('portletArea') !== null) {
+            Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
+        }
+        var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
+        $('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+        if (typeof task === 'function') {
+            $(link).click(function (ev) {
+                task();
+                ev.preventDefault();
+            });
+        }
+        if ($.collapsibleTabs) {
+            $.collapsibleTabs.handleResize();
+        }
+        return link;
+    },
+    disabledModules: null,
+    load: function () {
+        // Don't activate on special pages other than those listed here, so
+        // that others load faster, especially the watchlist.
+        var activeSpecialPageList = ['Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked']; // wgRelevantUserName defined for non-sysops on Special:Block
+        if (Morebits.userIsSysop) {
+            activeSpecialPageList = activeSpecialPageList.concat(['DeletedContributions', 'Prefixindex']);
+        }
+        if (mw.config.get('wgNamespaceNumber') === -1 &&
+            activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
+            return;
+        }
+        // Prevent clickjacking
+        if (window.top !== window.self) {
+            return;
+        }
+        // Set custom Api-User-Agent header, for server-side logging purposes
+        Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
+        Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
+        // Redefine addInitCallback so that any modules being loaded now on are directly
+        // initialised rather than added to initCallbacks array
+        Twinkle.addInitCallback = function (func, name) {
+            if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
+                func();
+            }
+        };
+        // Initialise modules that were saved in initCallbacks array
+        Twinkle.initCallbacks.forEach(function (module) {
+            Twinkle.addInitCallback(module.func, module.name);
+        });
+        // Increases text size in Twinkle dialogs, if so configured
+        if (Twinkle.getPref('dialogLargeFont')) {
+            mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
+                '.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
+        }
+        // Hide the lingering space if the TW menu is empty
+        if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
+            $('#p-cactions').css('margin-right', 'initial');
+        }
+    },
+    /**
+     * Twinkle-specific data shared by multiple modules
+     * Likely customized per installation
+     */
+    // Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
+    changeTags: 'twinkle',
+    // Available for actions that don't (yet) support tags
+    // currently: FlaggedRevs and PageTriage
+    summaryAd: ' ([[WP:TW|TW]])',
+    // Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
+    // ensure MOS:ORDER
+    hatnoteRegex: 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)',
+    // Used in XFD and PROD
+    makeFindSourcesDiv: function () {
+        var makeLink = function (href, text) {
+            return $('<a>').attr({ rel: 'nofollow', class: 'external text',
+                target: '_blank', href: href }).text(text);
+        };
+        var title = encodeURIComponent(Morebits.pageNameNorm);
+        return $('<div>')
+            .addClass('plainlinks')
+            .append('(', $('<i>').text('Find sources:'), ' ', makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'), ' (', makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ', makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ', makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ', makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ', makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ', makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'), ')', ' - ', makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ', makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ', makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ', makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'), ')')[0];
+    }
 };
-
-Twinkle.defaultConfig = {};
-/**
- * This holds the default set of preferences used by Twinkle.
- * It is important that all new preferences added here, especially admin-only ones, are also added to
- * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
- * For help on the actual preferences, see the comments in twinkleconfig.js.
- *
- * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
- */
-Twinkle.defaultConfig = {
-	// General
-	userTalkPageMode: 'tab',
-	dialogLargeFont: false,
-	disabledModules: [],
-	disabledSysopModules: [],
-
-	// ARV
-	spiWatchReport: 'yes',
-
-	// Block
-	defaultToPartialBlocks: false,
-	blankTalkpageOnIndefBlock: false,
-
-	// Fluff (revert and rollback)
-	autoMenuAfterRollback: false,
-	openTalkPage: [ 'agf', 'norm', 'vand' ],
-	openTalkPageOnAutoRevert: false,
-	rollbackInPlace: false,
-	markRevertedPagesAsMinor: [ 'vand' ],
-	watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
-	watchRevertedExpiry: 'yes',
-	offerReasonOnNormalRevert: true,
-	confirmOnFluff: false,
-	confirmOnMobileFluff: true,
-	showRollbackLinks: [ 'diff', 'others' ],
-
-	// DI (twinkleimage)
-	notifyUserOnDeli: true,
-	deliWatchPage: 'default',
-	deliWatchUser: 'default',
-
-	// PROD
-	watchProdPages: 'yes',
-	markProdPagesAsPatrolled: false,
-	prodReasonDefault: '',
-	logProdPages: false,
-	prodLogPageName: 'PROD log',
-
-	// CSD
-	speedySelectionStyle: 'buttonClick',
-	watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
-	watchSpeedyExpiry: 'yes',
-	markSpeedyPagesAsPatrolled: false,
-
-	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
-	promptForSpeedyDeletionSummary: [],
-	deleteTalkPageOnDelete: true,
-	deleteRedirectsOnDelete: true,
-	deleteSysopDefaultToDelete: false,
-	speedyWindowHeight: 500,
-	speedyWindowWidth: 800,
-	logSpeedyNominations: false,
-	speedyLogPageName: 'CSD log',
-	noLogOnSpeedyNomination: [ 'u1' ],
-
-	// Unlink
-	unlinkNamespaces: [ '0', '10', '100', '118' ],
-
-	// Warn
-	defaultWarningGroup: '1',
-	combinedSingletMenus: false,
-	showSharedIPNotice: true,
-	watchWarnings: 'yes',
-	oldSelect: false,
-	customWarningList: [],
-
-	// XfD
-	logXfdNominations: false,
-	xfdLogPageName: 'XfD log',
-	noLogOnXfdNomination: [],
-	xfdWatchDiscussion: 'default',
-	xfdWatchList: 'no',
-	xfdWatchPage: 'default',
-	xfdWatchUser: 'default',
-	xfdWatchRelated: 'default',
-	markXfdPagesAsPatrolled: true,
-
-	// Hidden preferences
-	autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
-	revertMaxRevisions: 50, // intentionally limited
-	batchMax: 5000,
-	batchChunks: 50,
-
-	// Deprecated options, as a fallback for add-on scripts/modules
-	summaryAd: ' ([[WP:TW|TW]])',
-	deletionSummaryAd: ' ([[WP:TW|TW]])',
-	protectionSummaryAd: ' ([[WP:TW|TW]])',
-
-	// Formerly defaultConfig.friendly:
-	// Tag
-	groupByDefault: true,
-	watchTaggedPages: 'yes',
-	watchMergeDiscussions: 'yes',
-	markTaggedPagesAsMinor: false,
-	markTaggedPagesAsPatrolled: true,
-	tagArticleSortOrder: 'cat',
-	customTagList: [],
-	customFileTagList: [],
-	customRedirectTagList: [],
-
-	// Welcome
-	topWelcomes: false,
-	watchWelcomes: 'yes',
-	welcomeHeading: 'Welcome',
-	insertHeadings: true,
-	insertUsername: true,
-	insertSignature: true,  // sign welcome templates, where appropriate
-	quickWelcomeMode: 'norm',
-	quickWelcomeTemplate: 'welcome',
-	customWelcomeList: [],
-	customWelcomeSignature: true,
-
-	// Talkback
-	markTalkbackAsMinor: true,
-	insertTalkbackSignature: true,  // always sign talkback templates
-	talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
-	mailHeading: "You've got mail!",
-
-	// Shared
-	markSharedIPAsMinor: true
-};
-
-// now some skin dependent config.
+// Some skin dependent config.
 switch (mw.config.get('skin')) {
-	case 'vector':
-		Twinkle.defaultConfig.portletArea = 'right-navigation';
-		Twinkle.defaultConfig.portletId = 'p-twinkle';
-		Twinkle.defaultConfig.portletName = 'TW';
-		Twinkle.defaultConfig.portletType = 'menu';
-		Twinkle.defaultConfig.portletNext = 'p-search';
-		break;
-	case 'timeless':
-		Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
-		Twinkle.defaultConfig.portletId = 'p-twinkle';
-		Twinkle.defaultConfig.portletName = 'Twinkle';
-		Twinkle.defaultConfig.portletType = null;
-		Twinkle.defaultConfig.portletNext = 'p-userpagetools';
-		break;
-	default:
-		Twinkle.defaultConfig.portletArea = null;
-		Twinkle.defaultConfig.portletId = 'p-cactions';
-		Twinkle.defaultConfig.portletName = null;
-		Twinkle.defaultConfig.portletType = null;
-		Twinkle.defaultConfig.portletNext = null;
+    case 'vector':
+        Twinkle.defaultConfig.portletArea = 'right-navigation';
+        Twinkle.defaultConfig.portletId = 'p-twinkle';
+        Twinkle.defaultConfig.portletName = 'TW';
+        Twinkle.defaultConfig.portletType = 'menu';
+        Twinkle.defaultConfig.portletNext = 'p-search';
+        break;
+    case 'timeless':
+        Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
+        Twinkle.defaultConfig.portletId = 'p-twinkle';
+        Twinkle.defaultConfig.portletName = 'Twinkle';
+        Twinkle.defaultConfig.portletType = null;
+        Twinkle.defaultConfig.portletNext = 'p-userpagetools';
+        break;
+    default:
+        Twinkle.defaultConfig.portletArea = null;
+        Twinkle.defaultConfig.portletId = 'p-cactions';
+        Twinkle.defaultConfig.portletName = null;
+        Twinkle.defaultConfig.portletType = null;
+        Twinkle.defaultConfig.portletNext = null;
 }
-
-
-Twinkle.getPref = function twinkleGetPref(name) {
-	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
-		return Twinkle.prefs[name];
-	}
-	// Old preferences format, used before twinkleoptions.js was a thing
-	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
-		return window.TwinkleConfig[name];
-	}
-	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
-		return window.FriendlyConfig[name];
-	}
-	return Twinkle.defaultConfig[name];
-};
-
-
-/**
- * **************** Twinkle.addPortlet() ****************
- *
- * Adds a portlet menu to one of the navigation areas on the page.
- * This is necessarily quite a hack since skins, navigation areas, and
- * portlet menu types all work slightly different.
- *
- * Available navigation areas depend on the skin used.
- * Vector:
- *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
- *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
- *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
- *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
- *  Special layout of p-personal portlet (part of "head") through specialized styles.
- * Monobook:
- *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *  Special layout of p-cactions and p-personal through specialized styles.
- * Modern:
- *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
- *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *
- * @param String navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
- * @param String id -- id of the portlet menu to create, preferably start with "p-".
- * @param String text -- name of the portlet menu to create. Visibility depends on the class used.
- * @param String type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
- * @param Node nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
- *
- * @return Node -- the DOM node of the new item (a DIV element) or null
- */
-Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
-	// sanity checks, and get required DOM nodes
-	var root = document.getElementById(navigation) || document.querySelector(navigation);
-	if (!root) {
-		return null;
-	}
-
-	var item = document.getElementById(id);
-	if (item) {
-		if (item.parentNode && item.parentNode === root) {
-			return item;
-		}
-		return null;
-	}
-
-	var nextnode;
-	if (nextnodeid) {
-		nextnode = document.getElementById(nextnodeid);
-	}
-
-	// verify/normalize input
-	var skin = mw.config.get('skin');
-	if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
-		type = null; // menu supported only in vector's #left-navigation & #right-navigation
-	}
-	var outerNavClass, innerDivClass;
-	switch (skin) {
-		case 'vector':
-			// XXX: portal doesn't work
-			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
-				navigation = 'mw-panel';
-			}
-			outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
-			innerDivClass = 'vector-menu-content';
-			break;
-		case 'modern':
-			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
-				navigation = 'mw_portlets';
-			}
-			outerNavClass = 'portlet';
-			break;
-		case 'timeless':
-			outerNavClass = 'mw-portlet';
-			innerDivClass = 'mw-portlet-body';
-			break;
-		default:
-			navigation = 'column-one';
-			outerNavClass = 'portlet';
-			break;
-	}
-
-	// Build the DOM elements.
-	var outerNav = document.createElement('nav');
-	outerNav.setAttribute('aria-labelledby', id + '-label');
-	outerNav.className = outerNavClass + ' emptyPortlet';
-	outerNav.id = id;
-	if (nextnode && nextnode.parentNode === root) {
-		root.insertBefore(outerNav, nextnode);
-	} else {
-		root.appendChild(outerNav);
-	}
-
-	var h3 = document.createElement('h3');
-	h3.id = id + '-label';
-	var ul = document.createElement('ul');
-
-	if (skin === 'vector') {
-		ul.className = 'vector-menu-content-list';
-
-		// add invisible checkbox to keep menu open when clicked
-		// similar to the p-cactions ("More") menu
-		if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
-			var chkbox = document.createElement('input');
-			chkbox.className = 'vector-menu-checkbox';
-			chkbox.setAttribute('type', 'checkbox');
-			chkbox.setAttribute('aria-labelledby', id + '-label');
-			outerNav.appendChild(chkbox);
-
-			// Vector gets its title in a span; all others except
-			// timeless have no title, and it has no span
-			var span = document.createElement('span');
-			span.appendChild(document.createTextNode(text));
-			h3.appendChild(span);
-
-			var a = document.createElement('a');
-			a.href = '#';
-
-			$(a).click(function(e) {
-				e.preventDefault();
-			});
-
-			h3.appendChild(a);
-		}
-	} else {
-		// Basically just Timeless
-		h3.appendChild(document.createTextNode(text));
-	}
-
-	outerNav.appendChild(h3);
-
-	if (innerDivClass) {
-		var innerDiv = document.createElement('div');
-		innerDiv.className = innerDivClass;
-		innerDiv.appendChild(ul);
-		outerNav.appendChild(innerDiv);
-	} else {
-		outerNav.appendChild(ul);
-	}
-
-
-	return outerNav;
-
-};
-
-
-/**
- * **************** Twinkle.addPortletLink() ****************
- * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
- * @param task: Either a URL for the portlet link or a function to execute.
- */
-Twinkle.addPortletLink = function(task, text, id, tooltip) {
-	if (Twinkle.getPref('portletArea') !== null) {
-		Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
-	}
-	var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
-	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
-	if (typeof task === 'function') {
-		$(link).click(function (ev) {
-			task();
-			ev.preventDefault();
-		});
-	}
-	if ($.collapsibleTabs) {
-		$.collapsibleTabs.handleResize();
-	}
-	return link;
-};
-
-
 /**
  * **************** General initialization code ****************
  */
-
-var scriptpathbefore = mw.util.wikiScript('index') + '?title=',
-	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
-
+var scriptpathbefore = mw.util.wikiScript('index') + '?title=', scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
 // Retrieve the user's Twinkle preferences
 $.ajax({
-	url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
-	dataType: 'text'
+    url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
+    dataType: 'text'
 })
-	.fail(function () {
-		mw.notify('Could not load your Twinkle preferences', {type: 'error'});
-	})
-	.done(function (optionsText) {
-
-		// Quick pass if user has no options
-		if (optionsText === '') {
-			return;
-		}
-
-		// Twinkle options are basically a JSON object with some comments. Strip those:
-		optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
-
-		// First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
-		if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
-			optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
-		}
-
-		try {
-			var options = JSON.parse(optionsText);
-			if (options) {
-				if (options.twinkle || options.friendly) { // Old preferences format
-					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
-				} else {
-					Twinkle.prefs = options;
-				}
-				// v2 established after unification of Twinkle/Friendly objects
-				Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
-			}
-		} catch (e) {
-			mw.notify('Could not parse your Twinkle preferences', {type: 'error'});
-		}
-	})
-	.always(function () {
-		$(Twinkle.load);
-	});
-
-// Developers: you can import custom Twinkle modules here
-// For example, mw.loader.load(scriptpathbefore + "User:UncleDouggie/morebits-test.js" + scriptpathafter);
-
-Twinkle.load = function () {
-	// Don't activate on special pages other than those listed here, so
-	// that others load faster, especially the watchlist.
-	var activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
-	if (Morebits.userIsSysop) {
-		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
-	}
-	if (mw.config.get('wgNamespaceNumber') === -1 &&
-		activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
-		return;
-	}
-
-	// Prevent clickjacking
-	if (window.top !== window.self) {
-		return;
-	}
-
-	// Set custom Api-User-Agent header, for server-side logging purposes
-	Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
-
-	Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
-
-	// Redefine addInitCallback so that any modules being loaded now on are directly
-	// initialised rather than added to initCallbacks array
-	Twinkle.addInitCallback = function(func, name) {
-		if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
-			func();
-		}
-	};
-	// Initialise modules that were saved in initCallbacks array
-	Twinkle.initCallbacks.forEach(function(module) {
-		Twinkle.addInitCallback(module.func, module.name);
-	});
-
-	// Increases text size in Twinkle dialogs, if so configured
-	if (Twinkle.getPref('dialogLargeFont')) {
-		mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
-			'.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
-	}
-
-	// Hide the lingering space if the TW menu is empty
-	if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
-		$('#p-cactions').css('margin-right', 'initial');
-	}
-};
-
-
-/**
- * Twinkle-specific data shared by multiple modules
- * Likely customized per installation
- */
-
-// Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
-Twinkle.changeTags = 'twinkle';
-// Available for actions that don't (yet) support tags
-// currently: FlaggedRevs and PageTriage
-Twinkle.summaryAd = ' ([[WP:TW|TW]])';
-
-// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
-// ensure MOS:ORDER
-Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)';
-
-// Used in XFD and PROD
-Twinkle.makeFindSourcesDiv = function makeSourcesDiv() {
-	var makeLink = function(href, text) {
-		return $('<a>').attr({ rel: 'nofollow', class: 'external text',
-			target: '_blank', href: href }).text(text);
-	};
-	var title = encodeURIComponent(Morebits.pageNameNorm);
-	return $('<div>')
-		.addClass('plainlinks')
-		.append(
-			'(',
-			$('<i>').text('Find sources:'), ' ',
-			makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'),
-			' (',
-			makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ',
-			makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ',
-			makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ',
-			makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ',
-			makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ',
-			makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'),
-			')', ' - ',
-			makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ',
-			makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ',
-			makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ',
-			makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'),
-			')'
-		)[0];
-};
-
-}(window, document, jQuery)); // End wrap with anonymous function
-
+    .fail(function () {
+    mw.notify('Could not load your Twinkle preferences', { type: 'error' });
+})
+    .done(function (optionsText) {
+    // Quick pass if user has no options
+    if (optionsText === '') {
+        return;
+    }
+    // Twinkle options are basically a JSON object with some comments. Strip those:
+    optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
+    // First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
+    if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
+        optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
+    }
+    try {
+        var options = JSON.parse(optionsText);
+        if (options) {
+            if (options.twinkle || options.friendly) { // Old preferences format
+                Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+            }
+            else {
+                Twinkle.prefs = options;
+            }
+            // v2 established after unification of Twinkle/Friendly objects
+            Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
+        }
+    }
+    catch (e) {
+        mw.notify('Could not parse your Twinkle preferences', { type: 'error' });
+    }
+})
+    .always(function () {
+    $(Twinkle.load);
+});
+window.Twinkle = Twinkle; // allow global access
 // </nowiki>
+//# sourceMappingURL=twinkle.js.map

--- a/twinkle.ts
+++ b/twinkle.ts
@@ -1,0 +1,537 @@
+/**
+ * +-------------------------------------------------------------------------+
+ * |                  === WARNING: GLOBAL GADGET FILE ===                    |
+ * |                Changes to this page affect many users.                  |
+ * |           Please discuss changes at [[WT:TW]] before editing.           |
+ * +-------------------------------------------------------------------------+
+ *
+ * Imported from github [https://github.com/azatoth/twinkle].
+ * All changes should be made in the repository, otherwise they will be lost.
+ *
+ * ----------
+ *
+ * This is AzaToth's Twinkle, the popular script sidekick for newbies, admins, and
+ * every Wikipedian in between. Visit [[WP:TW]] for more information.
+ */
+// <nowiki>
+
+/* global Morebits */
+
+// Check if account is experienced enough to use Twinkle
+if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirmed')) {
+	throw new Error('Twinkle: forbidden!');
+}
+
+// TypeScript: var declaration makes Twinkle available in global scope
+var Twinkle = {
+	initCallbacks: [],
+
+	/**
+	 * Adds a callback to execute when Twinkle has loaded.
+	 * @param {function} func
+	 * @param {string} [name] - name of module used to check if is disabled.
+	 * If name is not given, module is loaded unconditionally.
+	 */
+	addInitCallback(func: (() => void), name: string) {
+		Twinkle.initCallbacks.push({ func: func, name: name });
+	},
+
+	/**
+	 * This holds the default set of preferences used by Twinkle.
+	 * It is important that all new preferences added here, especially admin-only ones, are also added to
+	 * |Twinkle.config.sections| in twinkleconfig.js, so they are configurable via the Twinkle preferences panel.
+	 * For help on the actual preferences, see the comments in twinkleconfig.js.
+	 *
+	 * Formerly Twinkle.defaultConfig.twinkle and Twinkle.defaultConfig.friendly
+	 */
+	defaultConfig:  {
+		// General
+		userTalkPageMode: 'tab',
+		dialogLargeFont: false,
+		disabledModules: [],
+		disabledSysopModules: [],
+
+		// Portlet
+		portletArea: null,
+		portletId: null,
+		portletName: null,
+		portletType: null,
+		portletNext: null,
+
+		// ARV
+		spiWatchReport: 'yes',
+
+		// Block
+		defaultToPartialBlocks: false,
+		blankTalkpageOnIndefBlock: false,
+
+		// Fluff (revert and rollback)
+		autoMenuAfterRollback: false,
+		openTalkPage: [ 'agf', 'norm', 'vand' ],
+		openTalkPageOnAutoRevert: false,
+		rollbackInPlace: false,
+		markRevertedPagesAsMinor: [ 'vand' ],
+		watchRevertedPages: [ 'agf', 'norm', 'vand', 'torev' ],
+		watchRevertedExpiry: 'yes',
+		offerReasonOnNormalRevert: true,
+		confirmOnFluff: false,
+		confirmOnMobileFluff: true,
+		showRollbackLinks: [ 'diff', 'others' ],
+
+		// DI (twinkleimage)
+		notifyUserOnDeli: true,
+		deliWatchPage: 'default',
+		deliWatchUser: 'default',
+
+		// PROD
+		watchProdPages: 'yes',
+		markProdPagesAsPatrolled: false,
+		prodReasonDefault: '',
+		logProdPages: false,
+		prodLogPageName: 'PROD log',
+
+		// CSD
+		speedySelectionStyle: 'buttonClick',
+		watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
+		watchSpeedyExpiry: 'yes',
+		markSpeedyPagesAsPatrolled: false,
+
+		// these next two should probably be identical by default
+		welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 't3', 'p1', 'p2' ],
+		promptForSpeedyDeletionSummary: [],
+		deleteTalkPageOnDelete: true,
+		deleteRedirectsOnDelete: true,
+		deleteSysopDefaultToDelete: false,
+		speedyWindowHeight: 500,
+		speedyWindowWidth: 800,
+		logSpeedyNominations: false,
+		speedyLogPageName: 'CSD log',
+		noLogOnSpeedyNomination: [ 'u1' ],
+
+		// Unlink
+		unlinkNamespaces: [ '0', '10', '100', '118' ],
+
+		// Warn
+		defaultWarningGroup: '1',
+		combinedSingletMenus: false,
+		showSharedIPNotice: true,
+		watchWarnings: 'yes',
+		oldSelect: false,
+		customWarningList: [],
+
+		// XfD
+		logXfdNominations: false,
+		xfdLogPageName: 'XfD log',
+		noLogOnXfdNomination: [],
+		xfdWatchDiscussion: 'default',
+		xfdWatchList: 'no',
+		xfdWatchPage: 'default',
+		xfdWatchUser: 'default',
+		xfdWatchRelated: 'default',
+		markXfdPagesAsPatrolled: true,
+
+		// Hidden preferences
+		autolevelStaleDays: 3, // Huggle is 3, CBNG is 2
+		revertMaxRevisions: 50, // intentionally limited
+		batchMax: 5000,
+		batchChunks: 50,
+
+		// Deprecated options, as a fallback for add-on scripts/modules
+		summaryAd: ' ([[WP:TW|TW]])',
+		deletionSummaryAd: ' ([[WP:TW|TW]])',
+		protectionSummaryAd: ' ([[WP:TW|TW]])',
+
+		// Formerly defaultConfig.friendly:
+		// Tag
+		groupByDefault: true,
+		watchTaggedPages: 'yes',
+		watchMergeDiscussions: 'yes',
+		markTaggedPagesAsMinor: false,
+		markTaggedPagesAsPatrolled: true,
+		tagArticleSortOrder: 'cat',
+		customTagList: [],
+		customFileTagList: [],
+		customRedirectTagList: [],
+
+		// Welcome
+		topWelcomes: false,
+		watchWelcomes: 'yes',
+		welcomeHeading: 'Welcome',
+		insertHeadings: true,
+		insertUsername: true,
+		insertSignature: true,  // sign welcome templates, where appropriate
+		quickWelcomeMode: 'norm',
+		quickWelcomeTemplate: 'welcome',
+		customWelcomeList: [],
+		customWelcomeSignature: true,
+
+		// Talkback
+		markTalkbackAsMinor: true,
+		insertTalkbackSignature: true,  // always sign talkback templates
+		talkbackHeading: 'New message from ' + mw.config.get('wgUserName'),
+		mailHeading: "You've got mail!",
+
+		// Shared
+		markSharedIPAsMinor: true
+	},
+
+	prefs: undefined,
+
+	getPref(name: string) {
+		if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
+			return Twinkle.prefs[name];
+		}
+		// Old preferences format, used before twinkleoptions.js was a thing
+		if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
+			return window.TwinkleConfig[name];
+		}
+		if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
+			return window.FriendlyConfig[name];
+		}
+		return Twinkle.defaultConfig[name];
+	},
+
+	/**
+	 * **************** Twinkle.addPortlet() ****************
+	 *
+	 * Adds a portlet menu to one of the navigation areas on the page.
+	 * This is necessarily quite a hack since skins, navigation areas, and
+	 * portlet menu types all work slightly different.
+	 *
+	 * Available navigation areas depend on the skin used.
+	 * Vector:
+	 *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
+	 *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
+	 *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
+	 *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
+	 *  Special layout of p-personal portlet (part of "head") through specialized styles.
+	 * Monobook:
+	 *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	 *  Special layout of p-cactions and p-personal through specialized styles.
+	 * Modern:
+	 *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
+	 *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	 *
+	 * @param {string} navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
+	 * @param {string} id -- id of the portlet menu to create, preferably start with "p-".
+	 * @param {string} text -- name of the portlet menu to create. Visibility depends on the class used.
+	 * @param {string} type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
+	 * @param {Node} nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
+	 *
+	 * @return Node -- the DOM node of the new item (a DIV element) or null
+	 */
+	addPortlet(navigation: string, id: string, text: string, type: string, nextnodeid: string): HTMLElement {
+		// sanity checks, and get required DOM nodes
+		var root = document.getElementById(navigation) || document.querySelector(navigation);
+		if (!root) {
+			return null;
+		}
+
+		var item = document.getElementById(id);
+		if (item) {
+			if (item.parentNode && item.parentNode === root) {
+				return item;
+			}
+			return null;
+		}
+
+		var nextnode;
+		if (nextnodeid) {
+			nextnode = document.getElementById(nextnodeid);
+		}
+
+		// verify/normalize input
+		var skin = mw.config.get('skin');
+		if (skin !== 'vector' || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
+			type = null; // menu supported only in vector's #left-navigation & #right-navigation
+		}
+		var outerNavClass, innerDivClass;
+		switch (skin) {
+			case 'vector':
+				// XXX: portal doesn't work
+				if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
+					navigation = 'mw-panel';
+				}
+				outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+				innerDivClass = 'vector-menu-content';
+				break;
+			case 'modern':
+				if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
+					navigation = 'mw_portlets';
+				}
+				outerNavClass = 'portlet';
+				break;
+			case 'timeless':
+				outerNavClass = 'mw-portlet';
+				innerDivClass = 'mw-portlet-body';
+				break;
+			default:
+				navigation = 'column-one';
+				outerNavClass = 'portlet';
+				break;
+		}
+
+		// Build the DOM elements.
+		var outerNav = document.createElement('nav');
+		outerNav.setAttribute('aria-labelledby', id + '-label');
+		outerNav.className = outerNavClass + ' emptyPortlet';
+		outerNav.id = id;
+		if (nextnode && nextnode.parentNode === root) {
+			root.insertBefore(outerNav, nextnode);
+		} else {
+			root.appendChild(outerNav);
+		}
+
+		var h3 = document.createElement('h3');
+		h3.id = id + '-label';
+		var ul = document.createElement('ul');
+
+		if (skin === 'vector') {
+			ul.className = 'vector-menu-content-list';
+
+			// add invisible checkbox to keep menu open when clicked
+			// similar to the p-cactions ("More") menu
+			if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
+				var chkbox = document.createElement('input');
+				chkbox.className = 'vector-menu-checkbox';
+				chkbox.setAttribute('type', 'checkbox');
+				chkbox.setAttribute('aria-labelledby', id + '-label');
+				outerNav.appendChild(chkbox);
+
+				// Vector gets its title in a span; all others except
+				// timeless have no title, and it has no span
+				var span = document.createElement('span');
+				span.appendChild(document.createTextNode(text));
+				h3.appendChild(span);
+
+				var a = document.createElement('a');
+				a.href = '#';
+
+				$(a).click(function(e) {
+					e.preventDefault();
+				});
+
+				h3.appendChild(a);
+			}
+		} else {
+			// Basically just Timeless
+			h3.appendChild(document.createTextNode(text));
+		}
+
+		outerNav.appendChild(h3);
+
+		if (innerDivClass) {
+			var innerDiv = document.createElement('div');
+			innerDiv.className = innerDivClass;
+			innerDiv.appendChild(ul);
+			outerNav.appendChild(innerDiv);
+		} else {
+			outerNav.appendChild(ul);
+		}
+
+
+		return outerNav;
+
+	},
+
+	/**
+	 * **************** Twinkle.addPortletLink() ****************
+	 * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
+	 * @param task: Either a URL for the portlet link or a function to execute.
+	 * @param text
+	 * @param id
+	 * @param tooltip
+	 */
+	addPortletLink(task: string | (() => void), text: string, id: string, tooltip: string): HTMLLIElement {
+		if (Twinkle.getPref('portletArea') !== null) {
+			Twinkle.addPortlet(Twinkle.getPref('portletArea'), Twinkle.getPref('portletId'), Twinkle.getPref('portletName'), Twinkle.getPref('portletType'), Twinkle.getPref('portletNext'));
+		}
+		var link = mw.util.addPortletLink(Twinkle.getPref('portletId'), typeof task === 'string' ? task : '#', text, id, tooltip);
+		$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+		if (typeof task === 'function') {
+			$(link).click(function (ev) {
+				task();
+				ev.preventDefault();
+			});
+		}
+		if ($.collapsibleTabs) {
+			$.collapsibleTabs.handleResize();
+		}
+		return link;
+	},
+
+	disabledModules: null,
+
+	load() {
+		// Don't activate on special pages other than those listed here, so
+		// that others load faster, especially the watchlist.
+		var activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+		if (Morebits.userIsSysop) {
+			activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
+		}
+		if (mw.config.get('wgNamespaceNumber') === -1 &&
+			activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
+			return;
+		}
+
+		// Prevent clickjacking
+		if (window.top !== window.self) {
+			return;
+		}
+
+		// Set custom Api-User-Agent header, for server-side logging purposes
+		Morebits.wiki.api.setApiUserAgent('Twinkle (' + mw.config.get('wgWikiID') + ')');
+
+		Twinkle.disabledModules = Twinkle.getPref('disabledModules').concat(Twinkle.getPref('disabledSysopModules'));
+
+		// Redefine addInitCallback so that any modules being loaded now on are directly
+		// initialised rather than added to initCallbacks array
+		Twinkle.addInitCallback = function(func, name) {
+			if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
+				func();
+			}
+		};
+		// Initialise modules that were saved in initCallbacks array
+		Twinkle.initCallbacks.forEach(function(module) {
+			Twinkle.addInitCallback(module.func, module.name);
+		});
+
+		// Increases text size in Twinkle dialogs, if so configured
+		if (Twinkle.getPref('dialogLargeFont')) {
+			mw.util.addCSS('.morebits-dialog-content, .morebits-dialog-footerlinks { font-size: 100% !important; } ' +
+				'.morebits-dialog input, .morebits-dialog select, .morebits-dialog-content button { font-size: inherit !important; }');
+		}
+
+		// Hide the lingering space if the TW menu is empty
+		if (mw.config.get('skin') === 'vector' && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
+			$('#p-cactions').css('margin-right', 'initial');
+		}
+	},
+
+
+	/**
+	 * Twinkle-specific data shared by multiple modules
+	 * Likely customized per installation
+	 */
+
+	// Custom change tag(s) to be applied to all Twinkle actions, create at Special:Tags
+	changeTags: 'twinkle',
+	// Available for actions that don't (yet) support tags
+	// currently: FlaggedRevs and PageTriage
+	summaryAd: ' ([[WP:TW|TW]])',
+
+	// Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
+	// ensure MOS:ORDER
+	hatnoteRegex: 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)',
+
+	// Used in XFD and PROD
+	makeFindSourcesDiv() {
+		var makeLink = function(href: string, text: string) {
+			return $('<a>').attr({ rel: 'nofollow', class: 'external text',
+				target: '_blank', href: href }).text(text);
+		};
+		var title = encodeURIComponent(Morebits.pageNameNorm);
+		return $('<div>')
+			.addClass('plainlinks')
+			.append(
+				'(',
+				$('<i>').text('Find sources:'), ' ',
+				makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'),
+				' (',
+				makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ',
+				makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ',
+				makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ',
+				makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ',
+				makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ',
+				makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'),
+				')', ' - ',
+				makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ',
+				makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ',
+				makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ',
+				makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'),
+				')'
+			)[0];
+	}
+
+}
+
+
+// Some skin dependent config.
+switch (mw.config.get('skin')) {
+	case 'vector':
+		Twinkle.defaultConfig.portletArea = 'right-navigation';
+		Twinkle.defaultConfig.portletId = 'p-twinkle';
+		Twinkle.defaultConfig.portletName = 'TW';
+		Twinkle.defaultConfig.portletType = 'menu';
+		Twinkle.defaultConfig.portletNext = 'p-search';
+		break;
+	case 'timeless':
+		Twinkle.defaultConfig.portletArea = '#page-tools .sidebar-inner';
+		Twinkle.defaultConfig.portletId = 'p-twinkle';
+		Twinkle.defaultConfig.portletName = 'Twinkle';
+		Twinkle.defaultConfig.portletType = null;
+		Twinkle.defaultConfig.portletNext = 'p-userpagetools';
+		break;
+	default:
+		Twinkle.defaultConfig.portletArea = null;
+		Twinkle.defaultConfig.portletId = 'p-cactions';
+		Twinkle.defaultConfig.portletName = null;
+		Twinkle.defaultConfig.portletType = null;
+		Twinkle.defaultConfig.portletNext = null;
+}
+
+
+/**
+ * **************** General initialization code ****************
+ */
+
+var scriptpathbefore = mw.util.wikiScript('index') + '?title=',
+	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
+
+// Retrieve the user's Twinkle preferences
+$.ajax({
+	url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
+	dataType: 'text'
+})
+	.fail(function () {
+		mw.notify('Could not load your Twinkle preferences', {type: 'error'});
+	})
+	.done(function (optionsText) {
+
+		// Quick pass if user has no options
+		if (optionsText === '') {
+			return;
+		}
+
+		// Twinkle options are basically a JSON object with some comments. Strip those:
+		optionsText = optionsText.replace(/(?:^(?:\/\/[^\n]*\n)*\n*|(?:\/\/[^\n]*(?:\n|$))*$)/g, '');
+
+		// First version of options had some boilerplate code to make it eval-able -- strip that too. This part may become obsolete down the line.
+		if (optionsText.lastIndexOf('window.Twinkle.prefs = ', 0) === 0) {
+			optionsText = optionsText.replace(/(?:^window.Twinkle.prefs = |;\n*$)/g, '');
+		}
+
+		try {
+			var options = JSON.parse(optionsText);
+			if (options) {
+				if (options.twinkle || options.friendly) { // Old preferences format
+					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+				} else {
+					Twinkle.prefs = options;
+				}
+				// v2 established after unification of Twinkle/Friendly objects
+				Twinkle.prefs.optionsVersion = Twinkle.prefs.optionsVersion || 1;
+			}
+		} catch (e) {
+			mw.notify('Could not parse your Twinkle preferences', {type: 'error'});
+		}
+	})
+	.always(function () {
+		$(Twinkle.load);
+	});
+
+window.Twinkle = Twinkle;  // allow global access
+
+// </nowiki>

--- a/types/jquery.d.ts
+++ b/types/jquery.d.ts
@@ -1,0 +1,4 @@
+import JQuery from '@types/jquery';
+
+declare const $ = JQuery;
+declare const jQuery = JQuery;

--- a/types/mediawiki.d.ts
+++ b/types/mediawiki.d.ts
@@ -1,0 +1,206 @@
+/**
+ * Type definitions for mediawiki modules
+ */
+
+type title = string | mw.Title
+type namespaceId = number
+
+declare namespace mw {
+
+
+	class Api {
+		constructor(options?: any)
+		abort(): void
+		get(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		post(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+
+		/**
+		 * @private
+		 */
+		preprocessParameters( parameters: any, useUS: boolean ): void
+
+		// index.js
+		ajax(parameters: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		postWithToken(tokenType: string, params: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		getToken( type: string, additionalParams?: any | string ): JQuery.Promise<string>
+		badToken(type: string): void
+		getErrorMessage(data: any): JQuery
+
+		// edit.js
+		postWithEditToken(params: any, ajaxOptions?: JQuery.AjaxSettings): JQuery.Promise<any>
+		getEditToken(): JQuery.Promise<string>
+		create(title: title, params: any, content: string): JQuery.Promise<any>
+		edit(title: title, transform: (data: {
+			timestamp: string,
+			content: string
+		}) => any | string): JQuery.Promise<any>
+		newSection(title: title, header: string, message: string, additionalParams?: any): JQuery.Promise<any>
+
+		// user.js
+		getUserInfo(): JQuery.Promise<{
+			groups: string[],
+			rights: string[]
+		}>
+		assertCurrentUser(query: any): JQuery.Promise<{
+			assert: 'anon' | 'user'
+			assertUser: string
+		}>
+
+		// options.js
+		saveOption(name: string, value: string): JQuery.Promise<any>
+		saveOptions(options: {[optionName: string]: string}): JQuery.Promise<any>
+
+		// watch.js
+		watch(pages: title | title[]): JQuery.Promise<{
+			watch: {title: string, watched: boolean} | {title: string, watched: boolean}[]
+		}>
+		unwatch(pages: title | title[]): JQuery.Promise<{
+			watch: {title: string, watched: boolean} | {title: string, watched: boolean}[]
+		}>
+
+		// parse.js
+		parse(content: string | Title, additionalParams?: any): JQuery.Promise<any>
+
+		// messages.js
+		getMessages(messages: string[], options?: any): JQuery.Promise<any>
+		loadMessages(messages: string[], options?: any): JQuery.Promise<any>
+		loadMessagesIfMissing(messages: string[], options?: any): JQuery.Promise<any>
+
+
+		// TODO
+		// category.js
+		// login.js
+		// rollback.js
+		// upload.js
+
+	}
+
+	class Title {
+		constructor(title: string, namespace?: namespaceId)
+		static newFromText(title: string, namespace?: namespaceId): mw.Title | null
+		static makeTitle(title: string, namespace?: namespaceId): mw.Title | null
+		static newFromUserInput(title: string, namespace?: namespaceId, options?: any): mw.Title
+		static newFromFileName(uncleanName: string): mw.Title
+		static newFromImg(img: HTMLElement | JQuery): mw.Title
+		static isTalkNamespace(namespaceId: namespaceId): boolean
+		static wantSignatureNamespace(namespaceId: namespaceId): boolean
+		static exists(title: title): boolean | null
+		static exist: {
+		    pages: {[title: string]: boolean},
+		    set: (titles: string | string[], state?: boolean) => boolean
+		}
+		static normalizeExtension(extension: string): string
+		static phpCharToUpper(chr: string): string
+
+		getNamespaceId(): namespaceId
+		getNamespacePrefix(): string
+		getName(): string
+		getNameText(): string
+		getExtension(): string | null
+		getDotExtension(): string
+		getMain(): string
+		getMainText(): string
+		getPrefixedDb(): string
+		getPrefixedText(): string
+		getRelativeText(namespace: namespaceId): string
+		getFragment(): string | null
+		getUrl(params: any): string
+		isTalkPage(): boolean
+		getTalkPage(): Title | null
+		getSubjectPage(): Title | null
+		canHaveTalkPage(): boolean
+		exists(): boolean | null
+		toString(): string
+		toText(): string
+	}
+
+	namespace util {
+		const $content: JQuery;
+		function rawurlencode(str: string): string;
+		function escapeIdForAttribute(str: string): string;
+		function escapeIdForLink(str: string): string;
+		function debounce(delay: number, callback: Function): (...args: any[]) => void;
+		function wikiUrlencode(str: string): string;
+		function getUrl(pageName: string, params?: {[param: string]: string}): string;
+		function wikiScript(str: string): string;
+		function addCSS(text: string): any;
+		function getParamValue(param: string, url?: string): string;
+		function hidePortlet(portletId: string): void;
+		function isPortletVisible(portletId: string): boolean;
+		function showPortlet(portletId: string): void;
+		function addPortletLink(portletId: string, href: string, text: string, id?: string,
+			tooltip?: string, accesskey?: string, nextnode?: string): HTMLLIElement;
+		function validateEmail(mailtxt: string): boolean;
+		function isIPv4Address(address: string, allowBlock?: boolean): boolean;
+		function isIPv6Address(address: string, allowBlock?: boolean): boolean;
+		function isIPAddress(address: string, allowBlock?: boolean): boolean;
+		function parseImageUrl(url: string): {
+			name: string;
+			width: number | null;
+			resizeUrl: (w: any) => string;
+		} | null;
+		function escapeRegExp(str: string): string;
+	}
+
+	namespace config {
+
+		// get() and set() are actually on mw.Map() but I guess all that isn't necessary to document
+		// here as we'd never use them
+		function get(configKey: string | string[], fallback?: any): any
+		function set(configKey: string, configValue: any): boolean
+		function exists(configKey: string): boolean
+	}
+
+
+	// Not everything is included
+	namespace loader {
+		/**
+		 * Execute a function after one or more modules are ready.
+		 *
+		 * @param dependencies
+		 * @param {Function} ready Callback to execute when all dependencies are
+		 * ready.
+		 * @param {Function} error Callback to execute if one or more dependencies
+		 * failed.
+		 */
+		function using(dependencies: string[] | string, ready?: Function, error?: Function): JQuery.Promise<any>;
+
+		/**
+		 * Load an external script or one or more modules.
+		 *
+		 * @param {string|Array} modules Either the name of a module, array of modules,
+		 *  or a URL of an external script or style
+		 * @param {string} [type='text/javascript'] MIME type to use if calling with a URL of an
+		 *  external script or style; acceptable values are "text/css" and
+		 *  "text/javascript"; if no type is provided, text/javascript is assumed.
+		 * @throws {Error} If type is invalid
+		 */
+		function load(modules: string | string[], type?: string): () => void;
+		/**
+		 * Get the loading state of the module.
+		 * On of 'registered', 'loaded', 'loading', 'ready', 'error', or 'missing'.
+		 *
+		 * @param module
+		 */
+		function getState(module: string): string | null;
+	}
+
+	/**
+	 * Loads the specified i18n message string.
+	 * Shortcut for `mw.message( key, parameters... ).text()`.
+	 *
+	 * @param messageName i18n message name
+	 */
+	function msg(messageName: string | null): string;
+
+	/**
+	 * Notification
+	 * @param {HTMLElement|HTMLElement[]|jQuery|string} message
+	 * @param {Object} [options] See mw.notification#defaults for the defaults.
+	 * @return {jQuery.Promise}
+	 */
+	function notify(message: string | JQuery | HTMLElement | HTMLElement[],
+		options?: { tag?: string, type?: string, title?: string }): JQuery.Promise<any>;
+
+}
+

--- a/types/mediawiki.d.ts
+++ b/types/mediawiki.d.ts
@@ -202,5 +202,10 @@ declare namespace mw {
 	function notify(message: string | JQuery | HTMLElement | HTMLElement[],
 		options?: { tag?: string, type?: string, title?: string }): JQuery.Promise<any>;
 
+
+	namespace language {
+		function listToText(arr: string[]): string
+	}
+
 }
 

--- a/types/morebits.d.ts
+++ b/types/morebits.d.ts
@@ -295,7 +295,7 @@ interface quickFormElementData {
 	tooltip?: string
 	extra?: any
 	adminonly?: boolean
-	label?: string | HTMLElement
+	label?: string | HTMLElement | (string | HTMLElement)[] // non-string cases applicable for type=div only
 	value?: string
 	size?: string // for input
 	multiple?: boolean // for select

--- a/types/morebits.d.ts
+++ b/types/morebits.d.ts
@@ -22,18 +22,18 @@ declare namespace Morebits {
 	class quickForm {
 		constructor(event: ((e: FormSubmitEvent) => void), eventType?: string)
 		render(): HTMLFormElement
-		append(quickFormElement): quickFormElement
+		append(data: quickFormElementData): quickFormElement
 		static getInputData(form: HTMLFormElement): Record<string, string>
 		static getElements(form: HTMLFormElement, fieldName: string): HTMLElement[]
 		static getCheckboxOrRadio(elementArray: HTMLInputElement[], value: string): HTMLInputElement
-		static getElementContainer()
-		static getElementLabelObject()
-		static getElementLabel()
-		static setElementLabel()
-		static overrideElementLabel()
-		static resetElementLabel()
-		static setElementVisibility()
-		static setElementTooltipVisibility()
+		static getElementContainer(element: HTMLElement): HTMLElement
+		static getElementLabelObject(element: HTMLElement): HTMLElement
+		static getElementLabel(element: HTMLElement): string
+		static setElementLabel(element: HTMLElement): boolean
+		static overrideElementLabel(element: HTMLElement, temporaryLabelText: string): boolean
+		static resetElementLabel(element: HTMLElement): boolean | null
+		static setElementVisibility(element: HTMLElement | JQuery | string): void
+		static setElementTooltipVisibility(element: HTMLElement | JQuery | string, visibility?: boolean): void
 		static element: typeof quickFormElement
 	}
 
@@ -235,7 +235,6 @@ declare namespace Morebits {
 		setPageList(pageList: T[]): void
 
 		// Overloaded definition
-		setOption(optionName: any, optionValue: any)
 		setOption(optionName: 'chunkSize', optionValue: number)
 		setOption(optionName: 'preserveIndividualStatusLines', optionValue: boolean)
 
@@ -279,9 +278,34 @@ declare namespace Morebits {
 declare class quickFormElement {
 	constructor(data: any)
 	static id: number
-	append(data: quickFormElement): quickFormElement
+	append(data: quickFormElementData): quickFormElement
 	render(): HTMLElement
-	compute(data: any): any
+	private compute(data: quickFormElementData): [HTMLElement, HTMLElement]
 	static generateTooltip(node: HTMLElement, data: any): void
+}
+
+interface quickFormElementData {
+	type?: 'input' | 'textarea' | 'submit' | 'checkbox' | 'radio' | 'select' |
+		'option' | 'optgroup' | 'field' | 'dyninput' | 'hidden' | 'header' |
+		'div' | 'button' | 'fragment'
+	name?: string
+	id?: string
+	className?: string
+	style?: string
+	tooltip?: string
+	extra?: any
+	adminonly?: boolean
+	label?: string | HTMLElement
+	value?: string
+	size?: string // for input
+	multiple?: boolean // for select
+	checked?: boolean
+	disabled?: boolean
+	event?: ((event?: Event) => void)
+	list?: quickFormElementData[]
+	subgroup?: quickFormElementData | quickFormElementData[]
+	required?: boolean // for input, textarea
+	readonly?: boolean // for input, textarea
+	maxlength?: number // for input, textarea
 }
 

--- a/types/morebits.d.ts
+++ b/types/morebits.d.ts
@@ -1,0 +1,287 @@
+/**
+ * Type definitions for morebits.js
+ */
+
+interface FormSubmitEvent extends Event {
+	target: HTMLFormElement
+}
+
+declare namespace Morebits {
+
+	function userIsInGroup(group: string): boolean
+	const userIsSysop: boolean
+
+	function sanitizeIPv6(address: string): string | null
+
+	function isPageRedirect(): boolean
+
+	const pageNameNorm: string
+
+	function pageNameRegex(pageName: string): string
+
+	class quickForm {
+		constructor(event: ((e: FormSubmitEvent) => void), eventType?: string)
+		render(): HTMLFormElement
+		append(quickFormElement): quickFormElement
+		static getInputData(form: HTMLFormElement): Record<string, string>
+		static getElements(form: HTMLFormElement, fieldName: string): HTMLElement[]
+		static getCheckboxOrRadio(elementArray: HTMLInputElement[], value: string): HTMLInputElement
+		static getElementContainer()
+		static getElementLabelObject()
+		static getElementLabel()
+		static setElementLabel()
+		static overrideElementLabel()
+		static resetElementLabel()
+		static setElementVisibility()
+		static setElementTooltipVisibility()
+		static element: typeof quickFormElement
+	}
+
+	namespace string {
+		function toUpperCaseFirstChar(str: string): string
+		function toLowerCaseFirstChar(str: string): string
+		function splitWeightedByKeys(str: string, start: string, end: string, skiplist: string | string[]): string[]
+		function formatReasonText(str: string): string
+		function formatReasonForLog(str: string): string
+		function safeReplace(string: string, pattern: string | RegExp, replacement: string): string
+		function isInfinity(expiry: string): boolean
+		function escapeRegExp(text: string): string
+	}
+
+	namespace array {
+		function uniq<T>(arr: T[]): T[]
+		function dups<T>(arr: T[]): T[]
+		function chunk<T>(arr: T[], size: number): T[][]
+	}
+
+	class unbinder {
+		// has some properties too but they're not supposed to be public
+		unbind(prefix: string, postfix: string): void
+		rebind(): string
+	}
+
+	class date extends Date {
+		private _d: Date
+		isValid(): boolean
+		isBefore(date: Morebits.date | Date): boolean
+		isAfter(date: Morebits.date | Date): boolean
+		getDayName(): string
+		getDayNameAbbrev(): string
+		getUTCDayName(): string
+		getUTCDayNameAbbrev(): string
+		getMonthName(): string
+		getMonthNameAbbrev(): string
+		getUTCMonthName(): string
+		getUTCMonthNameAbbrev(): string
+		add(number: number, unit: string): Morebits.date
+		subtract(number: number, unit: string): Morebits.date
+		format(formatstr: string, zone: number | 'utc' | 'system'): string
+		calendar(zone: number | 'utc' | 'system'): string
+		monthHeaderRegex(): RegExp
+		monthHeader(level?: number): string
+	}
+
+	namespace wiki {
+		let numberOfActionsLeft: number
+		let nbrOfCheckpointsLeft: number
+		let actionCompleted: {
+			(): void
+			event: (() => void)
+			timeout: number
+			redirect: string
+			notice: string
+			followRedirect: boolean
+		}
+		function addCheckpoint(): void
+		function removeCheckpoint(): void
+
+		class api {
+			constructor(currentAction: string, query: any, onSuccess?: ((apiobj: api) => any),
+						statusElement?: string, onFailure?: ((apiobj: api) => any))
+			responseXML: XMLDocument
+			setParent(parent: any): void
+			setStatusElement(statusElement: Morebits.status): void
+			post(callerAjaxParameters?: JQuery.AjaxSettings): JQuery.Promise<api>
+			private returnError(callerAjaxParameters: JQuery.AjaxSettings): JQuery.Promise<api>
+			getStatusElement(): Morebits.status
+			getErrorCode(): string
+			getErrorText(): string
+			getXML(): XMLDocument
+			getResponse(): any
+			static setApiUserAgent(ua: string): void
+			static getToken(): JQuery.Promise<string>
+		}
+
+		class page {
+			constructor(pageName: string, currentAction?: string)
+			load(onSuccess: ((pageobj: page) => void)): void
+			save(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			append(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			prepend(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			newSection(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			getPageName(): string
+			getPageText(): string
+			setPageText(pageText: string)
+			setAppendText(appendText: string)
+			setPrependText(prependText: string)
+			setNewSectionText(newSectionText: string)
+			setNewSectionTitle(newSectionTitle: string)
+			setEditSummary(summary: string): void
+			setChangeTags(tags: string | string[]): void
+			setCreateOption(createOption: string): void
+			setMinorEdit(minorEdit: string): void
+			setBotEdit(botEdit: boolean): void
+			setPageSection(pageSection: string): void
+			setMaxConflictRetries(maxConflictRetries: number): void
+			setMaxRetries(maxRetries: number): void
+			setWatchlist(watchlistOption: string): void
+			setWatchlistExpiry(watchlistExpiry: string): void
+			setWatchlistFromPreferences(watchlistOption: string): void
+			setFollowRedirect(followRedirect, followCrossNsRedirect: string): void
+			setLookupNonRedirectCreator(flag: boolean): void
+			setMoveDestination(destination: string): void
+			setMoveTalkPage(flag: boolean): void
+			setMoveSubpages(flag: boolean): void
+			setMoveSuppressRedirect(flag: boolean): void
+			setEditProtection(level: string, expiry: string): void
+			setMoveProtection(level: string, expiry: string): void
+			setCreateProtection(level: string, expiry: string): void
+			setCascadingProtection(flag: boolean): void
+			suppressProtectWarning(): void
+			setOldID(oldID: string): void
+			getCurrentID(): string
+			getRevisionUser(): string
+			getLastEditTime(): string
+			setCallbackParameters(callbackParameters: any)
+			getCallbackParameters(): any
+			getStatusElement(): Morebits.status
+			setFlaggedRevs(level: string, expiry: string)
+			exists(): boolean
+			getPageID(): string
+			getLoadTime(): string
+			getCreator(): string
+			getCreationTimestamp(): string
+			canEdit(): boolean
+			lookupCreation(onSuccess: ((pageobj: page) => void)): void
+			revert(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			move(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			patrol(): void
+			triage(): void
+			deletePage(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			undeletePage(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			protect(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+			stabilize(onSuccess?: ((pageobj: page) => void), onFailure?: ((pageobj: page) => void)): void
+		}
+
+		class preview {
+			constructor(previewbox: HTMLElement)
+			previewbox: HTMLElement
+			beginRender(wikitext: string, pageTitle: string, sectionTitle: string): void
+			closePreview(): void
+		}
+
+	}
+
+	namespace wikitext {
+		function parseTemplate(text: string, start: number): {name: string, parameters: {[key: string]: string}}
+		class page {
+			text: string
+			removeLink(link_target: string)
+			commentOutImage(image: string, reason: string)
+			addToImageComment(image: string, data: string)
+			removeTemplate(template: string)
+			insertAfterTemplates(tag: string, regex: string | string[], flags: string, preRegex: string | string[])
+			getText(): string
+		}
+	}
+
+	class userspaceLogger {
+		initialText: string
+		headerLevel: number
+		changeTags: string | string[]
+		log(logText: string, summaryText: string): void
+	}
+
+
+	class status {
+		textRaw: string
+		text: DocumentFragment
+		type: 'status' | 'info' | 'warn' | 'error'
+		static init(root: HTMLElement): void
+		static root: HTMLElement
+		onError(handler: ((arg: any) => any)): void // XXX: check handler types
+		link(): void
+		unlink(): void
+		codify(obj: (string | HTMLElement)[])
+		update(status: string, type: 'status' | 'info' | 'warn' | 'error')
+		generate(): void
+		render(): void
+		status(status: string)
+		info(status: string)
+		warn(status: string)
+		error(status: string)
+		static info(text: string, status: string): void
+		static warn(text: string, status: string): void
+		static error(text: string, status: string): void
+		static actionCompleted(text: string): void
+		static printUserText(comments: string, message: string)
+	}
+
+	function htmlNode(type: string, content: string, color?: string): HTMLElement
+	function checkboxShiftClickSupport(jQuerySelector: string | JQuery, jQueryContext: string | JQuery)
+
+	class batchOperation<T> {
+		getStatusElement(): Morebits.status
+		setPageList(pageList: T[]): void
+
+		// Overloaded definition
+		setOption(optionName: any, optionValue: any)
+		setOption(optionName: 'chunkSize', optionValue: number)
+		setOption(optionName: 'preserveIndividualStatusLines', optionValue: boolean)
+
+		run(worker: ((item: T) => any), postFinish: (() => any)): void
+		workerSuccess(arg: any): void
+		workerFailure(arg: any): void
+	}
+
+	class taskManager {
+		taskDependencyMap: Map<Function, Function[]>
+		deferreds: Map<Function, JQuery.Deferred<any>[]>
+		allDeferreds: JQuery.Deferred<any>[]
+		add(func: Function, deps: Function[])
+		execute(): JQuery.Promise<void>
+	}
+
+	class simpleWindow {
+		constructor(width: number, height: number)
+		buttons: Array<any>
+		height: number
+		hasFooterLinks: boolean
+		scriptName: string
+		focus(): Morebits.simpleWindow
+		close(event: Event): Morebits.simpleWindow
+		display(): Morebits.simpleWindow
+		setTitle(title: string): Morebits.simpleWindow
+		setScriptName(name: string): Morebits.simpleWindow
+		setWidth(width: number): Morebits.simpleWindow
+		setHeight(height: number): Morebits.simpleWindow
+		setContent(content: HTMLElement): Morebits.simpleWindow
+		addContent(content: HTMLElement): Morebits.simpleWindow
+		purgeContent(): Morebits.simpleWindow
+		addFooterLink(text: string, wikiPage: string, prep?: boolean): Morebits.simpleWindow
+		setModality(modal: boolean): Morebits.simpleWindow
+		static setButtonsEnabled(enabled: boolean)
+	}
+
+}
+
+// TypeScript's handling of nested classes is pathetic ...
+declare class quickFormElement {
+	constructor(data: any)
+	static id: number
+	append(data: quickFormElement): quickFormElement
+	render(): HTMLElement
+	compute(data: any): any
+	static generateTooltip(node: HTMLElement, data: any): void
+}
+


### PR DESCRIPTION
Builds up on #1220 (as that isn't yet merged, its commits are included here for now).

This is an object-oriented rewrite of the tag module where each mode (article, redirect, file) is a class extending the abstract base class `TagMode`. Common functionality are shared in either the `Tag` class or in `TagMode`.

All functionality are methods on the class, for example `captureFormData()`, `validateInputs()`, `action()`.

This is a WIP. `TagMode` could probably be improved to _do_ something (`action()`) by default. I think I can figure that out while working on article/file modes.

Also, #1170 needs to be integrated into this. 