### PR TITLE
morebits.wikitext.parseTemplate: Fix bug parsing terminal template parameters

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4373,9 +4373,9 @@ Morebits.wikitext = {};
 Morebits.wikitext.parseTemplate = function(text, start) {
 	start = start || 0;
 
+	var level = []; // Track of how deep we are ({{, {{{, or [[)
 	var count = -1;  // Number of parameters found
 	var unnamed = 0; // Keep track of what number an unnamed parameter should receive
-	var level = -1;  // How many levels deep of template code we're in, 0-based
 	var equals = -1; // After finding "=" before a parameter, the index; otherwise, -1
 	var current = '';
 	var result = {
@@ -4390,7 +4390,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 	 * @param {boolean} [final=false] - Whether this is the final
 	 * parameter and we need to remove the trailing `}}`.
 	 */
-	var findParam = function(final) {
+	function findParam(final) {
 		// Nothing found yet, this must be the template name
 		if (count === -1) {
 			result.name = current.substring(2).trim();
@@ -4412,14 +4412,18 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 				}
 			}
 		}
-	};
+	}
 
 	for (var i = start; i < text.length; ++i) {
 		var test3 = text.substr(i, 3);
-		if (test3 === '{{{' || test3 === '}}}') {
+		if (test3 === '{{{' || (test3 === '}}}' && level[level.length - 1] === 3)) {
 			current += test3;
 			i += 2;
-			test3 === '}}}' ? --level : ++level;
+			if (test3 === '{{{') {
+				level.push(3);
+			} else {
+				level.pop();
+			}
 			continue;
 		}
 		var test2 = text.substr(i, 2);
@@ -4427,36 +4431,33 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 		if (test2 === '{{' || test2 === '[[') {
 			current += test2;
 			++i;
-			++level;
+			if (test2 === '{{') {
+				level.push(2);
+			} else {
+				level.push('wl');
+			}
 			continue;
 		}
-		// Leaving a link
-		if (test2 === ']]') {
-			current += ']]';
-			++i;
-			--level;
-			continue;
-		}
-		// Either leaving a template or an internal template/parser function
-		if (test2 === '}}') {
-			// Regardless, decrement the level
+		// Either leaving a link or template/parser function
+		if ((test2 === '}}' && level[level.length - 1] === 2) ||
+			(test2 === ']]' && level[level.length - 1] === 'wl')) {
 			current += test2;
 			++i;
-			--level;
+			level.pop();
 
 			// Find the final parameter if this really is the end
-			if (level === -1) {
+			if (test2 === '}}' && level.length === 0) {
 				findParam(true);
 				break;
 			}
 			continue;
 		}
 
-		if (text.charAt(i) === '|' && level === 0) {
+		if (text.charAt(i) === '|' && level.length === 1) {
 			// Another pipe found, toplevel, so parameter coming up!
 			findParam();
 			current = '';
-		} else if (equals === -1 && text.charAt(i) === '=' && level === 0) {
+		} else if (equals === -1 && text.charAt(i) === '=' && level.length === 1) {
 			// Equals found, toplevel
 			equals = current.length;
 			current += text.charAt(i);

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -47,20 +47,20 @@ QUnit.test('parseTemplate', assert => {
 	var multiLevel = {
 		name: 'toplevel',
 		parameters: {
-			named: 'namedtop',
+			named: '{{namedtop}}',
 			other: '{{{namedintro|{{{3|asd}}}|really=yes|a}}}',
 			1: 'onetop',
-			final: '{{{last|iswear}}}'
+			final: '{{last|iswear}}'
 		}
 	};
 	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(multiLevel)), multiLevel, 'Multiple levels');
 	var parser = {
 		name: 'toplevel',
 		parameters: {
-			named: 'namedtop',
+			named: '{{namedtop}}',
 			other: '{{#if:{{{namedintro|{{{3|asd}}}|really=yes|a}}}|true|false}}',
 			1: 'onetop',
-			final: '{{{last|iswear}}}'
+			final: '{{last|iswear}}'
 		}
 	};
 	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(parser)), parser, 'Parser function');
@@ -71,7 +71,7 @@ QUnit.test('parseTemplate', assert => {
 			named: 'parameter {{tq|with an internal}} template',
 			other: '{{#if:{{{namedintro|{{{3|asd}}}|really=yes|a}}}|true|false}}',
 			1: 'onetop',
-			final: '{{{last|iswear}}}'
+			final: '{{last|iswear}}'
 		}
 	};
 	assert.deepEqual(Morebits.wikitext.parseTemplate(makeTemplate(internal)), internal, 'Internal templates');


### PR DESCRIPTION
Closes #1259.  The detection of ending templates or template parameters was always `}}}` then `}}`, in order not to miss things.  This meant, however, that something like a final parameter that was itself a template (`{{42}}`) would end up at `}}}}` getting preferentially (and incorrectly) parsed as `}}}`.  There's a fair bit of cruft here, but we need to keep track of exactly what level we're in, in order to ensure we properly exit it; that means tracking any previous levels for nested items (technically, everything, since *all* parameters are nested in the actual template).  I've converted the `level` integer to an array to which we can `push` and `pop`, covering all our bases.