### PR TITLE
tests: Fix typo in morebits.string tests

### DIFF
--- a/tests/morebits.string.js
+++ b/tests/morebits.string.js
@@ -30,7 +30,7 @@ QUnit.test('formatReasonText', assert => {
 });
 QUnit.test('isInfinity', assert => {
 	assert.true(Morebits.string.isInfinity('infinity'), 'Infinity');
-	assert.true(Morebits.string.isInfinity('infinity'), 'Indefinite');
+	assert.true(Morebits.string.isInfinity('indefinite'), 'Indefinite');
 	assert.true(Morebits.string.isInfinity('never'), 'Never');
 	assert.true(Morebits.string.isInfinity('infinite'), 'Infinite');
 	assert.false(Morebits.string.isInfinity('always'), 'Always');


### PR DESCRIPTION
There are two "infinity" tests. I think it's a typo.