### PR TITLE
speedy/image: don't share addToLog

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1555,10 +1555,6 @@ Twinkle.speedy.callbacks = {
 			}
 		},
 
-		// note: this code is also invoked from twinkleimage
-		// the params used are:
-		//   for CSD: params.values, params.normalizeds  (note: normalizeds is an array)
-		//   for DI: params.fromDI = true, params.templatename, params.normalized  (note: normalized is a string)
 		addToLog: function(params, initialContrib) {
 			var usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
 			usl.initialText =
@@ -1574,8 +1570,7 @@ Twinkle.speedy.callbacks = {
 					(normalize === 'G6' && csdparam === 'sourcepage') ||
 					(normalize === 'A2' && csdparam === 'source') ||
 					(normalize === 'A10' && csdparam === 'article') ||
-					(normalize === 'F1' && csdparam === 'filename') ||
-					(normalize === 'F5' && csdparam === 'replacement')) {
+					(normalize === 'F1' && csdparam === 'filename')) {
 					input = '[[:' + input + ']]';
 				} else if (normalize === 'G5' && csdparam === 'user') {
 					input = '[[:User:' + input + ']]';
@@ -1597,57 +1592,44 @@ Twinkle.speedy.callbacks = {
 			var editsummary = 'Logging speedy deletion nomination';
 			var appendText = '# [[:' + Morebits.pageNameNorm;
 
-			if (params.fromDI) {
-				appendText += ']]' + fileLogLink + ': DI [[WP:CSD#' + params.normalized.toUpperCase() + '|CSD ' + params.normalized.toUpperCase() + ']] ({{tl|di-' + params.templatename + '}})';
-				// The params data structure when coming from DI is quite different,
-				// so this hardcodes the only interesting items worth logging
-				['reason', 'replacement', 'source'].forEach(function(item) {
-					if (params[item]) {
-						extraInfo += formatParamLog(params.normalized.toUpperCase(), item, params[item]);
-						return false;
-					}
-				});
+			if (params.normalizeds.indexOf('g10') === -1) {  // no article name in log for G10 taggings
+				appendText += ']]' + fileLogLink + ': ';
 				editsummary += ' of [[:' + Morebits.pageNameNorm + ']].';
 			} else {
-				if (params.normalizeds.indexOf('g10') === -1) {  // no article name in log for G10 taggings
-					appendText += ']]' + fileLogLink + ': ';
-					editsummary += ' of [[:' + Morebits.pageNameNorm + ']].';
-				} else {
-					appendText += '|This]] attack page' + fileLogLink + ': ';
-					editsummary += ' of an attack page.';
-				}
-				if (params.normalizeds.length > 1) {
-					appendText += 'multiple criteria (';
-					$.each(params.normalizeds, function(index, norm) {
-						appendText += '[[WP:CSD#' + norm.toUpperCase() + '|' + norm.toUpperCase() + ']], ';
-					});
-					appendText = appendText.substr(0, appendText.length - 2);  // remove trailing comma
-					appendText += ')';
-				} else if (params.normalizeds[0] === 'db') {
-					appendText += '{{tl|db-reason}}';
-				} else {
-					appendText += '[[WP:CSD#' + params.normalizeds[0].toUpperCase() + '|CSD ' + params.normalizeds[0].toUpperCase() + ']] ({{tl|db-' + params.values[0] + '}})';
-				}
+				appendText += '|This]] attack page' + fileLogLink + ': ';
+				editsummary += ' of an attack page.';
+			}
+			if (params.normalizeds.length > 1) {
+				appendText += 'multiple criteria (';
+				$.each(params.normalizeds, function(index, norm) {
+					appendText += '[[WP:CSD#' + norm.toUpperCase() + '|' + norm.toUpperCase() + ']], ';
+				});
+				appendText = appendText.substr(0, appendText.length - 2);  // remove trailing comma
+				appendText += ')';
+			} else if (params.normalizeds[0] === 'db') {
+				appendText += '{{tl|db-reason}}';
+			} else {
+				appendText += '[[WP:CSD#' + params.normalizeds[0].toUpperCase() + '|CSD ' + params.normalizeds[0].toUpperCase() + ']] ({{tl|db-' + params.values[0] + '}})';
+			}
 
-				// If params is "empty" it will still be full of empty arrays, but ask anyway
-				if (params.templateParams) {
-					// Treat custom rationale individually
-					if (params.normalizeds[0] && params.normalizeds[0] === 'db') {
-						extraInfo += formatParamLog('Custom', 'rationale', params.templateParams[0]['1']);
-					} else {
-						params.templateParams.forEach(function(item, index) {
-							var keys = Object.keys(item);
-							if (keys[0] !== undefined && keys[0].length > 0) {
-								// Second loop required since some items (G12, F9) may have multiple keys
-								keys.forEach(function(key, keyIndex) {
-									if (keys[keyIndex] === 'blanked' || keys[keyIndex] === 'ts') {
-										return true; // Not worth logging
-									}
-									extraInfo += formatParamLog(params.normalizeds[index].toUpperCase(), keys[keyIndex], item[key]);
-								});
-							}
-						});
-					}
+			// If params is "empty" it will still be full of empty arrays, but ask anyway
+			if (params.templateParams) {
+				// Treat custom rationale individually
+				if (params.normalizeds[0] && params.normalizeds[0] === 'db') {
+					extraInfo += formatParamLog('Custom', 'rationale', params.templateParams[0]['1']);
+				} else {
+					params.templateParams.forEach(function(item, index) {
+						var keys = Object.keys(item);
+						if (keys[0] !== undefined && keys[0].length > 0) {
+							// Second loop required since some items (G12, F9) may have multiple keys
+							keys.forEach(function(key, keyIndex) {
+								if (keys[keyIndex] === 'blanked' || keys[keyIndex] === 'ts') {
+									return true; // Not worth logging
+								}
+								extraInfo += formatParamLog(params.normalizeds[index].toUpperCase(), keys[keyIndex], item[key]);
+							});
+						}
+					});
 				}
 			}
 


### PR DESCRIPTION
Speedy module needs to be changed a lot for localizability. It's no longer wise for image module to piggyback on speedy's `addToLog` function. This means some duplication but not much (particularly since #878). The integration was never elegant to begin with (noted in a comment as "params data structure when coming from DI is quite different"), so there was a large `if` separating the behaviour for the two modules.