### PR TITLE
Fixes after renaming of {{Rfd}} and Module:RfD

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -254,7 +254,7 @@ Twinkle.prod.callbacks = {
 			var text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:Redirect for discussion/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1446,7 +1446,7 @@ Twinkle.speedy.callbacks = {
 					return;
 				}
 
-				var xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
+				var xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(Redirect for discussion)/.exec(text);
 				if (xfd && !confirm('The deletion-related template {{' + xfd[1] + '}} was found on the page. Do you still want to add a CSD template?')) {
 					return;
 				}

--- a/morebits.js
+++ b/morebits.js
@@ -113,12 +113,12 @@ Morebits.sanitizeIPv6 = function (address) {
 /**
  * Determines whether the current page is a redirect or soft redirect. Fails
  * to detect soft redirects on edit, history, etc. pages.  Will attempt to
- * detect Module:RfD, with the same failure points.
+ * detect [[Module:Redirect for discussion]], with the same failure points.
  *
  * @returns {boolean}
  */
 Morebits.isPageRedirect = function() {
-	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-RfD').length);
+	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-Redirect_for_discussion').length);
 };
 
 /**


### PR DESCRIPTION
See RM: https://en.wikipedia.org/w/index.php?title=Template_talk:Redirect_for_discussion&oldid=1006311755#Requested_move_4_February_2021

- Module:RfD was renamed, and so was its class; `.box-RfD` thus becomes `.box-Redirect_for_discussion`
- Fix regex check for RfD nomination text in prod and speedy

cc @JJMC89 (PS you made things much smoother by cleaning up all current invocations!)

----

Will put this up now 'cause things be broke.