### PR TITLE
morebits: Update statusElement on successful lookupCreation

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -3883,6 +3883,8 @@ Morebits.wiki.page = function(pageName, status) {
 				ctx.onLookupCreationFailure(this);
 				return;
 			}
+
+			ctx.statusElement.info('retrieved page creation information');
 			ctx.onLookupCreationSuccess(this);
 
 		} else {
@@ -3925,6 +3927,7 @@ Morebits.wiki.page = function(pageName, status) {
 			return;
 		}
 
+		ctx.statusElement.info('retrieved page creation information');
 		ctx.onLookupCreationSuccess(this);
 
 	};


### PR DESCRIPTION
`lookupCreation` would often leave a hanging status message when used on a new/separate instance of `Morebits.wiki.page` since we were never actually registering a success.  When using the original page object, things would be fine, since the corresponding method would typically pick up the slack.  Fixes #1049.