### PR TITLE
server.js: Set encoding in content-type header

### DIFF
--- a/scripts/server.js
+++ b/scripts/server.js
@@ -17,7 +17,7 @@ const server = http.createServer((request, response) => {
 		if (error) {
 			response.end('Oops, something went wrong: ' + error.code + ' ..\n');
 		} else {
-			response.writeHead(200, { 'Content-Type': contentType });
+			response.writeHead(200, { 'Content-Type': contentType + '; charset=utf-8' });
 			response.end(content, 'utf-8');
 		}
 	});


### PR DESCRIPTION
Setting encoding in `response.end` is not enough. I saw mojibake when I visited the script file in browser. Set encoding in Content-Type header to fix it.