### PR TITLE
Return from Morebits.wiki.preview, use to generate {{Find sources}}

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -65,8 +65,9 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 
 	field.append({
 		type: 'div',
-		label: Twinkle.makeFindSourcesDiv(),
-		style: 'margin-bottom: 5px;'
+		label: '', // Added later by Twinkle.makeFindSourcesDiv()
+		id: 'twinkle-prod-findsources',
+		style: 'margin-bottom: 5px; margin-top: -5px;'
 	});
 
 	field.append({
@@ -177,6 +178,8 @@ Twinkle.prod.callback.prodtypechanged = function(event) {
 		default:
 			break;
 	}
+
+	Twinkle.makeFindSourcesDiv('#twinkle-prod-findsources');
 
 	event.target.form.replaceChild(field.render(), $(event.target.form).find('fieldset[name="parameters"]')[0]);
 };

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -309,8 +309,9 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			work_area.append({
 				type: 'div',
-				label: Twinkle.makeFindSourcesDiv(),
-				style: 'margin-bottom: 5px;'
+				label: '', // Added later by Twinkle.makeFindSourcesDiv()
+				id: 'twinkle-xfd-findsources',
+				style: 'margin-bottom: 5px; margin-top: -5px;'
 			});
 
 			work_area.append({
@@ -395,6 +396,8 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			appendReasonBox();
 			work_area = work_area.render();
 			old_area.parentNode.replaceChild(work_area, old_area);
+
+			Twinkle.makeFindSourcesDiv('#twinkle-xfd-findsources');
 
 			$(work_area).find('[name=delsortCats]')
 				.attr('data-placeholder', 'Select delsort pages')

--- a/morebits.js
+++ b/morebits.js
@@ -4355,6 +4355,7 @@ Morebits.wiki.preview = function(previewbox) {
 	 * @param {string} wikitext - Wikitext to render; most things should work, including `subst:` and `~~~~`.
 	 * @param {string} [pageTitle] - Optional parameter for the page this should be rendered as being on, if omitted it is taken as the current page.
 	 * @param {string} [sectionTitle] - If provided, render the text as a new section using this as the title.
+	 * @returns {jQuery.promise}
 	 */
 	this.beginRender = function(wikitext, pageTitle, sectionTitle) {
 		$(previewbox).show();
@@ -4377,7 +4378,7 @@ Morebits.wiki.preview = function(previewbox) {
 			query.sectiontitle = sectionTitle;
 		}
 		var renderApi = new Morebits.wiki.api('loading...', query, fnRenderSuccess, new Morebits.status('Preview'));
-		renderApi.post();
+		return renderApi.post();
 	};
 
 	var fnRenderSuccess = function(apiobj) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -502,32 +502,20 @@ Twinkle.summaryAd = ' ([[WP:TW|TW]])';
 Twinkle.hatnoteRegex = 'short description|hatnote|main|correct title|dablink|distinguish|for|further|selfref|year dab|similar names|highway detail hatnote|broader|about(?:-distinguish| other people)?|other\\s?(?:hurricane(?: use)?s|people|persons|places|ships|uses(?: of)?)|redirect(?:-(?:distinguish|synonym|multi))?|see\\s?(?:wiktionary|also(?: if exists)?)';
 
 // Used in XFD and PROD
-Twinkle.makeFindSourcesDiv = function makeSourcesDiv() {
-	var makeLink = function(href, text) {
-		return $('<a>').attr({ rel: 'nofollow', class: 'external text',
-			target: '_blank', href: href }).text(text);
-	};
-	var title = encodeURIComponent(Morebits.pageNameNorm);
-	return $('<div>')
-		.addClass('plainlinks')
-		.append(
-			'(',
-			$('<i>').text('Find sources:'), ' ',
-			makeLink('//www.google.com/search?as_eq=wikipedia&q=%22' + title + '%22', 'Google'),
-			' (',
-			makeLink('//www.google.com/search?tbs=bks:1&q=%22' + title + '%22+-wikipedia', 'books'), ' - ',
-			makeLink('//www.google.com/search?tbm=nws&q=%22' + title + '%22+-wikipedia', 'news'), ' - ',
-			makeLink('//www.google.com/search?&q=%22' + title + '%22+site:news.google.com/newspapers&source=newspapers', 'newspapers'), ' - ',
-			makeLink('//scholar.google.com/scholar?q=%22' + title + '%22', 'scholar'), ' - ',
-			makeLink('https://www.google.com/search?safe=off&tbs=sur:fmc&tbm=isch&q=%22' + title + '%22+-site:wikipedia.org+-site:wikimedia.org', 'free images'), ' - ',
-			makeLink('https://www.google.com/custom?hl=en&cx=007734830908295939403%3Agalkqgoksq0&cof=FORID%3A13%3BAH%3Aleft%3BCX%3AWikipedia%2520Reference%2520Search&q=%22' + title + '%22', 'WP refs'),
-			')', ' - ',
-			makeLink('https://en.wikipedia.org/wiki/Wikipedia:Free_English_newspaper_sources', 'FENS'), ' - ',
-			makeLink('https://www.jstor.org/action/doBasicSearch?Query=%22' + title + '%22&acc=on&wc=on', 'JSTOR'), ' - ',
-			makeLink('https://www.nytimes.com/search/%22' + title + '%22', 'NYT'), ' - ',
-			makeLink('https://wikipedialibrary.wmflabs.org/partners/', 'TWL'),
-			')'
-		)[0];
+Twinkle.makeFindSourcesDiv = function makeSourcesDiv(divID) {
+	if (!$(divID).length) {
+		return;
+	}
+	if (!Twinkle.findSources) {
+		var parser = new Morebits.wiki.preview($(divID)[0]);
+		parser.beginRender('({{Find sources|' + Morebits.pageNameNorm + '}})', 'WP:AFD').then(function() {
+			// Save for second-time around
+			Twinkle.findSources = parser.previewbox.innerHTML;
+			$(divID).removeClass('morebits-previewbox');
+		});
+	} else {
+		$(divID).html(Twinkle.findSources);
+	}
 };
 
 }(window, document, jQuery)); // End wrap with anonymous function


### PR DESCRIPTION
Follows up on comments at https://github.com/wikimedia-gadgets/twinkle/issues/1047#issuecomment-671911400 cc @siddharthvp 

<s>Adds a callback option to `Morebits.wiki.preview`, then uses that to fill in xfd and prod.</s>  See below https://github.com/wikimedia-gadgets/twinkle/pull/1280#issuecomment-779032190

----

Could skip the Morebits edit and just use the api directly, but feels like we might as well use what we got.

{{Find sources}} is TE protected, but, uh, html being executed, etc.