### PR TITLE
batch/deprod/unlink: Sort lists of pages by namespace then title

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -171,6 +171,10 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		pages = pages.filter(function(page) {
 			return !page.missing && page.imagerepository !== 'shared';
 		});
+		// json formatversion=2 doesn't sort pages by namespace
+		pages.sort(function(one, two) {
+			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+		});
 		pages.forEach(function(page) {
 			var metadata = [];
 			if (page.redirect) {
@@ -342,6 +346,10 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				var response = apiobj.getResponse();
 				var pages = (response.query && response.query.pages) || [];
 				var subpageList = [];
+				// json formatversion=2 doesn't sort pages by namespace
+				pages.sort(function(one, two) {
+					return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+				});
 				pages.forEach(function(page) {
 					var metadata = [];
 					if (page.redirect) {

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -181,6 +181,10 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		var response = apiobj.getResponse();
 		var pages = (response.query && response.query.pages) || [];
 		var list = [];
+		// json formatversion=2 doesn't sort pages by namespace
+		pages.sort(function(one, two) {
+			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+		});
 		pages.forEach(function(page) {
 			var metadata = [];
 			var missing = !!page.missing, editProt;

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -70,6 +70,10 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 			return page.missing;
 		});
 		var list = [];
+		// json formatversion=2 doesn't sort pages by namespace
+		pages.sort(function(one, two) {
+			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+		});
 		pages.forEach(function(page) {
 			var editProt = page.protection.filter(function(pr) {
 				return pr.type === 'create' && pr.level === 'sysop';

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -61,6 +61,10 @@ Twinkle.deprod.callback = function() {
 		});
 		var list = [];
 		var re = /\{\{Proposed deletion/;
+		// json formatversion=2 doesn't sort pages by namespace
+		pages.sort(function(one, two) {
+			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+		});
 		pages.forEach(function(page) {
 			var metadata = [];
 

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -131,7 +131,10 @@ Twinkle.unlink.callbacks = {
 			var list, namespaces, i;
 
 			if (apiobj.params.image) {
-				var imageusage = response.query.imageusage;
+				var imageusage = response.query.imageusage.sort(function(one, two) {
+					// json formatversion=2 doesn't sort pages by namespace
+					return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+				});
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
 					var usagetitle = imageusage[i].title;
@@ -180,7 +183,10 @@ Twinkle.unlink.callbacks = {
 				}
 			}
 
-			var backlinks = response.query.backlinks;
+			var backlinks = response.query.backlinks.sort(function(one, two) {
+				// json formatversion=2 doesn't sort pages by namespace
+				return one.ns - two.ns || (one.title > two.title ? 1 : -1);
+			});
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {


### PR DESCRIPTION
Noted at [WT:TW](https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=995362073#Dbatch) by @Siddharthvp, but apparently json `formatversion=2` preferentially sorts by `pageid`, whereas xml and `formatversion=1` sorts by namespace then title.  This manually reintroduces that sorting.

Technically, it's not identical, as xml/`formatversion=1` sorts preferentially by existence, but that isn't hugely important for our purposes.