### PR TITLE
tag: Hide subheadings on quick filter

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -231,7 +231,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	// for quick filter:
 	$allCheckboxDivs = $(result).find('[name$=tags]').parent();
-	$allHeaders = $(result).find('h5');
+	$allHeaders = $(result).find('h5, .quickformDescription');
 	result.quickfilter.focus();  // place cursor in the quick filter field as soon as window is opened
 	result.quickfilter.autocomplete = 'off'; // disable browser suggestions
 	result.quickfilter.addEventListener('keypress', function(e) {


### PR DESCRIPTION
Extends hiding subheadings to redirect tagging, as they are already hidden on article tagging, and file tagging doesn't include subheadings. Partially per https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&diff=1002467677&oldid=1002159993