### PR TITLE
arv: Add a blank newline after UAA entries

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -639,7 +639,9 @@ Twinkle.arv.callback.evaluate = function(e) {
 				uaaPage.getStatusElement().status('Adding new report...');
 				uaaPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].');
 				uaaPage.setChangeTags(Twinkle.changeTags);
-				uaaPage.setPageText(text + '\n' + reason);
+
+				// Blank newline per [[Special:Permalink/996949310#Spacing]]; see also [[WP:LISTGAP]] and [[WP:INDENTGAP]]
+				uaaPage.setPageText(text + '\n' + reason + '\n*');
 				uaaPage.save();
 			});
 			break;


### PR DESCRIPTION
Requested at [[Special:Permalink/996949310#Spacing]] and [[Special:Permalink/997971536#Spacing between reports at WP:UAA]], follows [[WP:LISTGAP]] and [[WP:INDENTGAP]]