### PR TITLE
speedy: Add preference to watchlist user page on notification

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -489,6 +489,15 @@ Twinkle.config.sections = [
 				type: 'boolean'
 			},
 
+			// TwinkleConfig.watchSpeedyUser (string)
+			// The watchlist setting of the user talk page if they receive a notification.
+			{
+				name: 'watchSpeedyUser',
+				label: 'Add user talk page of initial contributor to watchlist (when notifying)',
+				type: 'enum',
+				enumValues: Twinkle.config.watchlistEnums
+			},
+
 			// TwinkleConfig.welcomeUserOnSpeedyDeletionNotification (array of strings)
 			// On what types of speedy deletion notifications shall the user be welcomed
 			// with a "firstarticle" notice if their talk page has not yet been created.

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1238,6 +1238,7 @@ Twinkle.speedy.callbacks = {
 			usertalkpage.setEditSummary(editsummary);
 			usertalkpage.setChangeTags(Twinkle.changeTags);
 			usertalkpage.setCreateOption('recreate');
+			usertalkpage.setWatchlist(Twinkle.getPref('watchSpeedyUser'));
 			usertalkpage.setFollowRedirect(true, false);
 			usertalkpage.append(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it

--- a/twinkle.js
+++ b/twinkle.js
@@ -96,6 +96,7 @@ Twinkle.defaultConfig = {
 	watchSpeedyPages: [ 'g3', 'g5', 'g10', 'g11', 'g12' ],
 	watchSpeedyExpiry: '1 month',
 	markSpeedyPagesAsPatrolled: false,
+	watchSpeedyUser: '1 month',
 
 	// these next two should probably be identical by default
 	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u3', 'u5', 'p1', 'p2' ],


### PR DESCRIPTION
This wasn't asked for - and I don't even recommend it - but it's a hole in our preferences, especially stark since we have `deliWatchUser`.  <s>Unlike others, defaulting to `nochange` since that's the current practice.  That being said, we could default to `1 month` to match the new temporary settings in #1249?  I might lean that way, minimal impact in the end.</s>  I've done this, defaulting to `1 month` to match `deliWatchUser` (and `xfdWatchUser`) after #1249.