### PR TITLE
tag: Avoid regex inefficiency

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1722,7 +1722,7 @@ Twinkle.tag.callbacks = {
 		// Check for all Rcat shell redirects (from #433)
 		if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
 			// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
-			var oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]*|{{[^}]*}})+)(}})\s*/i);
+			var oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]|{{[^}]+}})+)(}})\s*/i);
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell


### PR DESCRIPTION
CodeQL brought this up (https://github.com/wikimedia-gadgets/twinkle/security/code-scanning/17) and yes, this does have the potential for a catastrophic backtracking reDoS.  In practice, we're unlikely to run into it, but still.