### PR TITLE
twinkle: Add mw-portlet class to Vector outerdiv, removes newly-(re)established bullets

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -277,7 +277,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
 				navigation = 'mw-panel';
 			}
-			outerNavClass = 'vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+			outerNavClass = 'mw-portlet vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
 			innerDivClass = 'vector-menu-content';
 			break;
 		case 'modern':


### PR DESCRIPTION
Not sure when this changed (somewhere in 1.36-wmf28 or 29, presumably), but looks like the top-level of the menu gained a `.mw-portlet`, which apaprently means no bullets.  See also #713 and #763.

@MusikAnimal [MoreMenu](https://github.com/wikimedia-gadgets/MoreMenu) will need an update as well, I believe.  The train has been messed up lately, but I *think* things are going forward this week so it might need to be?  29 is on testwiki, where I've just pushed this, so good for testing I guess.

(I should note that in the intervening few hours, the hover state of the vector menus at testwiki have become unrelatedly borked)