### PR TITLE
morebits.css: Add 2px margin-right to checkboxes, clearer spacing between elements

### DIFF
--- a/morebits.css
+++ b/morebits.css
@@ -68,8 +68,9 @@ form.quickform select
 form.quickform input[type=checkbox],
 form.quickform input[type=radio] {
 	height: 13px;
-	margin-bottom: 2px;
 	margin-top: 2px;
+	margin-right: 2px;
+	margin-bottom: 2px;
 	padding: 0;
 	width: 13px;
 	vertical-align: top;


### PR DESCRIPTION
The label for a checkbox or radio button was abutting just too close to the box/button on Vector/Timeless/Monobook (not Modern?), this should space them out a little more clearly.