### PR TITLE
speedy: F7a (immediate deletion of invalid fair-use tag) removed after RfC

### DIFF
--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -79,7 +79,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 			{
 				label: 'Disputed fair use rationale (CSD F7)',
 				value: 'disputed fair use rationale',
-				tooltip: 'Image or media has a fair use rationale that is disputed'
+				tooltip: 'Image or media has a fair use rationale that is disputed or invalid, such as a {{Non-free logo}} tag on a photograph of a mascot'
 			},
 			{
 				label: 'Replaceable fair use (CSD F7)',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -557,20 +557,9 @@ Twinkle.speedy.fileList = [
 		hideWhenUser: true
 	},
 	{
-		label: 'F7: Clearly invalid fair-use tag',
-		value: 'badfairuse',  // same as below
-		tooltip: 'This is only for files with a clearly invalid fair-use tag, such as a {{Non-free logo}} tag on a photograph of a mascot. For cases that require a waiting period (replaceable images or otherwise disputed rationales), use the options on Twinkle\'s DI tab.',
-		subgroup: {
-			name: 'badfairuse_rationale',
-			type: 'input',
-			label: 'Optional explanation: ',
-			size: 60
-		}
-	},
-	{
 		label: 'F7: Fair-use media from a commercial image agency which is not the subject of sourced commentary',
-		value: 'badfairuse',  // same as above
-		tooltip: 'Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC.',
+		value: 'badfairuse',
+		tooltip: 'Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC. For cases that require a waiting period (invalid or otherwise disputed rationales or replaceable images), use the options on Twinkle\'s DI tab.',
 		subgroup: {
 			name: 'badfairuse_rationale',
 			type: 'input',


### PR DESCRIPTION
Incredibly premature, but tracking https://en.wikipedia.org/wiki/Wikipedia_talk:Criteria_for_speedy_deletion#RfC:_Deprecate_criterion_a._from_F7