### PR TITLE
twinkle: Remove unused preferences from default config

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -160,10 +160,7 @@ Twinkle.defaultConfig = {
 	// Welcome
 	topWelcomes: false,
 	watchWelcomes: 'yes',
-	welcomeHeading: 'Welcome',
-	insertHeadings: true,
 	insertUsername: true,
-	insertSignature: true,  // sign welcome templates, where appropriate
 	quickWelcomeMode: 'norm',
 	quickWelcomeTemplate: 'welcome',
 	customWelcomeList: [],


### PR DESCRIPTION
Remove preferences from the default config that are not used in any of the modules.