### PR TITLE
talkback: Simplify menu a bit, reducing redundant talkback items

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -17,7 +17,6 @@ Twinkle.talkback = function() {
 	if (!mw.config.exists('wgRelevantUserName') || Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		return;
 	}
-
 	Twinkle.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
 };
 
@@ -38,20 +37,12 @@ Twinkle.talkback.callback = function() {
 	form.append({ type: 'radio', name: 'tbtarget',
 		list: [
 			{
-				label: 'Talkback: my talk page',
-				value: 'mytalk',
+				label: 'Talkback',
+				value: 'talkback',
 				checked: 'true'
 			},
 			{
-				label: 'Talkback: other user talk page',
-				value: 'usertalk'
-			},
-			{
-				label: 'Talkback: other page',
-				value: 'other'
-			},
-			{
-				label: '"Please see"',
+				label: 'Please see',
 				value: 'see'
 			},
 			{
@@ -59,7 +50,7 @@ Twinkle.talkback.callback = function() {
 				value: 'notice'
 			},
 			{
-				label: "\"You've got mail\"",
+				label: "You've got mail",
 				value: 'mail'
 			}
 		],
@@ -74,7 +65,7 @@ Twinkle.talkback.callback = function() {
 
 	var previewlink = document.createElement('a');
 	$(previewlink).click(function() {
-		Twinkle.talkback.preview(result);  // |result| is defined below
+		Twinkle.talkback.callbacks.preview(result);  // |result| is defined below
 	});
 	previewlink.style.cursor = 'pointer';
 	previewlink.textContent = 'Preview';
@@ -126,6 +117,7 @@ var prev_message = '';
 Twinkle.talkback.changeTarget = function(e) {
 	var value = e.target.values;
 	var root = e.target.form;
+
 	var old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
 
 	if (root.section) {
@@ -147,7 +139,7 @@ Twinkle.talkback.changeTarget = function(e) {
 	root.previewer.closePreview();
 
 	switch (value) {
-		case 'mytalk':
+		case 'talkback':
 			/* falls through */
 		default:
 			work_area.append({
@@ -156,40 +148,22 @@ Twinkle.talkback.changeTarget = function(e) {
 				style: 'color: red',
 				id: 'twinkle-talkback-optout-message'
 			});
-			work_area.append({
-				type: 'input',
-				name: 'section',
-				label: 'Linked section (optional)',
-				tooltip: 'The section heading on your talk page where you left a message. Leave empty for no section to be linked.',
-				value: prev_section
-			});
-			break;
 
-		case 'usertalk':
-			work_area.append({
-				type: 'div',
-				label: '',
-				style: 'color: red',
-				id: 'twinkle-talkback-optout-message'
-			});
 			work_area.append({
 				type: 'input',
 				name: 'page',
-				label: 'User (required)',
-				tooltip: 'The username of the user on whose talk page you left a message. Required.',
-				value: prev_page,
-				required: true
+				label: 'Page name of the discussion',
+				tooltip: "The page name where the discussion is being held. For example: 'User talk:Jimbo Wales' or Wikipedia talk:Twinkle'.",
+				value: prev_page || 'User talk:' + mw.config.get('wgUserName')
 			});
-
 			work_area.append({
 				type: 'input',
 				name: 'section',
 				label: 'Linked section (optional)',
-				tooltip: 'The section heading on the page where you left a message. Leave empty for no section to be linked.',
+				tooltip: "The section heading where the discussion is being held. For example: 'Merge proposal'.",
 				value: prev_section
 			});
 			break;
-
 		case 'notice':
 			var noticeboard = work_area.append({
 				type: 'select',
@@ -197,11 +171,11 @@ Twinkle.talkback.changeTarget = function(e) {
 				label: 'Noticeboard:',
 				event: function(e) {
 					if (e.target.value === 'afchd') {
-						Morebits.quickForm.overrideElementLabel(e.target.form.section, 'Title of draft (excluding the prefix): ');
-						Morebits.quickForm.setElementTooltipVisibility(e.target.form.section, false);
+						Morebits.quickForm.overrideElementLabel(root.section, 'Title of draft (excluding the prefix): ');
+						Morebits.quickForm.setElementTooltipVisibility(root.section, false);
 					} else {
-						Morebits.quickForm.resetElementLabel(e.target.form.section);
-						Morebits.quickForm.setElementTooltipVisibility(e.target.form.section, true);
+						Morebits.quickForm.resetElementLabel(root.section);
+						Morebits.quickForm.setElementTooltipVisibility(root.section, true);
 					}
 				}
 			});
@@ -223,56 +197,12 @@ Twinkle.talkback.changeTarget = function(e) {
 				value: prev_section
 			});
 			break;
-
-		case 'other':
-			work_area.append({
-				type: 'div',
-				label: '',
-				style: 'color: red',
-				id: 'twinkle-talkback-optout-message'
-			});
-			work_area.append({
-				type: 'input',
-				name: 'page',
-				label: 'Full page name (required)',
-				tooltip: "The full page name where you left the message. For example: 'Wikipedia talk:Twinkle'. Required.",
-				value: prev_page,
-				required: true
-			});
-
-			work_area.append({
-				type: 'input',
-				name: 'section',
-				label: 'Linked section (optional)',
-				tooltip: 'The section heading on the page where you left a message. Leave empty for no section to be linked.',
-				value: prev_section
-			});
-			break;
-
 		case 'mail':
 			work_area.append({
 				type: 'input',
 				name: 'section',
 				label: 'Subject of email (optional)',
 				tooltip: 'The subject line of the email you sent.'
-			});
-			break;
-
-		case 'see':
-			work_area.append({
-				type: 'input',
-				name: 'page',
-				label: 'Full page name (required)',
-				tooltip: "The full page name of where the discussion is being held. For example: 'Wikipedia talk:Twinkle'. Required.",
-				value: prev_page,
-				required: true
-			});
-			work_area.append({
-				type: 'input',
-				name: 'section',
-				label: 'Linked section (optional)',
-				tooltip: "The section heading where the discussion is being held. For example: 'Merge proposal'.",
-				value: prev_section
 			});
 			break;
 	}
@@ -388,9 +318,6 @@ Twinkle.talkback.evaluate = function(e) {
 	Morebits.wiki.actionCompleted.redirect = fullUserTalkPageName;
 	Morebits.wiki.actionCompleted.notice = 'Talkback complete; reloading talk page in a few seconds';
 
-	// Not used for notice or mail
-	input.page = input.page || mw.config.get('wgUserName');
-
 	switch (input.tbtarget) {
 		case 'notice':
 			talkpage.setEditSummary(Twinkle.talkback.noticeboards[input.noticeboard].editSummary);
@@ -399,18 +326,18 @@ Twinkle.talkback.evaluate = function(e) {
 			talkpage.setEditSummary("Notification: You've got mail");
 			break;
 		case 'see':
+			input.page = Twinkle.talkback.callbacks.normalizeTalkbackPage(input.page);
 			talkpage.setEditSummary('Please check the discussion at [[:' + input.page +
 			(input.section ? '#' + input.section : '') + ']]');
 			break;
-		default:  // tbtarget one of mytalk, usertalk, other
-			var editSummary = 'Talkback ([[:';
-			if (input.tbtarget !== 'other' && !new RegExp('^\\s*' + Morebits.namespaceRegex(3) + ':', 'i').test(input.page)) {
-				editSummary += 'User talk:';
-			}
-			talkpage.setEditSummary(editSummary + input.page + (input.section ? '#' + input.section : '') + ']])');
+		default:  // talkback
+			input.page = Twinkle.talkback.callbacks.normalizeTalkbackPage(input.page);
+			talkpage.setEditSummary('Talkback ([[:' + input.page +
+			(input.section ? '#' + input.section : '') + ']])');
+			break;
 	}
 
-	talkpage.setAppendText('\n\n' + Twinkle.talkback.getNoticeWikitext(input));
+	talkpage.setAppendText('\n\n' + Twinkle.talkback.callbacks.getNoticeWikitext(input));
 	talkpage.setChangeTags(Twinkle.changeTags);
 	talkpage.setCreateOption('recreate');
 	talkpage.setMinorEdit(Twinkle.getPref('markTalkbackAsMinor'));
@@ -418,54 +345,72 @@ Twinkle.talkback.evaluate = function(e) {
 	talkpage.append();
 };
 
-Twinkle.talkback.preview = function(form) {
-	var input = Morebits.quickForm.getInputData(form);
+Twinkle.talkback.callbacks = {
+	// Not used for notice or mail, default to user page
+	normalizeTalkbackPage: function(page) {
+		page = page || mw.config.get('wgUserName');
 
-	if (input.tbtarget !== 'notice') {
-		// usertalk, other, see
-		input.page = input.page || mw.config.get('wgUserName');
-	}
-
-	var noticetext = Twinkle.talkback.getNoticeWikitext(input);
-	form.previewer.beginRender(noticetext, 'User_talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
-};
-
-Twinkle.talkback.getNoticeWikitext = function(input) {
-	var text;
-
-	switch (input.tbtarget) {
-		case 'notice':
-			text = Morebits.string.safeReplace(Twinkle.talkback.noticeboards[input.noticeboard].text, '$SECTION', input.section);
-			break;
-		case 'mail':
-			text =
-				'==' + Twinkle.getPref('mailHeading') + '==\n' +
-				"{{You've got mail|subject=" + input.section + '|ts=~~~~~}}';
-
-			if (input.message) {
-				text += '\n' + input.message + '  ~~~~';
-			} else if (Twinkle.getPref('insertTalkbackSignature')) {
-				text += '\n~~~~';
+		// Assume no prefix is a username, convert to user talk space
+		var normal = mw.Title.newFromText(page, 3);
+		// Normalize erroneous or likely mis-entered items
+		if (normal) {
+			// Only allow talks and WPspace
+			if (normal.namespace !== 4) {
+				normal = normal.getTalkPage();
 			}
-			break;
-		case 'see':
-			text = '{{subst:Please see|location=' + input.page + (input.section ? '#' + input.section : '') + '|more=' + input.message + '}}';
-			break;
-		default:  // tbtarget one of mytalk, usertalk, other
-			// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
-			text =
-				'==' + Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n' +
-				'{{talkback|' + input.page + (input.section ? '|' + input.section : '') + '|ts=~~~~~}}';
+			page = normal.getPrefixedText();
+		}
+		return page;
+	},
 
-			if (input.message) {
-				text += '\n' + input.message + ' ~~~~';
-			} else if (Twinkle.getPref('insertTalkbackSignature')) {
-				text += '\n~~~~';
-			}
+	preview: function(form) {
+		var input = Morebits.quickForm.getInputData(form);
+
+		if (input.tbtarget === 'talkback' || input.tbtarget === 'see') {
+			input.page = Twinkle.talkback.callbacks.normalizeTalkbackPage(input.page);
+		}
+
+		var noticetext = Twinkle.talkback.callbacks.getNoticeWikitext(input);
+		form.previewer.beginRender(noticetext, 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
+	},
+
+	getNoticeWikitext: function(input) {
+		var text;
+
+		switch (input.tbtarget) {
+			case 'notice':
+				text = Morebits.string.safeReplace(Twinkle.talkback.noticeboards[input.noticeboard].text, '$SECTION', input.section);
+				break;
+			case 'mail':
+				text = '==' + Twinkle.getPref('mailHeading') + '==\n' +
+					"{{You've got mail|subject=" + input.section + '|ts=~~~~~}}';
+
+				if (input.message) {
+					text += '\n' + input.message + '  ~~~~';
+				} else if (Twinkle.getPref('insertTalkbackSignature')) {
+					text += '\n~~~~';
+				}
+				break;
+			case 'see':
+				// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
+				var heading = Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1');
+				text = '{{subst:Please see|location=' + input.page + (input.section ? '#' + input.section : '') +
+				'|more=' + input.message + '|heading=' + heading + '}}';
+				break;
+			default:  // talkback
+				// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
+				text = '==' + Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n' +
+					'{{talkback|' + input.page + (input.section ? '|' + input.section : '') + '|ts=~~~~~}}';
+
+				if (input.message) {
+					text += '\n' + input.message + ' ~~~~';
+				} else if (Twinkle.getPref('insertTalkbackSignature')) {
+					text += '\n~~~~';
+				}
+		}
+		return text;
 	}
-	return text;
 };
-
 Twinkle.addInitCallback(Twinkle.talkback, 'talkback');
 })(jQuery);
 

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -694,7 +694,7 @@ Twinkle.config.sections = [
 			},
 			{
 				name: 'talkbackHeading',
-				label: 'Section heading to use for talkbacks',
+				label: 'Section heading to use for talkback and please see',
 				type: 'string'
 			},
 			{


### PR DESCRIPTION
Coallesces the three {{talkback}} options into one, with the location defaulting to your own user talk page for {{talkback}} and {{please see}}, aka roughly what was suggested at https://github.com/wikimedia-gadgets/twinkle/pull/929#issuecomment-707630150 by @sidarthvp, less the {{whisperback}}-related stuff.  Ensures only project- and talkspaces will be used.

{{whisperback}} might still be good to add, though I haven't looked much since it was merged and became a wrapper.