### PR TITLE
Morebits.date.add: parseInt number to be nice, throw if NaN

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1746,11 +1746,15 @@ Morebits.date.prototype = {
 	 * @returns {Morebits.date}
 	 */
 	add: function(number, unit) {
+		var num = parseInt(number, 10); // normalize
+		if (isNaN(num)) {
+			throw new Error('Invalid number "' + number + '" provided.');
+		}
 		unit = unit.toLowerCase(); // normalize
 		var unitMap = Morebits.date.unitMap;
 		var unitNorm = unitMap[unit] || unitMap[unit + 's']; // so that both singular and  plural forms work
 		if (unitNorm) {
-			this['set' + unitNorm](this['get' + unitNorm]() + number);
+			this['set' + unitNorm](this['get' + unitNorm]() + num);
 			return this;
 		}
 		throw new Error('Invalid unit "' + unit + '": Only ' + Object.keys(unitMap).join(', ') + ' are allowed.');

--- a/tests/morebits.date.js
+++ b/tests/morebits.date.js
@@ -52,7 +52,9 @@ QUnit.test('RegEx headers', assert => {
 QUnit.test('add/subtract', assert => {
 	assert.strictEqual(new Morebits.date(timestamp).add(1, 'day').toISOString(), '2020-11-08T16:26:00.000Z', 'Add 1 day');
 	assert.strictEqual(new Morebits.date(timestamp).add(1, 'DaY').toISOString(), '2020-11-08T16:26:00.000Z', 'Loudly add 1 day');
+	assert.strictEqual(new Morebits.date(timestamp).add('1', 'day').toISOString(), '2020-11-08T16:26:00.000Z', "Add 1 day but it's a string");
 	assert.strictEqual(new Morebits.date(timestamp).subtract(1, 'day').toISOString(), '2020-11-06T16:26:00.000Z', 'Subtract 1 day');
+	assert.throws(() => new Morebits.date(timestamp).add('forty-two'), 'throws: non-number provided');
 	assert.throws(() => new Morebits.date(timestamp).add(1), 'throws: no unit');
 	assert.throws(() => new Morebits.date(timestamp).subtract(1, 'dayo'), 'throws: bad unit');
 });


### PR DESCRIPTION
There was a comment about whether to do this or not when first added (https://github.com/wikimedia-gadgets/twinkle/pull/814#discussion_r379708198), but if users pass a string they'll get some extremely unexpected behavior thanks to coercion.

`new Morebits.date('2021-01-01').add('1', 'day').toDateString()`
>Thu Oct 07 2021

`new Morebits.date('2021-01-02').add('1', 'day').toDateString()`
>Mon Jan 11 2021