### PR TITLE
morebits.date: Make unitMap available through Morebits.date.unitMap

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1667,6 +1667,22 @@ Morebits.date.localeData = {
 	}
 };
 
+/**
+ * Map units with getter/setter function names, for `add` and `subtract`
+ * methods.
+ *
+ * @memberof Morebits.date
+ * @type {object.<string, string>}
+ */
+Morebits.date.unitMap = {
+	seconds: 'Seconds',
+	minutes: 'Minutes',
+	hours: 'Hours',
+	days: 'Date',
+	months: 'Month',
+	years: 'FullYear'
+};
+
 Morebits.date.prototype = {
 	/** @returns {boolean} */
 	isValid: function() {
@@ -1731,15 +1747,8 @@ Morebits.date.prototype = {
 	 * @returns {Morebits.date}
 	 */
 	add: function(number, unit) {
-		// mapping time units with getter/setter function names
-		var unitMap = {
-			seconds: 'Seconds',
-			minutes: 'Minutes',
-			hours: 'Hours',
-			days: 'Date',
-			months: 'Month',
-			years: 'FullYear'
-		};
+		unit = unit.toLowerCase(); // normalize
+		var unitMap = Morebits.date.unitMap;
 		var unitNorm = unitMap[unit] || unitMap[unit + 's']; // so that both singular and  plural forms work
 		if (unitNorm) {
 			this['set' + unitNorm](this['get' + unitNorm]() + number);

--- a/tests/morebits.date.js
+++ b/tests/morebits.date.js
@@ -51,6 +51,7 @@ QUnit.test('RegEx headers', assert => {
 });
 QUnit.test('add/subtract', assert => {
 	assert.strictEqual(new Morebits.date(timestamp).add(1, 'day').toISOString(), '2020-11-08T16:26:00.000Z', 'Add 1 day');
+	assert.strictEqual(new Morebits.date(timestamp).add(1, 'DaY').toISOString(), '2020-11-08T16:26:00.000Z', 'Loudly add 1 day');
 	assert.strictEqual(new Morebits.date(timestamp).subtract(1, 'day').toISOString(), '2020-11-06T16:26:00.000Z', 'Subtract 1 day');
 	assert.throws(() => new Morebits.date(timestamp).add(1), 'throws: no unit');
 	assert.throws(() => new Morebits.date(timestamp).subtract(1, 'dayo'), 'throws: bad unit');


### PR DESCRIPTION
<s>`localeData` needs work, but</s> Doing this makes the available units for `add` and `subtract` accessible elsewhere; since using wrong units returns an error, we had no way of checking whether we had a correct unit without hardcoding the values.

In a similar vein, also makes `Morebits.date.add` and `Morebits.date.subtract` ignore unit case.