### PR TITLE
block: Only select {{rangeblock}} for non-/64 ranges

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1541,7 +1541,7 @@ Twinkle.block.blockGroups = [
 			{ label: 'checkuserblock-wide', value: 'checkuserblock-wide' },
 			{ label: 'colocationwebhost', value: 'colocationwebhost' },
 			{ label: 'oversightblock', value: 'oversightblock' },
-			{ label: 'rangeblock', value: 'rangeblock', selected: true }, // Only for IP ranges
+			{ label: 'rangeblock', value: 'rangeblock' }, // Only for IP ranges, selected for non-/64 ranges in filtered_block_groups
 			{ label: 'spamblacklistblock', value: 'spamblacklistblock' },
 			{ label: 'tor', value: 'tor' },
 			{ label: 'webhostblock', value: 'webhostblock' },
@@ -1584,6 +1584,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 					if (!Morebits.ip.isRange(relevantUserName)) {
 						return;
 					}
+					blockPreset.selected = !Morebits.ip.get64(relevantUserName);
 					break;
 				case 'CheckUser block':
 				case 'checkuserblock-account':


### PR DESCRIPTION
As mentioned in https://github.com/wikimedia-gadgets/twinkle/pull/1266#issuecomment-779521407

----

@Molly @ToBeFree This does what I suggested as a resolution for item 1, namely uses {{rangeblock}} only for non-/64 ranges (I'm heading to bed/The Expanse but figured I could whip it up quickly for your perusal).