### PR TITLE
Improve and expand handling of IP ranges

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -9,7 +9,7 @@
  *** friendlyshared.js: Shared IP tagging module
  ****************************************
  * Mode of invocation:     Tab ("Shared")
- * Active on:              Existing IP user talk pages
+ * Active on:              IP user talk pages
  */
 
 Twinkle.shared = function friendlyshared() {

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -9,13 +9,14 @@
  *** friendlytalkback.js: Talkback module
  ****************************************
  * Mode of invocation:     Tab ("TB")
- * Active on:              Any page with relevant user name (userspace, contribs, etc.)
+ * Active on:              Any page with relevant user name (userspace, contribs, etc.) except IP ranges
  * Config directives in:   FriendlyConfig
  */
 
 Twinkle.talkback = function() {
 
-	if (!mw.config.get('wgRelevantUserName')) {
+	if (!mw.config.exists('wgRelevantUserName') ||
+		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) !== mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
 		return;
 	}
 

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -84,7 +84,9 @@ Twinkle.welcome.normal = function() {
 			}
 		}
 	}
-	if (mw.config.get('wgRelevantUserName')) {
+	// Users and IPs but not IP ranges
+	if (mw.config.exists('wgRelevantUserName') &&
+		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) === mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
 		Twinkle.addPortletLink(function() {
 			Twinkle.welcome.callback(mw.config.get('wgRelevantUserName'));
 		}, 'Wel', 'friendly-welcome', 'Welcome user');

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -19,6 +19,10 @@ Twinkle.arv = function twinklearv() {
 	}
 
 	var isIP = mw.util.isIPAddress(username, true);
+	// Ignore ranges wider than the CIDR limit
+	if (isIP && !mw.util.isIPAddress(username) && !Morebits.validCIDR(username)) {
+		return;
+	}
 	var userType = isIP ? 'IP' + (!mw.util.isIPAddress(username) ? ' range' : '') : 'user';
 
 	Twinkle.addPortletLink(function() {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -16,9 +16,10 @@ menuFormattedNamespaces[0] = '(Article)';
  */
 
 Twinkle.block = function twinkleblock() {
-	// should show on Contributions or Block pages, anywhere there's a relevant user
 	relevantUserName = mw.config.get('wgRelevantUserName');
-	if (Morebits.userIsSysop && relevantUserName) {
+	// should show on Contributions or Block pages, anywhere there's a relevant user
+	// Ignore ranges wider than the CIDR limit
+	if (Morebits.userIsSysop && relevantUserName && (!mw.util.isIPAddress(relevantUserName, true) || mw.util.isIPAddress(relevantUserName) || Morebits.validCIDR(relevantUserName))) {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -10,12 +10,14 @@
  ****************************************
  * Mode of invocation:     Tab ("Warn")
  * Active on:              Any page with relevant user name (userspace, contribs,
- *                         etc.), as well as the rollback success page
+ *                         etc.) (not IP ranges), as well as the rollback success page
  */
 
 Twinkle.warn = function twinklewarn() {
 
-	if (mw.config.get('wgRelevantUserName')) {
+	// Users and IPs but not IP ranges
+	if (mw.config.exists('wgRelevantUserName') &&
+		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) === mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
 		Twinkle.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&
 			mw.config.get('wgNamespaceNumber') === 3 &&

--- a/morebits.js
+++ b/morebits.js
@@ -111,6 +111,27 @@ Morebits.sanitizeIPv6 = function (address) {
 };
 
 /**
+ * Get the /64 subnet for an IPv6 address.
+ *
+ * @param {string} ipv6 - The IPv6 address, with or without a subnet.
+ * @returns {boolean|string} - False if not IPv6 or bigger than a 64,
+ * otherwise the (sanitized) /64 address.
+ */
+Morebits.get64 = function (ipv6) {
+	if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
+		return false;
+	}
+	var subnetMatch = ipv6.match(/\/(\d{1,3})$/);
+	if (subnetMatch && parseInt(subnetMatch[1], 10) < 64) {
+		return false;
+	}
+	ipv6 = Morebits.sanitizeIPv6(ipv6);
+	var ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
+	return ipv6.replace(ip_re, '$1' + '0:0:0:0/64');
+};
+
+
+/**
  * Determines whether the current page is a redirect or soft redirect. Fails
  * to detect soft redirects on edit, history, etc. pages.  Will attempt to
  * detect [[Module:Redirect for discussion]], with the same failure points.

--- a/morebits.js
+++ b/morebits.js
@@ -111,6 +111,32 @@ Morebits.sanitizeIPv6 = function (address) {
 };
 
 /**
+ * Check that an IP range is within the CIDR limits.  Most likely to be useful
+ * in conjunction with `wgRelevantUserName`.  CIDR limits are harcoded as /16
+ * for IPv4 and /32 for IPv6.
+ *
+ * @returns {boolean} - True for valid ranges within the CIDR limits,
+ * otherwise false (ranges outside the limit, single IPs, non-IPs).
+ */
+Morebits.validCIDR = function (ip) {
+	if (mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip)) {
+		var subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
+		if (subnet) { // Should be redundant
+			if (mw.util.isIPv6Address(ip, true)) {
+				if (subnet >= 32) {
+					return true;
+				}
+			} else {
+				if (subnet >= 16) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+};
+
+/**
  * Get the /64 subnet for an IPv6 address.
  *
  * @param {string} ipv6 - The IPv6 address, with or without a subnet.

--- a/tests/morebits.js
+++ b/tests/morebits.js
@@ -14,18 +14,28 @@ QUnit.test('userIsInGroup', assert => {
 });
 
 QUnit.test('sanitizeIPv6', assert => {
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0001:0000:0000:0ab9:C0A8:0102'), '2001:DB8:1:0:0:AB9:C0A8:102', 'Shorten IPv6');
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0001::1'), '2001:DB8:1:0:0:0:0:1', 'Condensed form');
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/42'), '2001:DB8:1:0:0:AB9:C0A8:102/42', 'Subnet');
-	assert.strictEqual(Morebits.sanitizeIPv6('127.0.0.1'), '127.0.0.1', 'Home sweet home');
+	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001'), '2001:DB8:10:0:0:0:0:1', 'Shorten IPv6');
+	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010::1'), '2001:DB8:10:0:0:0:0:1', 'Condensed form');
+	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001/42'), '2001:DB8:10:0:0:0:0:1/42', 'Subnet');
+	assert.strictEqual(Morebits.sanitizeIPv6('192.0.2.0'), '192.0.2.0', 'IPv4');
+});
+QUnit.test('validCIDR', assert => {
+	assert.true(Morebits.validCIDR('192.0.2.0/24'), 'IPv4 range');
+	assert.true(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1/42'), 'IPv6 range');
+	assert.true(Morebits.validCIDR('2001:DB8:0010::1/42'), 'IPv6 range condensed');
+	assert.false(Morebits.validCIDR('192.0.2.0'), 'IPv4 single IP');
+	assert.false(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1'), 'IPv6 single IP');
+	assert.false(Morebits.validCIDR('Apple'), 'Username');
+	assert.false(Morebits.validCIDR('192.0.2.0/15'), 'IPv4 range too large');
+	assert.false(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1/31'), 'IPv6 range too large');
 });
 QUnit.test('get64', assert => {
-	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102'), '2001:DB8:1:0:0:0:0:0/64', 'IPv6');
-	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/65'), '2001:DB8:1:0:0:0:0:0/64', '65 subnet');
-	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/64'), '2001:DB8:1:0:0:0:0:0/64', '64 subnet');
-	assert.false(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/63'), '63 subnet');
+	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1'), '2001:DB8:10:0:0:0:0:0/64', 'IPv6');
+	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1/65'), '2001:DB8:10:0:0:0:0:0/64', '65 subnet');
+	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1/64'), '2001:DB8:10:0:0:0:0:0/64', '64 subnet');
+	assert.false(Morebits.get64('2001:DB8:10:0:0:0:0:1/63'), '63 subnet');
 	assert.false(Morebits.get64(), 'Missing');
-	assert.false(Morebits.get64('127.0.0.1'), 'IPv4');
+	assert.false(Morebits.get64('192.0.2.0'), 'IPv4');
 });
 
 QUnit.test('pageNameRegex', assert => {

--- a/tests/morebits.js
+++ b/tests/morebits.js
@@ -19,6 +19,14 @@ QUnit.test('sanitizeIPv6', assert => {
 	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/42'), '2001:DB8:1:0:0:AB9:C0A8:102/42', 'Subnet');
 	assert.strictEqual(Morebits.sanitizeIPv6('127.0.0.1'), '127.0.0.1', 'Home sweet home');
 });
+QUnit.test('get64', assert => {
+	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102'), '2001:DB8:1:0:0:0:0:0/64', 'IPv6');
+	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/65'), '2001:DB8:1:0:0:0:0:0/64', '65 subnet');
+	assert.strictEqual(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/64'), '2001:DB8:1:0:0:0:0:0/64', '64 subnet');
+	assert.false(Morebits.get64('2001:0db8:0001:0000:0000:0ab9:C0A8:0102/63'), '63 subnet');
+	assert.false(Morebits.get64(), 'Missing');
+	assert.false(Morebits.get64('127.0.0.1'), 'IPv4');
+});
 
 QUnit.test('pageNameRegex', assert => {
 	assert.strictEqual(Morebits.pageNameRegex(mw.config.get('wgPageName')), '[Mm]acbeth,[_ ]King[_ ]of[_ ]Scotland', 'First character and spaces');


### PR DESCRIPTION
Most of this should be straightforward, with the complicated changes mainly found in the block module.  Commits are as follows:

1. <s>fluff: Use `wgRelevantUserName` for IP ranges on contribs (#775) (Ends hacky reliance on `MediaWiki:Sp-contributions-footer-anon-range` from #476)</s> EDIT: moved to #1296
2. warn/welcome/talkback: Don't show for IP ranges (#775)
3. arv: Allow IP ranges but limit to AIV and SPI (`{{rvuser}}` doesn't support ranges) (#775)
    * Builds on #817/#1184/#1204 cc @DannyS712
4. block: Enable for IP ranges, improve handling of rangeblocks (#775)
    * Enable on ranges
        * Leaving a template is disabled, but the "templated reason" {{rangeblock}} is used as the default
    * Determine if IP is caught in a range block
        * Display the range, whether it's the same block, etc.
    * Use correct information for IPs covered by two blocks (e.g. a single IP and a range block)
    * Move/hide unblock link for IPs covered by ranges but not directly blocked
5. morebits: `Morebits.get64` to get the /64 subnet for an IPv6 address
6. fluff: Use Morebits.get64 to revert consecutive edits by same IPv6 /64 (#924)
    * cc @pppery @QEDK @martijnhoekstra @Eostrix77
7. block: Add checkbox to just block the /64 (#1173)
    * Obviously relies on `Morebits.get64`, but otherwise, a large part of this is just making increased use of `relevantUserName` (rather than `mw.config.get('wgRelevantUserName')`), and simply adjusting that when (un)checking the checkbox.  A number of things previously stable need to be changeable, but the overall structure isn't too different, since this form is used to reloading frequently.  The main things adjusted:
    * Unblock footerlink and window title toggled
    * Template option unchecked/disabled as necessary
    * Prior block preset reset
    * Data processing in `Twinkle.block.fetchUserInfo` is pulled out into `Twinkle.block.processUserInfo`
        * `Twinkle.block.processUserInfo` caches its results in `Twinkle.block.fetchedData`, thus allowing `Twinkle.block.fetchUserInfo` to only be rerun as necessary on multiple togglings
    * cc @ToBeFree @L235 @molly @MusikAnimal
8. Added `Morebits.validCIDR` to test if an IP range is within CIDR limits; use to limit block and arv
    * This is operating under the assumption that ranges that are too wide but are valid will still show the username.
    

The first four depend on [T206954](https://phabricator.wikimedia.org/T206954) being fully implemented to be of any use, but I *think* only the first one (fluff) should have any material harm if done beforehand (EDIT: This commit has been moved to #1296).  The last three (the /64 ones) should work without it, so in theory could be separate, but changes to the block module as written depend on the prior commit.  There's plenty of opinionated stuff in here, so comments/tests/etc. welcome!  I've got some thoughts for further changes, but this is what's needed for now.

Two questions off the top of my head:
- Is it worth adding a preference for fluff to disable treating the same /64 as the same user?  I'd argue no, but that might be worth a conversation (here and/or on-wiki), since it's an opinionated change.
- Is it worth adding a preference for block to default to the /64 checkbox?  If we did, should it default to on or off?  ATM I'd say no to both: opinionated change, essay not policy, probably new for many folks, etc.