### PR TITLE
talkback: Remove cleanup for talkbackHeading prefs with erroneous equals signs

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -392,14 +392,12 @@ Twinkle.talkback.callbacks = {
 				}
 				break;
 			case 'see':
-				// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
-				var heading = Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1');
+				var heading = Twinkle.getPref('talkbackHeading');
 				text = '{{subst:Please see|location=' + input.page + (input.section ? '#' + input.section : '') +
 				'|more=' + input.message + '|heading=' + heading + '}}';
 				break;
 			default:  // talkback
-				// clean talkback heading: strip section header markers that were erroneously suggested in the documentation
-				text = '==' + Twinkle.getPref('talkbackHeading').replace(/^\s*=+\s*(.*?)\s*=+$\s*/, '$1') + '==\n' +
+				text = '==' + Twinkle.getPref('talkbackHeading') + '==\n' +
 					'{{talkback|' + input.page + (input.section ? '|' + input.section : '') + '|ts=~~~~~}}';
 
 				if (input.message) {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -695,11 +695,13 @@ Twinkle.config.sections = [
 			{
 				name: 'talkbackHeading',
 				label: 'Section heading to use for talkback and please see',
+				tooltip: 'Should NOT include the equals signs ("==") used for wikitext formatting',
 				type: 'string'
 			},
 			{
 				name: 'mailHeading',
 				label: "Section heading to use for \"you've got mail\" notices",
+				tooltip: 'Should NOT include the equals signs ("==") used for wikitext formatting',
 				type: 'string'
 			}
 		]


### PR DESCRIPTION
This was added in 2010 ([sysop-only link](https://en.wikipedia.org/w/index.php?title=Special:Undelete&target=User:Ioeth/friendlytalkback.js&timestamp=20100623142531&diff=prev)) to fix an issue with the [old Friendly documentation](https://en.wikipedia.org/w/index.php?title=Wikipedia:Friendly&oldid=410035412#Parameter_Descriptions).  In an ideal world, we'd have ways to clean up erroneous entries in preferences, but for this, I think we can remove it.  There are, on enWiki, on [five instances](https://en.wikipedia.org/w/index.php?title=Special:Search&limit=250&offset=0&ns2=1&sort=last_edit_desc&search=insource:/talkbackHeading/+intitle:twinkleoptions&advancedSearc$), with only three of those editors active.  I can ping them or clean those up directly, but I don't think we need to hold on to this.

I added tooltip instructions in the prefs for this, and for the mail heading, which we don't have a check for.