### PR TITLE
Pull repetitive namespace-sort into Twinkle function

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -172,10 +172,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		pages = pages.filter(function(page) {
 			return !page.missing && page.imagerepository !== 'shared';
 		});
-		// json formatversion=2 doesn't sort pages by namespace
-		pages.sort(function(one, two) {
-			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-		});
+		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
 			var metadata = [];
 			if (page.redirect) {
@@ -339,10 +336,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				var response = apiobj.getResponse();
 				var pages = (response.query && response.query.pages) || [];
 				var subpageList = [];
-				// json formatversion=2 doesn't sort pages by namespace
-				pages.sort(function(one, two) {
-					return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-				});
+				pages.sort(Twinkle.sortByNamespace);
 				pages.forEach(function(page) {
 					var metadata = [];
 					if (page.redirect) {

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -182,10 +182,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		var response = apiobj.getResponse();
 		var pages = (response.query && response.query.pages) || [];
 		var list = [];
-		// json formatversion=2 doesn't sort pages by namespace
-		pages.sort(function(one, two) {
-			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-		});
+		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
 			var metadata = [];
 			var missing = !!page.missing, editProt;

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -71,10 +71,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 			return page.missing;
 		});
 		var list = [];
-		// json formatversion=2 doesn't sort pages by namespace
-		pages.sort(function(one, two) {
-			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-		});
+		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
 			var editProt = page.protection.filter(function(pr) {
 				return pr.type === 'create' && pr.level === 'sysop';

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -59,10 +59,7 @@ Twinkle.deprod.callback = function() {
 		var pages = (response.query && response.query.pages) || [];
 		var list = [];
 		var re = /\{\{Proposed deletion/;
-		// json formatversion=2 doesn't sort pages by namespace
-		pages.sort(function(one, two) {
-			return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-		});
+		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
 			var metadata = [];
 

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -143,10 +143,7 @@ Twinkle.unlink.callbacks = {
 			var list, namespaces, i;
 
 			if (apiobj.params.image) {
-				var imageusage = response.query.imageusage.sort(function(one, two) {
-					// json formatversion=2 doesn't sort pages by namespace
-					return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-				});
+				var imageusage = response.query.imageusage.sort(Twinkle.sortByNamespace);
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
 					// Label made by Twinkle.generateBatchPageLinks
@@ -195,10 +192,7 @@ Twinkle.unlink.callbacks = {
 				}
 			}
 
-			var backlinks = response.query.backlinks.sort(function(one, two) {
-				// json formatversion=2 doesn't sort pages by namespace
-				return one.ns - two.ns || (one.title > two.title ? 1 : -1);
-			});
+			var backlinks = response.query.backlinks.sort(Twinkle.sortByNamespace);
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -515,6 +515,13 @@ Twinkle.makeFindSourcesDiv = function makeSourcesDiv(divID) {
 	}
 };
 
+/** Twinkle-specific utility functions shared by multiple modules */
+// Used in batch, unlink, and deprod to sort pages by namespace, as
+// json formatversion=2 sorts by pageid instead (#1251)
+Twinkle.sortByNamespace = function(first, second) {
+	return first.ns - second.ns || (first.title > second.title ? 1 : -1);
+};
+
 // Used in batch listings to link to the page in question with >
 Twinkle.generateArrowLinks = function (checkbox) {
 	var link = Morebits.htmlNode('a', ' >');


### PR DESCRIPTION
Not a big deal I suppose, but used seven times, so probably best to pull into a shared function.  Mentioned at https://github.com/wikimedia-gadgets/twinkle/pull/1251#issuecomment-748678116