### PR TITLE
warn: move {{uw-agf-sock}} from singlewarn to singlenotice

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -895,6 +895,10 @@ Twinkle.warn.messages = {
 	},
 
 	singlenotice: {
+		'uw-agf-sock': {
+			label: 'Use of multiple accounts (assuming good faith)',
+			summary: 'Notice: Using multiple accounts'
+		},
 		'uw-aiv': {
 			label: 'Bad AIV report',
 			summary: 'Notice: Bad AIV report'
@@ -1076,10 +1080,6 @@ Twinkle.warn.messages = {
 		'uw-affiliate': {
 			label: 'Affiliate marketing',
 			summary: 'Warning: Affiliate marketing'
-		},
-		'uw-agf-sock': {
-			label: 'Use of multiple accounts (assuming good faith)',
-			summary: 'Warning: Using multiple accounts'
 		},
 		'uw-attack': {
 			label: 'Creating attack pages',


### PR DESCRIPTION
Inspired by https://en.wikipedia.org/wiki/Wikipedia_talk:Template_index/User_talk_namespace#Possibly_inappropriate_icon_for_Template:Uw-agf-sock (should probably hold if/until that happens); cc @Enterprisey