### PR TITLE
tag: Add R to subpage

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -980,7 +980,8 @@ Twinkle.tag.redirectList = {
 			{ tag: 'R mentioned in hatnote', description: 'redirect from a title that is mentioned in a hatnote at the redirect target' },
 			{ tag: 'R to section', description: 'similar to {{R to list entry}}, but when list is organized in sections, such as list of characters in a fictional universe' },
 			{ tag: 'R from shortcut', description: 'redirect from a Wikipedia shortcut' },
-			{ tag: 'R from template shortcut', description: 'redirect from a shortcut page name in any namespace to a page in template namespace' }
+			{ tag: 'R from template shortcut', description: 'redirect from a shortcut page name in any namespace to a page in template namespace' },
+			{ tag: 'R to subpage', description: 'redirect to a subpage' }
 
 		],
 		'Disambiguation': [


### PR DESCRIPTION
Per https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Redirect_tagging_doesn't_include_{{R_to_subpage}}