### PR TITLE
remove type=error in mw.notify on TWPREF load failures

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -397,7 +397,7 @@ $.ajax({
 	dataType: 'text'
 })
 	.fail(function () {
-		mw.notify('Could not load your Twinkle preferences', {type: 'error'});
+		mw.notify('Could not load your Twinkle preferences, resorting to default preferences');
 	})
 	.done(function (optionsText) {
 


### PR DESCRIPTION
This occurs frequently on slow internet connections. Twinkle is very much usable without the preferences so there's no need to show a jarring red message.