### PR TITLE
Generate links for batchprotect/batchundelete (arrows) and unlink (title links)

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -238,21 +238,13 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		var result = form.render();
 		apiobj.params.Window.setContent(result);
 
-		Morebits.quickForm.getElements(result, 'pages').forEach(generateArrowLinks);
+		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
 	}, statelem);
 
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();
 };
-
-function generateArrowLinks (checkbox) {
-	var link = Morebits.htmlNode('a', ' >');
-	link.setAttribute('class', 'tw-dbatch-page-link');
-	link.setAttribute('href', mw.util.getUrl(checkbox.value));
-	link.setAttribute('target', '_blank');
-	checkbox.nextElementSibling.append(link);
-}
 
 Twinkle.batchdelete.generateNewPageList = function(form) {
 
@@ -302,8 +294,8 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
-			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages').forEach(Twinkle.generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(Twinkle.generateArrowLinks);
 
 			return;
 		}
@@ -393,8 +385,8 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
 			$('#tw-dbatch-pages').replaceWith(newPageList);
 
-			Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
-			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages').forEach(Twinkle.generateArrowLinks);
+			Morebits.quickForm.getElements(newPageList, 'pages.subpages').forEach(Twinkle.generateArrowLinks);
 
 			subpagesLoaded = true;
 
@@ -418,7 +410,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		newPageList = Twinkle.batchdelete.generateNewPageList(form);
 		$('#tw-dbatch-pages').replaceWith(newPageList);
 
-		Morebits.quickForm.getElements(newPageList, 'pages').forEach(generateArrowLinks);
+		Morebits.quickForm.getElements(newPageList, 'pages').forEach(Twinkle.generateArrowLinks);
 	}
 };
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -239,6 +239,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		result.moveexpiry.value = '2 days';
 		result.createexpiry.value = 'infinity';
 
+		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
 	}, statelem);
 

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -110,6 +110,8 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		var result = apiobj.params.form.render();
 		apiobj.params.Window.setContent(result);
 
+		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
+
 	}, statelem);
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -114,14 +114,7 @@ Twinkle.deprod.callback = function() {
 
 		var rendered = apiobj.params.form.render();
 		apiobj.params.Window.setContent(rendered);
-		Morebits.quickForm.getElements(rendered, 'pages').forEach(function(checkbox) {
-			var $checkbox = $(checkbox);
-			var link = Morebits.htmlNode('a', $checkbox.val());
-			link.setAttribute('class', 'deprod-page-link');
-			link.setAttribute('href', mw.util.getUrl($checkbox.val()));
-			link.setAttribute('target', '_blank');
-			$checkbox.next().prepend([link, ' ']);
-		});
+		Morebits.quickForm.getElements(rendered, 'pages').forEach(Twinkle.generateBatchPageLinks);
 	}, statelem);
 
 	wikipedia_api.params = { form: form, Window: Window };

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -134,8 +134,8 @@ Twinkle.unlink.callbacks = {
 				var imageusage = response.query.imageusage;
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
-					var usagetitle = imageusage[i].title;
-					list.push({ label: usagetitle, value: usagetitle, checked: true });
+					// Label made by Twinkle.generateBatchPageLinks
+					list.push({ label: '', value: imageusage[i].title, checked: true });
 				}
 				if (!list.length) {
 					apiobj.params.form.append({ type: 'div', label: 'No instances of file usage found.' });
@@ -184,8 +184,8 @@ Twinkle.unlink.callbacks = {
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {
-					var title = backlinks[i].title;
-					list.push({ label: title, value: title, checked: true });
+					// Label made by Twinkle.generateBatchPageLinks
+					list.push({ label: '', value: backlinks[i].title, checked: true });
 				}
 				apiobj.params.form.append({ type: 'header', label: 'Backlinks' });
 				namespaces = [];
@@ -195,7 +195,7 @@ Twinkle.unlink.callbacks = {
 				apiobj.params.form.append({
 					type: 'div',
 					label: 'Selected namespaces: ' + namespaces.join(', '),
-					tooltip: 'You can change this with your Twinkle preferences, at [[WP:TWPREFS]]'
+					tooltip: 'You can change this with your Twinkle preferences, linked at the bottom of this Twinkle window'
 				});
 				if (response['query-continue'] && response['query-continue'].backlinks) {
 					apiobj.params.form.append({
@@ -234,6 +234,9 @@ Twinkle.unlink.callbacks = {
 
 			var result = apiobj.params.form.render();
 			apiobj.params.Window.setContent(result);
+
+			Morebits.quickForm.getElements(result, 'backlinks').forEach(Twinkle.generateBatchPageLinks);
+			Morebits.quickForm.getElements(result, 'imageusage').forEach(Twinkle.generateBatchPageLinks);
 
 		}
 	},

--- a/twinkle.js
+++ b/twinkle.js
@@ -539,6 +539,15 @@ Twinkle.generateArrowLinks = function (checkbox) {
 	checkbox.nextElementSibling.append(link);
 };
 
+// Used in deprod and unlink listings to link the page title
+Twinkle.generateBatchPageLinks = function (checkbox) {
+	var $checkbox = $(checkbox);
+	var link = Morebits.htmlNode('a', $checkbox.val());
+	link.setAttribute('class', 'tw-batchpage-link');
+	link.setAttribute('href', mw.util.getUrl($checkbox.val()));
+	link.setAttribute('target', '_blank');
+	$checkbox.next().prepend([link, ' ']);
+};
 
 }(window, document, jQuery)); // End wrap with anonymous function
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -530,6 +530,16 @@ Twinkle.makeFindSourcesDiv = function makeSourcesDiv() {
 		)[0];
 };
 
+// Used in batch listings to link to the page in question with >
+Twinkle.generateArrowLinks = function (checkbox) {
+	var link = Morebits.htmlNode('a', ' >');
+	link.setAttribute('class', 'tw-arrowpage-link');
+	link.setAttribute('href', mw.util.getUrl(checkbox.value));
+	link.setAttribute('target', '_blank');
+	checkbox.nextElementSibling.append(link);
+};
+
+
 }(window, document, jQuery)); // End wrap with anonymous function
 
 // </nowiki>


### PR DESCRIPTION
1. batchprotect/batchundelete: Show arrow links for batchprotect and batchundelete.  Pull the `generateArrowLinks` function from batchdelete out to `Twinkle.generateArrowLinks` and use for all three `twinklebatch`- modules.
2. unlink: Link the pages being listed.  Copy what's done for deprod, pulled out into `Twinkle.generateBatchPageLinks` (cf. `Twinkle.generateArrowLinks`).

----

Personally, I'd wanted to link the pages directly (as in deprod/unlink) for all batch modules, but that leads to complications around misleading stylings for nonexistent pages as well as protection status, and I'm not sure most folks would find it overly clarifying.