### PR TITLE
tag: Fix bug in file and redirect tagging from #1126

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1748,7 +1748,7 @@ Twinkle.tag.callbacks = {
 
 		pageobj.setPageText(pageText);
 		pageobj.setEditSummary(summaryText);
-		if (Twinkle.getPref('watchTaggedPages').indexOf('redirects') !== -1) {
+		if (Twinkle.getPref('watchTaggedVenues').indexOf('redirects') !== -1) {
 			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
@@ -1857,7 +1857,7 @@ Twinkle.tag.callbacks = {
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summary.substring(0, summary.length - 2));
 		pageobj.setChangeTags(Twinkle.changeTags);
-		if (Twinkle.getPref('watchTaggedPages').indexOf('files') !== -1) {
+		if (Twinkle.getPref('watchTaggedVenues').indexOf('files') !== -1) {
 			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));


### PR DESCRIPTION
`watchTaggedPages` erroneously used instead of `watchTaggedVenues`.  Reported on WT:TW: https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=995623858#File_maintenance_tagging_not_working and https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=995623858#Redirect_tagging_getting_stuck