### PR TITLE
morebits: Reorganize ip functions into Morebits.ip, add Morebits.ip.isRange to avoid mw.util.isIPAddress

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -14,9 +14,7 @@
  */
 
 Twinkle.talkback = function() {
-
-	if (!mw.config.exists('wgRelevantUserName') ||
-		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) !== mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
+	if (!mw.config.exists('wgRelevantUserName') || Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		return;
 	}
 

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -85,8 +85,7 @@ Twinkle.welcome.normal = function() {
 		}
 	}
 	// Users and IPs but not IP ranges
-	if (mw.config.exists('wgRelevantUserName') &&
-		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) === mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
+	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		Twinkle.addPortletLink(function() {
 			Twinkle.welcome.callback(mw.config.get('wgRelevantUserName'));
 		}, 'Wel', 'friendly-welcome', 'Welcome user');

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -20,7 +20,7 @@ Twinkle.arv = function twinklearv() {
 
 	var isIP = mw.util.isIPAddress(username, true);
 	// Ignore ranges wider than the CIDR limit
-	if (isIP && !mw.util.isIPAddress(username) && !Morebits.validCIDR(username)) {
+	if (isIP && !mw.util.isIPAddress(username) && !Morebits.ip.validCIDR(username)) {
 		return;
 	}
 	var userType = isIP ? 'IP' + (!mw.util.isIPAddress(username) ? ' range' : '') : 'user';

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -20,10 +20,10 @@ Twinkle.arv = function twinklearv() {
 
 	var isIP = mw.util.isIPAddress(username, true);
 	// Ignore ranges wider than the CIDR limit
-	if (isIP && !mw.util.isIPAddress(username) && !Morebits.ip.validCIDR(username)) {
+	if (Morebits.ip.isRange(username) && !Morebits.ip.validCIDR(username)) {
 		return;
 	}
-	var userType = isIP ? 'IP' + (!mw.util.isIPAddress(username) ? ' range' : '') : 'user';
+	var userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
 	Twinkle.addPortletLink(function() {
 		Twinkle.arv.callback(username, isIP);
@@ -40,8 +40,6 @@ Twinkle.arv.callback = function (uid, isIP) {
 	Window.addFooterLink('ARV prefs', 'WP:TW/PREF#arv');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#arv');
 	Window.addFooterLink('Give feedback', 'WT:TW');
-
-	var isIPRange = isIP && !mw.util.isIPAddress(uid);
 
 	var form = new Morebits.quickForm(Twinkle.arv.callback.evaluate);
 	var categories = form.append({
@@ -75,7 +73,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 		type: 'option',
 		label: 'Edit warring (WP:AN3)',
 		value: 'an3',
-		disabled: isIPRange // rvuser template doesn't support ranges
+		disabled: Morebits.ip.isRange(uid) // rvuser template doesn't support ranges
 	});
 	form.append({
 		type: 'div',
@@ -117,7 +115,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 		if (blocklist.length) {
 			// If an IP is blocked *and* rangeblocked, only use whichever is more recent
 			var block = blocklist[0];
-			var message = (isIP ? 'This IP ' + (isIPRange ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
+			var message = (isIP ? 'This IP ' + (Morebits.ip.isRange(uid) ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
 			// Start and end differ, range blocked
 			message += block.rangestart !== block.rangeend ? ' as part of a rangeblock.' : '.';
 			if (block.partial) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -19,7 +19,7 @@ Twinkle.block = function twinkleblock() {
 	relevantUserName = mw.config.get('wgRelevantUserName');
 	// should show on Contributions or Block pages, anywhere there's a relevant user
 	// Ignore ranges wider than the CIDR limit
-	if (Morebits.userIsSysop && relevantUserName && (!mw.util.isIPAddress(relevantUserName, true) || mw.util.isIPAddress(relevantUserName) || Morebits.ip.validCIDR(relevantUserName))) {
+	if (Morebits.userIsSysop && relevantUserName && (!Morebits.ip.isRange(relevantUserName) || Morebits.ip.validCIDR(relevantUserName))) {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
@@ -74,8 +74,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 				value: 'template',
 				tooltip: 'If the blocking admin forgot to issue a block template, or you have just blocked the user without templating them, you can use this to issue the appropriate template. Check the partial block box for partial block templates.',
 				// Disallow for IP ranges
-				checked: !mw.util.isIPAddress(relevantUserName, true) || mw.util.isIPAddress(relevantUserName),
-				disabled: !mw.util.isIPAddress(relevantUserName) && mw.util.isIPAddress(relevantUserName, true)
+				checked: !Morebits.ip.isRange(relevantUserName),
+				disabled: Morebits.ip.isRange(relevantUserName)
 			}
 		]
 	});
@@ -254,7 +254,7 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 		$form.find('[name=actiontype][value=template]').prop('disabled', true).prop('checked', false);
 	} else {
 		relevantUserName = mw.config.get('wgRelevantUserName');
-		$form.find('[name=actiontype][value=template]').prop('disabled', !mw.util.isIPv6Address(relevantUserName)).prop('checked', mw.util.isIPv6Address(relevantUserName));
+		$form.find('[name=actiontype][value=template]').prop('disabled', Morebits.ip.isRange(relevantUserName)).prop('checked', !Morebits.ip.isRange(relevantUserName));
 	}
 
 	// Refetch/reprocess user info then regenerate the main content
@@ -1574,7 +1574,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 		var list = $.map(blockGroup.list, function(blockPreset) {
 			// only show {{uw-talkrevoked}} if reblocking or {{rangeblock}} if rangeblocking
 			if ((blockPreset.value === 'uw-talkrevoked' && blockedUserName !== relevantUserName) ||
-				(blockPreset.value === 'rangeblock' && (mw.util.isIPAddress(relevantUserName) || !mw.util.isIPAddress(relevantUserName, true)))) {
+				(blockPreset.value === 'rangeblock' && !Morebits.ip.isRange(relevantUserName))) {
 				return;
 			}
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -19,7 +19,7 @@ Twinkle.block = function twinkleblock() {
 	relevantUserName = mw.config.get('wgRelevantUserName');
 	// should show on Contributions or Block pages, anywhere there's a relevant user
 	// Ignore ranges wider than the CIDR limit
-	if (Morebits.userIsSysop && relevantUserName && (!mw.util.isIPAddress(relevantUserName, true) || mw.util.isIPAddress(relevantUserName) || Morebits.validCIDR(relevantUserName))) {
+	if (Morebits.userIsSysop && relevantUserName && (!mw.util.isIPAddress(relevantUserName, true) || mw.util.isIPAddress(relevantUserName) || Morebits.ip.validCIDR(relevantUserName))) {
 		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
@@ -84,15 +84,15 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	  Add option for IPv6 ranges smaller than /64 to upgrade to the 64
 	  CIDR ([[WP:/64]]).  This is one of the few places where we want
 	  wgRelevantUserName since this depends entirely on the original user.
-	  In theory, we shouldn't use Morebits.get64 here since since we want
+	  In theory, we shouldn't use Morebits.ip.get64 here since since we want
 	  to exclude functionally-equivalent /64s.  That'd be:
 	  // if (mw.util.isIPv6Address(mw.config.get('wgRelevantUserName'), true) &&
 	  // (mw.util.isIPv6Address(mw.config.get('wgRelevantUserName')) || parseInt(mw.config.get('wgRelevantUserName').replace(/^(.+?)\/?(\d{1,3})?$/, '$2'), 10) > 64)) {
 	  In practice, though, since functionally-equivalent ranges are
 	  (mis)treated as separate by MediaWiki's logging ([[phab:T146628]]),
-	  using Morebits.get64 provides a modicum of relief in thise case.
+	  using Morebits.ip.get64 provides a modicum of relief in thise case.
 	*/
-	var sixtyFour = Morebits.get64(mw.config.get('wgRelevantUserName'));
+	var sixtyFour = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 	if (sixtyFour && sixtyFour !== mw.config.get('wgRelevantUserName')) {
 		var block64field = form.append({
 			type: 'field',
@@ -250,7 +250,7 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 	// Single IPv6, or IPv6 range smaller than a /64
 	var priorName = relevantUserName;
 	if ($block64.is(':checked')) {
-		relevantUserName = Morebits.get64(mw.config.get('wgRelevantUserName'));
+		relevantUserName = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 		$form.find('[name=actiontype][value=template]').prop('disabled', true).prop('checked', false);
 	} else {
 		relevantUserName = mw.config.get('wgRelevantUserName');
@@ -731,7 +731,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			if (sameUser) {
 				statusStr += ' as a rangeblock';
 			} else {
-				statusStr += ' within a' + (Morebits.get64(relevantUserName) === blockedUserName ? ' /64' : '') + ' rangeblock';
+				statusStr += ' within a' + (Morebits.ip.get64(relevantUserName) === blockedUserName ? ' /64' : '') + ' rangeblock';
 				// Link to the full range
 				var $rangeblockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: blockedUserName, type: 'block'}) + '">' + blockedUserName + '</a>)'));
 				statusStr += ' (' + $rangeblockloglink.html() + ')';

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -333,7 +333,7 @@ Twinkle.fluff.disableLinks = function disablelinks(parentNode) {
 
 Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 	if (mw.util.isIPv6Address(vandal)) {
-		vandal = Morebits.sanitizeIPv6(vandal);
+		vandal = Morebits.ip.sanitizeIPv6(vandal);
 	}
 
 	var pagename = page || mw.config.get('wgPageName');
@@ -505,7 +505,7 @@ Twinkle.fluff.callbacks = {
 		if (params.revid !== lastrevid) {
 			Morebits.status.warn('Warning', [ 'Latest revision ', Morebits.htmlNode('strong', lastrevid), ' doesn\'t equal our revision ', Morebits.htmlNode('strong', params.revid) ]);
 			// Treat ipv6 users on same 64 block as the same
-			if (lastuser === params.user || (mw.util.isIPv6Address(params.user) && Morebits.get64(lastuser) === Morebits.get64(params.user))) {
+			if (lastuser === params.user || (mw.util.isIPv6Address(params.user) && Morebits.ip.get64(lastuser) === Morebits.ip.get64(params.user))) {
 				switch (params.type) {
 					case 'vand':
 						Morebits.status.info('Info', [ 'Latest revision was made by ', Morebits.htmlNode('strong', userNorm),
@@ -572,7 +572,7 @@ Twinkle.fluff.callbacks = {
 			++count;
 			if (revs[i].user !== params.user) {
 				// Treat ipv6 users on same 64 block as the same
-				if (mw.util.isIPv6Address(revs[i].user) && Morebits.get64(revs[i].user) === Morebits.get64(params.user)) {
+				if (mw.util.isIPv6Address(revs[i].user) && Morebits.ip.get64(revs[i].user) === Morebits.ip.get64(params.user)) {
 					if (!seen64) {
 						new Morebits.status('Note', 'Treating consecutive IPv6 addresses in the same /64 as the same user');
 						seen64 = true;

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -16,8 +16,7 @@
 Twinkle.warn = function twinklewarn() {
 
 	// Users and IPs but not IP ranges
-	if (mw.config.exists('wgRelevantUserName') &&
-		mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) === mw.util.isIPAddress(mw.config.get('wgRelevantUserName'), true)) {
+	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		Twinkle.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&
 			mw.config.get('wgNamespaceNumber') === 3 &&

--- a/morebits.js
+++ b/morebits.js
@@ -1191,6 +1191,17 @@ Morebits.ip = {
 	},
 
 	/**
+	 * Determine if the given IP address is a range.  Just conjoins
+	 * `mw.util.isIPAddress` with and without the `allowBlock` option.
+	 *
+	 * @param {string} ip
+	 * @returns {boolean} - True if given a valid IP address range, false otherwise.
+	 */
+	isRange: function (ip) {
+		return mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip);
+	},
+
+	/**
 	 * Check that an IP range is within the CIDR limits.  Most likely to be useful
 	 * in conjunction with `wgRelevantUserName`.  CIDR limits are harcoded as /16
 	 * for IPv4 and /32 for IPv6.
@@ -1199,7 +1210,7 @@ Morebits.ip = {
 	 * otherwise false (ranges outside the limit, single IPs, non-IPs).
 	 */
 	validCIDR: function (ip) {
-		if (mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip)) {
+		if (Morebits.ip.isRange(ip)) {
 			var subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
 			if (subnet) { // Should be redundant
 				if (mw.util.isIPv6Address(ip, true)) {

--- a/morebits.js
+++ b/morebits.js
@@ -56,6 +56,9 @@ Morebits.userIsInGroup = function (group) {
 Morebits.userIsSysop = Morebits.userIsInGroup('sysop');
 
 /**
+ * Deprecated as of February 2021, use {@link Morebits.ip.sanitizeIPv6}.
+ *
+ * @deprecated Use {@link Morebits.ip.sanitizeIPv6}.
  * Converts an IPv6 address to the canonical form stored and used by MediaWiki.
  * JavaScript translation of the {@link https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/8eb6ac3e84ea3312d391ca96c12c49e3ad0753bb/includes/utils/IP.php#131|`IP::sanitizeIP()`}
  * function from the IPUtils library.  Adddresses are verbose, uppercase,
@@ -65,97 +68,9 @@ Morebits.userIsSysop = Morebits.userIsInGroup('sysop');
  * @returns {string}
  */
 Morebits.sanitizeIPv6 = function (address) {
-	address = address.trim();
-	if (address === '') {
-		return null;
-	}
-	if (!mw.util.isIPv6Address(address, true)) {
-		return address; // nothing else to do for IPv4 addresses or invalid ones
-	}
-	// Remove any whitespaces, convert to upper case
-	address = address.toUpperCase();
-	// Expand zero abbreviations
-	var abbrevPos = address.indexOf('::');
-	if (abbrevPos > -1) {
-		// We know this is valid IPv6. Find the last index of the
-		// address before any CIDR number (e.g. "a:b:c::/24").
-		var CIDRStart = address.indexOf('/');
-		var addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
-		// If the '::' is at the beginning...
-		var repeat, extra, pad;
-		if (abbrevPos === 0) {
-			repeat = '0:';
-			extra = address === '::' ? '0' : ''; // for the address '::'
-			pad = 9; // 7+2 (due to '::')
-		// If the '::' is at the end...
-		} else if (abbrevPos === (addressEnd - 1)) {
-			repeat = ':0';
-			extra = '';
-			pad = 9; // 7+2 (due to '::')
-		// If the '::' is in the middle...
-		} else {
-			repeat = ':0';
-			extra = ':';
-			pad = 8; // 6+2 (due to '::')
-		}
-		var replacement = repeat;
-		pad -= address.split(':').length - 1;
-		for (var i = 1; i < pad; i++) {
-			replacement += repeat;
-		}
-		replacement += extra;
-		address = address.replace('::', replacement);
-	}
-	// Remove leading zeros from each bloc as needed
-	return address.replace(/(^|:)0+([0-9A-Fa-f]{1,4})/g, '$1$2');
+	console.warn('NOTE: Morebits.sanitizeIPv6 was renamed to Morebits.ip.sanitizeIPv6 in February 2021, please use that instead'); // eslint-disable-line no-console
+	return Morebits.ip.sanitizeIPv6(address);
 };
-
-/**
- * Check that an IP range is within the CIDR limits.  Most likely to be useful
- * in conjunction with `wgRelevantUserName`.  CIDR limits are harcoded as /16
- * for IPv4 and /32 for IPv6.
- *
- * @returns {boolean} - True for valid ranges within the CIDR limits,
- * otherwise false (ranges outside the limit, single IPs, non-IPs).
- */
-Morebits.validCIDR = function (ip) {
-	if (mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip)) {
-		var subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
-		if (subnet) { // Should be redundant
-			if (mw.util.isIPv6Address(ip, true)) {
-				if (subnet >= 32) {
-					return true;
-				}
-			} else {
-				if (subnet >= 16) {
-					return true;
-				}
-			}
-		}
-	}
-	return false;
-};
-
-/**
- * Get the /64 subnet for an IPv6 address.
- *
- * @param {string} ipv6 - The IPv6 address, with or without a subnet.
- * @returns {boolean|string} - False if not IPv6 or bigger than a 64,
- * otherwise the (sanitized) /64 address.
- */
-Morebits.get64 = function (ipv6) {
-	if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
-		return false;
-	}
-	var subnetMatch = ipv6.match(/\/(\d{1,3})$/);
-	if (subnetMatch && parseInt(subnetMatch[1], 10) < 64) {
-		return false;
-	}
-	ipv6 = Morebits.sanitizeIPv6(ipv6);
-	var ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
-	return ipv6.replace(ip_re, '$1' + '0:0:0:0/64');
-};
-
 
 /**
  * Determines whether the current page is a redirect or soft redirect. Fails
@@ -1211,6 +1126,115 @@ HTMLFormElement.prototype.getUnchecked = function(name, type) {
 		}
 	}
 	return return_array;
+};
+
+/**
+ * Utilities to help process IP addresses.
+ *
+ * @namespace Morebits.ip
+ * @memberof Morebits
+ */
+Morebits.ip = {
+	/**
+	 * Converts an IPv6 address to the canonical form stored and used by MediaWiki.
+	 * JavaScript translation of the {@link https://gerrit.wikimedia.org/r/plugins/gitiles/mediawiki/core/+/8eb6ac3e84ea3312d391ca96c12c49e3ad0753bb/includes/utils/IP.php#131|`IP::sanitizeIP()`}
+	 * function from the IPUtils library.  Adddresses are verbose, uppercase,
+	 * normalized, and expanded to 8 words.
+	 *
+	 * @param {string} address - The IPv6 address, with or without CIDR.
+	 * @returns {string}
+	 */
+	sanitizeIPv6: function (address) {
+		address = address.trim();
+		if (address === '') {
+			return null;
+		}
+		if (!mw.util.isIPv6Address(address, true)) {
+			return address; // nothing else to do for IPv4 addresses or invalid ones
+		}
+		// Remove any whitespaces, convert to upper case
+		address = address.toUpperCase();
+		// Expand zero abbreviations
+		var abbrevPos = address.indexOf('::');
+		if (abbrevPos > -1) {
+			// We know this is valid IPv6. Find the last index of the
+			// address before any CIDR number (e.g. "a:b:c::/24").
+			var CIDRStart = address.indexOf('/');
+			var addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
+			// If the '::' is at the beginning...
+			var repeat, extra, pad;
+			if (abbrevPos === 0) {
+				repeat = '0:';
+				extra = address === '::' ? '0' : ''; // for the address '::'
+				pad = 9; // 7+2 (due to '::')
+				// If the '::' is at the end...
+			} else if (abbrevPos === (addressEnd - 1)) {
+				repeat = ':0';
+				extra = '';
+				pad = 9; // 7+2 (due to '::')
+				// If the '::' is in the middle...
+			} else {
+				repeat = ':0';
+				extra = ':';
+				pad = 8; // 6+2 (due to '::')
+			}
+			var replacement = repeat;
+			pad -= address.split(':').length - 1;
+			for (var i = 1; i < pad; i++) {
+				replacement += repeat;
+			}
+			replacement += extra;
+			address = address.replace('::', replacement);
+		}
+		// Remove leading zeros from each bloc as needed
+		return address.replace(/(^|:)0+([0-9A-Fa-f]{1,4})/g, '$1$2');
+	},
+
+	/**
+	 * Check that an IP range is within the CIDR limits.  Most likely to be useful
+	 * in conjunction with `wgRelevantUserName`.  CIDR limits are harcoded as /16
+	 * for IPv4 and /32 for IPv6.
+	 *
+	 * @returns {boolean} - True for valid ranges within the CIDR limits,
+	 * otherwise false (ranges outside the limit, single IPs, non-IPs).
+	 */
+	validCIDR: function (ip) {
+		if (mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip)) {
+			var subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
+			if (subnet) { // Should be redundant
+				if (mw.util.isIPv6Address(ip, true)) {
+					if (subnet >= 32) {
+						return true;
+					}
+				} else {
+					if (subnet >= 16) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	},
+
+	/**
+	 * Get the /64 subnet for an IPv6 address.
+	 *
+	 * @param {string} ipv6 - The IPv6 address, with or without a subnet.
+	 * @returns {boolean|string} - False if not IPv6 or bigger than a 64,
+	 * otherwise the (sanitized) /64 address.
+	 */
+	get64: function (ipv6) {
+		if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
+			return false;
+		}
+		var subnetMatch = ipv6.match(/\/(\d{1,3})$/);
+		if (subnetMatch && parseInt(subnetMatch[1], 10) < 64) {
+			return false;
+		}
+		ipv6 = Morebits.ip.sanitizeIPv6(ipv6);
+		var ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
+		return ipv6.replace(ip_re, '$1' + '0:0:0:0/64');
+	}
 };
 
 

--- a/tests/morebits.ip.js
+++ b/tests/morebits.ip.js
@@ -1,0 +1,26 @@
+QUnit.module('Morebits.ip');
+QUnit.test('sanitizeIPv6', assert => {
+	assert.strictEqual(Morebits.ip.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001'), '2001:DB8:10:0:0:0:0:1', 'Shorten IPv6');
+	assert.strictEqual(Morebits.ip.sanitizeIPv6('2001:0db8:0010::1'), '2001:DB8:10:0:0:0:0:1', 'Condensed form');
+	assert.strictEqual(Morebits.ip.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001/42'), '2001:DB8:10:0:0:0:0:1/42', 'Subnet');
+	assert.strictEqual(Morebits.ip.sanitizeIPv6('192.0.2.0'), '192.0.2.0', 'IPv4');
+	assert.strictEqual(Morebits.ip.sanitizeIPv6('Syenite'), 'Syenite', 'Username');
+});
+QUnit.test('validCIDR', assert => {
+	assert.true(Morebits.ip.validCIDR('192.0.2.0/24'), 'IPv4 range');
+	assert.true(Morebits.ip.validCIDR('2001:DB8:10:0:0:0:0:1/42'), 'IPv6 range');
+	assert.true(Morebits.ip.validCIDR('2001:DB8:0010::1/42'), 'IPv6 range condensed');
+	assert.false(Morebits.ip.validCIDR('192.0.2.0'), 'IPv4 single IP');
+	assert.false(Morebits.ip.validCIDR('2001:DB8:10:0:0:0:0:1'), 'IPv6 single IP');
+	assert.false(Morebits.ip.validCIDR('Essun'), 'Username');
+	assert.false(Morebits.ip.validCIDR('192.0.2.0/15'), 'IPv4 range too large');
+	assert.false(Morebits.ip.validCIDR('2001:DB8:10:0:0:0:0:1/31'), 'IPv6 range too large');
+});
+QUnit.test('get64', assert => {
+	assert.strictEqual(Morebits.ip.get64('2001:DB8:10:0:0:0:0:1'), '2001:DB8:10:0:0:0:0:0/64', 'IPv6');
+	assert.strictEqual(Morebits.ip.get64('2001:DB8:10:0:0:0:0:1/65'), '2001:DB8:10:0:0:0:0:0/64', '65 subnet');
+	assert.strictEqual(Morebits.ip.get64('2001:DB8:10:0:0:0:0:1/64'), '2001:DB8:10:0:0:0:0:0/64', '64 subnet');
+	assert.false(Morebits.ip.get64('2001:DB8:10:0:0:0:0:1/63'), '63 subnet');
+	assert.false(Morebits.ip.get64(), 'Missing');
+	assert.false(Morebits.ip.get64('192.0.2.0'), 'IPv4');
+});

--- a/tests/morebits.ip.js
+++ b/tests/morebits.ip.js
@@ -6,6 +6,14 @@ QUnit.test('sanitizeIPv6', assert => {
 	assert.strictEqual(Morebits.ip.sanitizeIPv6('192.0.2.0'), '192.0.2.0', 'IPv4');
 	assert.strictEqual(Morebits.ip.sanitizeIPv6('Syenite'), 'Syenite', 'Username');
 });
+QUnit.test('isRange', assert => {
+	assert.true(Morebits.ip.isRange('192.0.2.0/24'), 'IPv4 range');
+	assert.true(Morebits.ip.isRange('2001:DB8:10:0:0:0:0:1/42'), 'IPv6 range');
+	assert.true(Morebits.ip.isRange('2001:DB8:0010::1/42'), 'IPv6 range condensed');
+	assert.false(Morebits.ip.isRange('192.0.2.0'), 'IPv4 single IP');
+	assert.false(Morebits.ip.isRange('2001:DB8:10:0:0:0:0:1'), 'IPv6 single IP');
+	assert.false(Morebits.ip.isRange('Damaya'), 'Username');
+});
 QUnit.test('validCIDR', assert => {
 	assert.true(Morebits.ip.validCIDR('192.0.2.0/24'), 'IPv4 range');
 	assert.true(Morebits.ip.validCIDR('2001:DB8:10:0:0:0:0:1/42'), 'IPv6 range');

--- a/tests/morebits.js
+++ b/tests/morebits.js
@@ -13,31 +13,6 @@ QUnit.test('userIsInGroup', assert => {
 	assert.false(Morebits.userIsInGroup('Founder'), 'Founder');
 });
 
-QUnit.test('sanitizeIPv6', assert => {
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001'), '2001:DB8:10:0:0:0:0:1', 'Shorten IPv6');
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010::1'), '2001:DB8:10:0:0:0:0:1', 'Condensed form');
-	assert.strictEqual(Morebits.sanitizeIPv6('2001:0db8:0010:0000:0000:0000:0000:0001/42'), '2001:DB8:10:0:0:0:0:1/42', 'Subnet');
-	assert.strictEqual(Morebits.sanitizeIPv6('192.0.2.0'), '192.0.2.0', 'IPv4');
-});
-QUnit.test('validCIDR', assert => {
-	assert.true(Morebits.validCIDR('192.0.2.0/24'), 'IPv4 range');
-	assert.true(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1/42'), 'IPv6 range');
-	assert.true(Morebits.validCIDR('2001:DB8:0010::1/42'), 'IPv6 range condensed');
-	assert.false(Morebits.validCIDR('192.0.2.0'), 'IPv4 single IP');
-	assert.false(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1'), 'IPv6 single IP');
-	assert.false(Morebits.validCIDR('Apple'), 'Username');
-	assert.false(Morebits.validCIDR('192.0.2.0/15'), 'IPv4 range too large');
-	assert.false(Morebits.validCIDR('2001:DB8:10:0:0:0:0:1/31'), 'IPv6 range too large');
-});
-QUnit.test('get64', assert => {
-	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1'), '2001:DB8:10:0:0:0:0:0/64', 'IPv6');
-	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1/65'), '2001:DB8:10:0:0:0:0:0/64', '65 subnet');
-	assert.strictEqual(Morebits.get64('2001:DB8:10:0:0:0:0:1/64'), '2001:DB8:10:0:0:0:0:0/64', '64 subnet');
-	assert.false(Morebits.get64('2001:DB8:10:0:0:0:0:1/63'), '63 subnet');
-	assert.false(Morebits.get64(), 'Missing');
-	assert.false(Morebits.get64('192.0.2.0'), 'IPv4');
-});
-
 QUnit.test('pageNameRegex', assert => {
 	assert.strictEqual(Morebits.pageNameRegex(mw.config.get('wgPageName')), '[Mm]acbeth,[_ ]King[_ ]of[_ ]Scotland', 'First character and spaces');
 	assert.strictEqual(Morebits.pageNameRegex(''), '', 'Empty');


### PR DESCRIPTION
1. morebits: Reorganize IP utilities into Morebits.ip object
2. morebits: Add Morebits.ip.isRange to simplify use of mw.util.isIPAddress.  Equivalent to `mw.util.isIPAddress(ip, true) && !mw.util.isIPAddress(ip)` but saves us the trouble of repeating it throughout.  Used in `Morebits.ip.validCIDR` and various modules.

As discussed in #1266; with the addition of `get64` and `validCIDR`, now is the time to do this since they are obviously unused elsewhere.  Obviously a little dependent on how the feature gets implemented, but should stand.  Some interaction with #1296.