### PR TITLE
block: Reword uw-efblock reason to say 'Repeatedly triggering' rather than 'Deliberately triggering'

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1049,8 +1049,8 @@ Twinkle.block.blockPresetsInfo = {
 	'uw-efblock': {
 		autoblock: true,
 		nocreate: true,
-		reason: 'Deliberately triggering the [[WP:Edit filter|Edit filter]]',
-		summary: 'You have been blocked from editing for making disruptive edits that repeatedly triggered the [[WP:EF|edit filter]]'
+		reason: 'Repeatedly triggering the [[WP:Edit filter|Edit filter]]',
+		summary: 'You have been blocked from editing for disruptive edits that repeatedly triggered the [[WP:EF|edit filter]]'
 	},
 	'uw-ewblock': {
 		autoblock: true,


### PR DESCRIPTION
Proposed at https://en.wikipedia.org/wiki/MediaWiki_talk:Ipbreason-dropdown#Deliberately_triggering_the_edit_filter_%282%29