### PR TITLE
block: AP2 amended to post-1992

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1161,7 +1161,7 @@ Twinkle.block.dsinfo = {
 		code: 'ab',
 		page: 'Wikipedia:Arbitration/Requests/Case/Abortion'
 	},
-	'American politics post-1932': {
+	'American politics post-1992': {
 		code: 'ap',
 		page: 'Wikipedia:Arbitration/Requests/Case/American politics 2'
 	},


### PR DESCRIPTION
See [[Special:Permalink/1001488876#Motion: American politics 2 (1992 cutoff) enacted]] and https://en.wikipedia.org/w/index.php?oldid=1001485112#Motion:_American_politics_2_(1992_cutoff)