### PR TITLE
block: Leave block template on the page of the current IP even when blocking a /64

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -73,9 +73,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 				label: 'Add block template to user talk page',
 				value: 'template',
 				tooltip: 'If the blocking admin forgot to issue a block template, or you have just blocked the user without templating them, you can use this to issue the appropriate template. Check the partial block box for partial block templates.',
-				// Disallow for IP ranges
-				checked: !Morebits.ip.isRange(relevantUserName),
-				disabled: Morebits.ip.isRange(relevantUserName)
+				checked: true
 			}
 		]
 	});
@@ -112,7 +110,6 @@ Twinkle.block.callback = function twinkleblockCallback() {
 			list: [{
 				checked: relevantUserName !== mw.config.get('wgRelevantUserName'), // In case the user closes and reopens the form
 				label: 'Block the /64 instead',
-				tooltip: 'Will eschew leaving a template.',
 				value: 'block64'
 			}]
 		});
@@ -251,10 +248,8 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 	var priorName = relevantUserName;
 	if ($block64.is(':checked')) {
 		relevantUserName = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
-		$form.find('[name=actiontype][value=template]').prop('disabled', true).prop('checked', false);
 	} else {
 		relevantUserName = mw.config.get('wgRelevantUserName');
-		$form.find('[name=actiontype][value=template]').prop('disabled', Morebits.ip.isRange(relevantUserName)).prop('checked', !Morebits.ip.isRange(relevantUserName));
 	}
 
 	// Refetch/reprocess user info then regenerate the main content
@@ -1992,7 +1987,9 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 };
 
 Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTemplate(formData) {
-	var userTalkPage = 'User_talk:' + relevantUserName;
+	// Use wgRelevantUserName to ensure the block template goes to a single IP and not to the
+	// "talk page" of an IP range (which does not exist)
+	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
 	var params = $.extend(formData, {
 		messageData: Twinkle.block.blockPresetsInfo[formData.template],

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -73,7 +73,9 @@ Twinkle.block.callback = function twinkleblockCallback() {
 				label: 'Add block template to user talk page',
 				value: 'template',
 				tooltip: 'If the blocking admin forgot to issue a block template, or you have just blocked the user without templating them, you can use this to issue the appropriate template. Check the partial block box for partial block templates.',
-				checked: true
+				// Disallow when viewing the block dialog on an IP range
+				checked: !Morebits.ip.isRange(relevantUserName),
+				disabled: Morebits.ip.isRange(relevantUserName)
 			}
 		]
 	});
@@ -110,7 +112,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 			list: [{
 				checked: relevantUserName !== mw.config.get('wgRelevantUserName'), // In case the user closes and reopens the form
 				label: 'Block the /64 instead',
-				value: 'block64'
+				value: 'block64',
+				tooltip: Morebits.ip.isRange(mw.config.get('wgRelevantUserName')) ? 'Will eschew leaving a template.' : 'Any template issued will go to the original IP: ' + mw.config.get('wgRelevantUserName')
 			}]
 		});
 	}
@@ -251,6 +254,10 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 	} else {
 		relevantUserName = mw.config.get('wgRelevantUserName');
 	}
+	// No templates for ranges, but if the original user is a single IP, offer the option
+	// (done separately in Twinkle.block.callback.issue_template)
+	var originalIsRange = Morebits.ip.isRange(mw.config.get('wgRelevantUserName'));
+	$form.find('[name=actiontype][value=template]').prop('disabled', originalIsRange).prop('checked', !originalIsRange);
 
 	// Refetch/reprocess user info then regenerate the main content
 	var regenerateForm = function() {


### PR DESCRIPTION
Following from the conversation beginning at https://github.com/wikimedia-gadgets/twinkle/pull/1266#issuecomment-779498685, this changes the default behavior to leave a block template on the talk page for the IP whose talk page or contribs the block is originating from, even when the block is being applied to the /64.