### PR TITLE
block: Show the length of the last block if it expired naturally

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -612,7 +612,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			if (lastBlockAction.action === 'unblock') {
 				$blockloglink.append(' (unblocked ' + new Morebits.date(lastBlockAction.timestamp).calendar('utc') + ')');
 			} else { // block or reblock
-				$blockloglink.append(' (expired ' + new Morebits.date(lastBlockAction.params.expiry).calendar('utc') + ')');
+				$blockloglink.append(' (' + lastBlockAction.params.duration + ', expired ' + new Morebits.date(lastBlockAction.params.expiry).calendar('utc') + ')');
 			}
 		}
 


### PR DESCRIPTION
It'd be nice to do this for protect as well, but the protect and stablize logs don't show the duration so naturally, so we'd have to calculate and format it with a `timeBetween` function or something.