### PR TITLE
Morebits.namespaceRegex for matching all namespace capitalizations and aliases, use in morebits and modules

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -405,7 +405,7 @@ Twinkle.talkback.evaluate = function(e) {
 			break;
 		default:  // tbtarget one of mytalk, usertalk, other
 			var editSummary = 'Talkback ([[:';
-			if (input.tbtarget !== 'other' && !/^\s*user talk:/i.test(input.page)) {
+			if (input.tbtarget !== 'other' && !new RegExp('^\\s*' + Morebits.namespaceRegex(3) + ':', 'i').test(input.page)) {
 				editSummary += 'User talk:';
 			}
 			talkpage.setEditSummary(editSummary + input.page + (input.section ? '#' + input.section : '') + ']])');

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -467,7 +467,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 			delete_talk: input.delete_talk,
 			delete_redirects: input.delete_redirects,
 			unlink_page: input.unlink_page,
-			unlink_file: input.unlink_file && /^(File|Image):/i.test(pageName),
+			unlink_file: input.unlink_file && new RegExp('^' + Morebits.namespaceRegex(6) + ':', 'i').test(pageName),
 			reason: input.reason,
 			pageDeleter: pageDeleter
 		};
@@ -698,7 +698,7 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		var image = params.page.replace(/^(?:Image|File):/, '');
+		var image = params.page.replace(new RegExp('^' + Morebits.namespaceRegex(6) + ':'), '');
 		var text;
 		if (params.title in Twinkle.batchdelete.unlinkCache) {
 			text = Twinkle.batchdelete.unlinkCache[params.title];

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -183,7 +183,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 
 	var input = Morebits.quickForm.getInputData(event.target);
 	if (input.replacement) {
-		input.replacement = (/^(Image|File):/i.test(input.replacement) ? '' : 'File:') + input.replacement;
+		input.replacement = (new RegExp('^' + Morebits.namespaceRegex(6) + ':', 'i').test(input.replacement) ? '' : 'File:') + input.replacement;
 	}
 
 	var csdcrit;

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1704,7 +1704,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form['csd.repost_xfd']) {
 					var deldisc = form['csd.repost_xfd'].value;
 					if (deldisc) {
-						if (!/^(?:wp|wikipedia):/i.test(deldisc)) {
+						if (!new RegExp('^:?' + Morebits.namespaceRegex(4) + ':', 'i').test(deldisc)) {
 							alert('CSD G4:  The deletion discussion page name, if provided, must start with "Wikipedia:".');
 							parameters = null;
 							return false;
@@ -1743,7 +1743,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form['csd.xfd_fullvotepage']) {
 					var xfd = form['csd.xfd_fullvotepage'].value;
 					if (xfd) {
-						if (!/^(?:wp|wikipedia):/i.test(xfd)) {
+						if (!new RegExp('^:?' + Morebits.namespaceRegex(4) + ':', 'i').test(xfd)) {
 							alert('CSD G6 (XFD):  The deletion discussion page name, if provided, must start with "Wikipedia:".');
 							parameters = null;
 							return false;
@@ -1818,7 +1818,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 						parameters = null;
 						return false;
 					}
-					currentParams.filename = /^\s*(Image|File):/i.test(redimage) ? redimage : 'File:' + redimage;
+					currentParams.filename = new RegExp('^\\s*' + Morebits.namespaceRegex(6) + ':', 'i').test(redimage) ? redimage : 'File:' + redimage;
 				}
 				break;
 
@@ -1832,7 +1832,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form['csd.commons_filename']) {
 					var filename = form['csd.commons_filename'].value;
 					if (filename && filename.trim() && filename !== Morebits.pageNameNorm) {
-						currentParams.filename = /^\s*(Image|File):/i.test(filename) ? filename : 'File:' + filename;
+						currentParams.filename = new RegExp('^\\s*' + Morebits.namespaceRegex(6) + ':', 'i').test(filename) ? filename : 'File:' + filename;
 					}
 				}
 				break;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -988,7 +988,7 @@ Twinkle.xfd.callbacks = {
 					if (params.tfdtarget) {
 						var contentModel = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'Module:' : 'Template:';
 						appendText += '; Other ' + contentModel.toLowerCase() + ' [[';
-						if (!/^:?(?:template|module):/i.test(params.tfdtarget)) {
+						if (!new RegExp('^:?' + Morebits.namespaceRegex([10, 828]) + ':', 'i').test(params.tfdtarget)) {
 							appendText += contentModel;
 						}
 						appendText += params.tfdtarget + ']]';
@@ -1398,7 +1398,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:tfm|help=off|' + (params.templatetype !== 'standard' ? 'type=' + params.templatetype + '|' : '') +
-				'1=' + params.otherTemplateName.replace(/^(?:Template|Module):/, '') + '}}';
+				'1=' + params.otherTemplateName.replace(new RegExp('^' + Morebits.namespaceRegex([10, 828]) + ':'), '') + '}}';
 
 			if (pageobj.getContentModel() === 'sanitized-css') {
 				params.tagText = '/* ' + params.tagText + ' */';

--- a/morebits.js
+++ b/morebits.js
@@ -4535,11 +4535,24 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeLink: function(link_target) {
-		var link_re_string = Morebits.pageNameRegex(link_target);
+		// Rempve a leading colon, to be handled later
+		if (link_target.indexOf(':') === 0) {
+			link_target = link_target.slice(1);
+		}
+		var link_re_string = '', ns = '', title = link_target;
 
+		var idx = link_target.indexOf(':');
+		if (idx > 0) {
+			ns = link_target.slice(0, idx);
+			title = link_target.slice(idx + 1);
+
+			link_re_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
+		}
+		link_re_string += Morebits.pageNameRegex(title);
+
+		// Allow for an optional leading colon, e.g. [[:User:Test]]
 		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
-		// Otherwise, allow for an optional leading colon, e.g. [[:User:Test]]
-		var colon = new RegExp('^' + Morebits.namespaceRegex([6, 14]) + ':').test(link_target) ? ':' : ':?';
+		var colon = new RegExp(Morebits.namespaceRegex([6, 14])).test(ns) ? ':' : ':?';
 
 		var link_simple_re = new RegExp('\\[\\[' + colon + '(' + link_re_string + ')\\]\\]', 'g');
 		var link_named_re = new RegExp('\\[\\[' + colon + link_re_string + '\\|(.+?)\\]\\]', 'g');

--- a/morebits.js
+++ b/morebits.js
@@ -134,7 +134,7 @@ Morebits.pageNameNorm = mw.config.get('wgPageName').replace(/_/g, ' ');
 /**
  * Create a string for use in regex matching a page name.  Accounts for
  * leading character's capitalization, underscores as spaces, and special
- * characters being escaped.
+ * characters being escaped.  See also {@link Morebits.namespaceRegex}.
  *
  * @param {string} pageName - Page name without namespace.
  * @returns {string} - For a page name `Foo bar`, returns the string `[Ff]oo[_ ]bar`.
@@ -149,6 +149,50 @@ Morebits.pageNameRegex = function(pageName) {
 		return '[' + mw.Title.phpCharToUpper(firstChar) + firstChar.toLowerCase() + ']' + remainder;
 	}
 	return Morebits.string.escapeRegExp(firstChar) + remainder;
+};
+
+/**
+ * Create a string for use in regex matching all namespace aliases, regardless
+ * of the capitalization and underscores/spaces.  Doesn't include the optional
+ * leading `:`, but if there's more than one item, wraps the list in a
+ * non-capturing group.  This means you can do `Morebits.namespaceRegex([4]) +
+ * ':' + Morebits.pageNameRegex('Twinkle')` to match a full page.  Uses
+ * {@link Morebits.pageNameRegex}.
+ *
+ * @param {number[]} namespaces - Array of namespace numbers.  Unused/invalid
+ * namespace numbers are silently discarded.
+ * @example
+ * // returns '(?:[Ff][Ii][Ll][Ee]|[Ii][Mm][Aa][Gg][Ee])'
+ * Morebits.namespaceRegex([6])
+ * @returns {string} - Regex-suitable string of all namespace aliases.
+ */
+Morebits.namespaceRegex = function(namespaces) {
+	if (!Array.isArray(namespaces)) {
+		namespaces = [namespaces];
+	}
+	var aliases = [], regex;
+	$.each(mw.config.get('wgNamespaceIds'), function(name, number) {
+		if (namespaces.indexOf(number) !== -1) {
+			// Namespaces are completely agnostic as to case,
+			// and a regex string is more useful/compatibile than a RegExp object,
+			// so we accept any casing for any letter.
+			aliases.push(name.split('').map(function(char) {
+				return Morebits.pageNameRegex(char);
+			}).join(''));
+		}
+	});
+	switch (aliases.length) {
+		case 0:
+			regex = '';
+			break;
+		case 1:
+			regex = aliases[0];
+			break;
+		default:
+			regex = '(?:' + aliases.join('|') + ')';
+			break;
+	}
+	return regex;
 };
 
 
@@ -4495,8 +4539,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
 		// Otherwise, allow for an optional leading colon, e.g. [[:User:Test]]
-		var special_ns_re = /^(?:[Ff]ile|[Ii]mage|[Cc]ategory):/;
-		var colon = special_ns_re.test(link_target) ? ':' : ':?';
+		var colon = new RegExp('^' + Morebits.namespaceRegex([6, 14]) + ':').test(link_target) ? ':' : ':?';
 
 		var link_simple_re = new RegExp('\\[\\[' + colon + '(' + link_re_string + ')\\]\\]', 'g');
 		var link_named_re = new RegExp('\\[\\[' + colon + link_re_string + '\\|(.+?)\\]\\]', 'g');
@@ -4521,7 +4564,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Check for normal image links, i.e. [[File:Foobar.png|...]]
 		// Will eat the whole link
-		var links_re = new RegExp('\\[\\[(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		var links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
 		var allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
@@ -4535,7 +4578,7 @@ Morebits.wikitext.page.prototype = {
 		// Check for gallery images, i.e. instances that must start on a new line,
 		// eventually preceded with some space, and must include File: prefix
 		// Will eat the whole line.
-		var gallery_image_re = new RegExp('(^\\s*(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
+		var gallery_image_re = new RegExp('(^\\s*' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
 		unbinder.content = unbinder.content.replace(gallery_image_re, '<!-- ' + reason + '$1 -->');
 
 		// unbind the newly created comments
@@ -4543,7 +4586,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Check free image usages, for example as template arguments, might have the File: prefix excluded, but must be preceeded by an |
 		// Will only eat the image name and the preceeding bar and an eventual named parameter
-		var free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:(?:[Ii]mage|[Ff]ile):\\s*)?' + image_re_string + ')', 'mg');
+		var free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:' + Morebits.namespaceRegex(6) + ':\\s*)?' + image_re_string + ')', 'mg');
 		unbinder.content = unbinder.content.replace(free_image_re, '<!-- ' + reason + '$1 -->');
 		// Rebind the content now, we are done!
 		this.text = unbinder.rebind();
@@ -4559,7 +4602,7 @@ Morebits.wikitext.page.prototype = {
 	 */
 	addToImageComment: function(image, data) {
 		var image_re_string = Morebits.pageNameRegex(image);
-		var links_re = new RegExp('\\[\\[(?:[Ii]mage|[Ff]ile):\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		var links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
 		var allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
 		for (var i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
@@ -4584,7 +4627,7 @@ Morebits.wikitext.page.prototype = {
 	 */
 	removeTemplate: function(template) {
 		var template_re_string = Morebits.pageNameRegex(template);
-		var links_re = new RegExp('\\{\\{(?:[Tt]emplate:)?\\s*[' + template_re_string + '\\s*[\\|(?:\\}\\})]');
+		var links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
 		var allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
 		for (var i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {

--- a/tests/morebits.js
+++ b/tests/morebits.js
@@ -27,6 +27,14 @@ QUnit.test('pageNameRegex', assert => {
 	assert.strictEqual(Morebits.pageNameRegex('#'), '#', 'Single same-case');
 	assert.strictEqual(Morebits.pageNameRegex('*$, \{}(a) |.?+-^ [ ]'), '\\*\\$,[_ ]\\{\\}\\(a\\)[_ ]\\|\\.\\?\\+\\-\\^\[_ ]\\[[_ ]\\]', 'Special characters');
 });
+QUnit.test('namespaceRegex', assert => {
+	assert.strictEqual(Morebits.namespaceRegex([6]), '(?:[Ff][Ii][Ll][Ee]|[Ii][Mm][Aa][Gg][Ee])', 'Files');
+	assert.strictEqual(Morebits.namespaceRegex(10), '[Tt][Ee][Mm][Pp][Ll][Aa][Tt][Ee]', 'Non-array singlet');
+	assert.strictEqual(Morebits.namespaceRegex([4, 5]), '(?:[Ww][Ii][Kk][Ii][Pp][Ee][Dd][Ii][Aa]|[Ww][Ii][Kk][Ii][Pp][Ee][Dd][Ii][Aa][_ ][Tt][Aa][Ll][Kk]|[Ww][Pp]|[Ww][Tt]|[Pp][Rr][Oo][Jj][Ee][Cc][Tt]|[Pp][Rr][Oo][Jj][Ee][Cc][Tt][_ ][Tt][Aa][Ll][Kk])', 'Project and project talk');
+	assert.strictEqual(Morebits.namespaceRegex(0), '', 'Main');
+	assert.strictEqual(Morebits.namespaceRegex(), '', 'Empty');
+});
+
 QUnit.test('isPageRedirect', assert => {
 	assert.false(Morebits.isPageRedirect(), 'Is redirect');
 });

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -309,6 +309,13 @@ QUnit.test('Morebits.wikitext.page', assert => {
 		},
 		{
 			name: 'AltCaps',
+			method: 'removeLink',
+			input: 'O, [[WP:Juliet]] she [[wp:juliet|doth]] {{plural|teach}} [[Romeo|the]] [[wikipedia:Juliet|torches]] [[Wikipedia:juliet]] to burn bright!',
+			expected: 'O, WP:Juliet she doth {{plural|teach}} [[Romeo|the]] torches Wikipedia:juliet to burn bright!',
+			params: ['wikipedia:juliet']
+		},
+		{
+			name: 'AltCaps',
 			method: 'commentOutImage',
 			input: 'O, [[File:Fee.svg]] she [[file:Fee.svg|doth|teach]] the [[File:fee.svg|torches]] to burn [[file:fee.svg]] bright!',
 			expected: 'O, <!-- [[File:Fee.svg]] --> she <!-- [[file:Fee.svg|doth|teach]] --> the <!-- [[File:fee.svg|torches]] --> to burn <!-- [[file:fee.svg]] --> bright!',

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -275,9 +275,9 @@ QUnit.test('Morebits.wikitext.page', assert => {
 		{
 			name: 'Template namespace',
 			method: 'removeTemplate',
-			input: 'O, she doth {{Template:plural|teach}} the {{template:plural|torches}} to burn bright!',
-			expected: 'O, she doth  the  to burn bright!',
-			params: ['Template:plural']
+			input: 'O, {{plural|she}} doth {{Template:plural|teach}} the {{template:plural|torches}} to burn bright!',
+			expected: 'O,  doth  the  to burn bright!',
+			params: ['plural']
 		},
 		{
 			name: 'Similar names',
@@ -306,6 +306,27 @@ QUnit.test('Morebits.wikitext.page', assert => {
 			input: 'O, {{plural|she|}} doth {{pluralize|teach}} the {{plural  | torches}} t{{plural \n\n |}}o {{plural temp|burn}} bright!',
 			expected: 'O,  doth {{pluralize|teach}} the  to {{plural temp|burn}} bright!',
 			params: ['plural']
+		},
+		{
+			name: 'AltCaps',
+			method: 'commentOutImage',
+			input: 'O, [[File:Fee.svg]] she [[file:Fee.svg|doth|teach]] the [[File:fee.svg|torches]] to burn [[file:fee.svg]] bright!',
+			expected: 'O, <!-- [[File:Fee.svg]] --> she <!-- [[file:Fee.svg|doth|teach]] --> the <!-- [[File:fee.svg|torches]] --> to burn <!-- [[file:fee.svg]] --> bright!',
+			params: ['fee.svg']
+		},
+		{
+			name: 'AltCaps gallery',
+			method: 'commentOutImage',
+			input: '<gallery>\nFile:Fee.svg|1\nfile:Fee.svg|2\nFile:fee.svg|3\nfile:fee.svg|4\n</gallery>',
+			expected: '<gallery>\n<!-- File:Fee.svg|1 -->\n<!-- file:Fee.svg|2 -->\n<!-- File:fee.svg|3 -->\n<!-- file:fee.svg|4 -->\n</gallery>',
+			params: ['Fee.svg']
+		},
+		{
+			name: 'AltCaps',
+			method: 'addToImageComment',
+			input: 'O, [[File:Fee.svg]] she [[file:Fee.svg|doth|teach]] the [[File:fee.svg|torches]] to burn [[file:fee.svg]] bright!',
+			expected: 'O, [[File:Fee.svg|thumb]] she [[file:Fee.svg|doth|teach|thumb]] the [[File:fee.svg|torches|thumb]] to burn [[file:fee.svg|thumb]] bright!',
+			params: ['Fee.svg', 'thumb']
 		}
 	];
 


### PR DESCRIPTION
We were manually checking namespaces, which was largely working fine, but was repetitive and prone to ignoring case (`Morebits.wikitext.page` methods) or alternative aliases (`Project`).  A string is more versatile than an actual regex string/RegExp object, but means that it gets fairly awkward; hence this function.  Used in file-specific regex in `Morebits.wikitext.page` methods, for which it enables `commentOutImage` and `addToImageComment` to parse images regardless of namespace or title capitalization, and in speedy, xfd, image, batchdelete, talkback, where there should be no negative change.

Second commit uses it in `removeLink`, can probably be squashed.