### PR TITLE
tag: Use separate mb.w.page instance for lookup

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1349,7 +1349,7 @@ Twinkle.tag.callbacks = {
 					});
 				}
 				if (params.translationNotify) {
-					pageobj.lookupCreation(function(innerPageobj) {
+					new Morebits.wiki.page(Morebits.pageNameNorm).lookupCreation(function(innerPageobj) {
 						var initialContrib = innerPageobj.getCreator();
 
 						// Disallow warning yourself


### PR DESCRIPTION
Otherwise you get "Tagging article" associated with the lookup message, which doesn't make much sense.  Especially improved along with #1339.