### PR TITLE
xfd: Use new rfd=yes parameter for {{Xfd edit protected}}

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -750,7 +750,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.getStatusElement().warn('Page protected, requesting edit');
 
 			var editRequest = '{{subst:Xfd edit protected|page=' + pageobj.getPageName() +
-				'|discussion=' + params.discussionpage + '|tag=<nowiki>' + params.tagText + '\u003C/nowiki>}}'; // U+003C: <
+				'|discussion=' + params.discussionpage + (params.venue === 'rfd' ? '|rfd=yes' : '') +
+				'|tag=<nowiki>' + params.tagText + '\u003C/nowiki>}}'; // U+003C: <
 
 			var talk_page = new Morebits.wiki.page(talkName, 'Automatically posting edit request on talk page');
 			talk_page.setNewSectionTitle('Edit request to complete ' + utils.toTLACase(params.venue) + ' nomination');


### PR DESCRIPTION
RfD nominations wrap the entire page content in a template, but the requesting template was just noting the top bit.  Everything should have worked fine, but it's Wrong.  This makes use of the new `rfd=yes` to do it Right.

----

Placeholder pending #1303