### PR TITLE
batchdelete: fix type for page namespace

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -185,7 +185,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 				(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)'));
 			}
 
-			if (page.ns === '6') {  // mimic what delimages used to show for files
+			if (page.ns === 6) {  // mimic what delimages used to show for files
 				metadata.push('uploader: ' + page.imageinfo[0].user);
 				metadata.push('last edit from: ' + page.revisions[0].user);
 			} else {


### PR DESCRIPTION
JSON API gets the page namespace as number, not string.

Stems from #1224.