### PR TITLE
Add Morebits.wiki.user class for user info and processing

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1382,6 +1382,7 @@ Twinkle.tag.callbacks = {
 							(params.translationPostAtPNT ? '' : '|nopnt=yes') + '}} ~~~~');
 						user.setReason('Notice: Please use English when contributing to the English Wikipedia.');
 						user.setChangeTags(Twinkle.changeTags);
+						user.setNotifySkips(Twinkle.makeOptoutLink('tag'), Twinkle.optoutTemplates);
 						user.notify();
 					});
 				}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1375,16 +1375,14 @@ Twinkle.tag.callbacks = {
 							return;
 						}
 
-						var userTalkPage = new Morebits.wiki.page('User talk:' + initialContrib,
+						var user = new Morebits.wiki.user(initialContrib,
 							'Notifying initial contributor (' + initialContrib + ')');
-						userTalkPage.setNewSectionTitle('Your article [[' + Morebits.pageNameNorm + ']]');
-						userTalkPage.setNewSectionText('{{subst:uw-notenglish|1=' + Morebits.pageNameNorm +
+						user.setSectionTitle('Your article [[' + Morebits.pageNameNorm + ']]');
+						user.setMessage('{{subst:uw-notenglish|1=' + Morebits.pageNameNorm +
 							(params.translationPostAtPNT ? '' : '|nopnt=yes') + '}} ~~~~');
-						userTalkPage.setEditSummary('Notice: Please use English when contributing to the English Wikipedia.');
-						userTalkPage.setChangeTags(Twinkle.changeTags);
-						userTalkPage.setCreateOption('recreate');
-						userTalkPage.setFollowRedirect(true, false);
-						userTalkPage.newSection();
+						user.setReason('Notice: Please use English when contributing to the English Wikipedia.');
+						user.setChangeTags(Twinkle.changeTags);
+						user.notify();
 					});
 				}
 			});

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -99,31 +99,16 @@ Twinkle.arv.callback = function (uid, isIP) {
 	Window.display();
 
 	// Check if the user is blocked, update notice
-	var query = {
-		action: 'query',
-		list: 'blocks',
-		bkprop: 'range|flags',
-		format: 'json'
-	};
-	if (isIP) {
-		query.bkip = uid;
-	} else {
-		query.bkusers = uid;
-	}
-	new Morebits.wiki.api("Checking the user's block status", query, function(apiobj) {
-		var blocklist = apiobj.getResponse().query.blocks;
-		if (blocklist.length) {
-			// If an IP is blocked *and* rangeblocked, only use whichever is more recent
-			var block = blocklist[0];
-			var message = (isIP ? 'This IP ' + (Morebits.ip.isRange(uid) ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
-			// Start and end differ, range blocked
-			message += block.rangestart !== block.rangeend ? ' as part of a rangeblock.' : '.';
-			if (block.partial) {
+	new Morebits.wiki.user(uid, "Checking the user's block status").load(function(userobj) {
+		if (userobj.isBlocked()) {
+			var message = (isIP ? 'This IP ' + (userobj.isIPRange() ? 'range' : 'address') : 'This account') + ' is ' + (userobj.getPartial() ? 'partially' : 'already') + ' blocked';
+			message += userobj.isRangeBlocked() ? ' as part of a rangeblock.' : '.';
+			if (userobj.getPartial()) {
 				$('#twinkle-arv-blockwarning').css('color', 'black'); // Less severe
 			}
 			$('#twinkle-arv-blockwarning').text(message);
 		}
-	}).post();
+	});
 
 
 	// We must init the

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -826,12 +826,12 @@ Twinkle.arv.processSock = function(params) {
 		var notifyText = '\n\n{{subst:socksuspectnotice|1=' + params.uid + '}} ~~~~';
 
 		// notify user's master account
-		var masterTalkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying suspected sockpuppeteer');
-		masterTalkPage.setFollowRedirect(true);
-		masterTalkPage.setEditSummary(notifyEditSummary);
-		masterTalkPage.setChangeTags(Twinkle.changeTags);
-		masterTalkPage.setAppendText(notifyText);
-		masterTalkPage.append();
+		var userPuppeteer = new Morebits.wiki.user(params.uid, 'Notifying suspected sockpuppeteer');
+		userPuppeteer.setReason(notifyEditSummary);
+		userPuppeteer.setChangeTags(Twinkle.changeTags);
+		userPuppeteer.setMessage(notifyText);
+		userPuppeteer.setNotifyBots(true); // Just in case
+		userPuppeteer.notify();
 
 		var statusIndicator = new Morebits.status('Notifying suspected sockpuppets', '0%');
 		var total = params.sockpuppets.length;
@@ -851,12 +851,12 @@ Twinkle.arv.processSock = function(params) {
 
 		// notify each puppet account
 		for (var i = 0; i < socks.length; ++i) {
-			var sockTalkPage = new Morebits.wiki.page('User talk:' + socks[i], 'Notification for ' + socks[i]);
-			sockTalkPage.setFollowRedirect(true);
-			sockTalkPage.setEditSummary(notifyEditSummary);
-			sockTalkPage.setChangeTags(Twinkle.changeTags);
-			sockTalkPage.setAppendText(notifyText);
-			sockTalkPage.append(onSuccess);
+			var sockUser = new Morebits.wiki.user(socks[i], 'Notification for ' + socks[i]);
+			sockUser.setReason(notifyEditSummary);
+			sockUser.setChangeTags(Twinkle.changeTags);
+			sockUser.setMessage(notifyText);
+			sockUser.setNotifyBots(true); // Just in case
+			sockUser.notify(onSuccess);
 		}
 	}
 
@@ -1011,15 +1011,14 @@ Twinkle.arv.processAN3 = function(params) {
 		an3Page.append();
 
 		// notify user
-
 		var notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
 
-		var talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
-		talkPage.setFollowRedirect(true);
-		talkPage.setEditSummary('Notifying about edit warring noticeboard discussion.');
-		talkPage.setChangeTags(Twinkle.changeTags);
-		talkPage.setAppendText(notifyText);
-		talkPage.append();
+		var user = new Morebits.wiki.user(params.uid, 'Notifying edit warrior');
+		user.setReason('Notifying about edit warring noticeboard discussion.');
+		user.setChangeTags(Twinkle.changeTags);
+		user.setMessage(notifyText);
+		user.setNotifyBots(true);
+		user.notify();
 		Morebits.wiki.removeCheckpoint();  // all page updates have been started
 	}).fail(function(data) {
 		console.log('API failed :(', data); // eslint-disable-line no-console

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -302,6 +302,7 @@ Twinkle.image.callbacks = {
 			user.setMessage(notifytext);
 			user.setReason('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].');
 			user.setChangeTags(Twinkle.changeTags);
+			user.setNotifySkips(Twinkle.makeOptoutLink('csd'), Twinkle.optoutTemplates);
 			// Custom watchlist behavior
 			user.setPageobjectFunctions({setWatchlist: Twinkle.getPref('deliWatchUser')});
 			user.notify();

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -292,19 +292,19 @@ Twinkle.image.callbacks = {
 		if (initialContrib === mw.config.get('wgUserName')) {
 			pageobj.getStatusElement().warn('You (' + initialContrib + ') created this page; skipping user notification');
 		} else {
-			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
+			var user = new Morebits.wiki.user(initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			var notifytext = '\n{{subst:di-' + params.templatename + '-notice|1=' + mw.config.get('wgTitle');
 			if (params.type === 'no permission') {
 				notifytext += params.source ? '|source=' + params.source : '';
 			}
 			notifytext += '}} ~~~~';
-			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].');
-			usertalkpage.setChangeTags(Twinkle.changeTags);
-			usertalkpage.setCreateOption('recreate');
-			usertalkpage.setWatchlist(Twinkle.getPref('deliWatchUser'));
-			usertalkpage.setFollowRedirect(true, false);
-			usertalkpage.append();
+
+			user.setMessage(notifytext);
+			user.setReason('Notification: tagging for deletion of [[:' + Morebits.pageNameNorm + ']].');
+			user.setChangeTags(Twinkle.changeTags);
+			// Custom watchlist behavior
+			user.setPageobjectFunctions({setWatchlist: Twinkle.getPref('deliWatchUser')});
+			user.notify();
 		}
 
 		// add this nomination to the user's userspace log, if the user has enabled it

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -398,12 +398,13 @@ Twinkle.prod.callbacks = {
 		user.setMessage(notifytext);
 		user.setReason('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
 		user.setChangeTags(Twinkle.changeTags);
-		// Notify everyone for BLPPROD
+		// Notify everyone for BLPPROD, allow optouts otherwise
 		if (params.blp) {
 			user.setNotifyBots(true);
 			user.setNotifyIndef(true);
+		} else {
+			user.setNotifySkips(Twinkle.makeOptoutLink('prod'), Twinkle.optoutTemplates);
 		}
-
 		user.notify(function onNotifySuccess() {
 			// add nomination to the userspace log, if the user has enabled it
 			params.logInitialContrib = params.initialContrib;

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -394,13 +394,17 @@ Twinkle.prod.callbacks = {
 		}
 		var notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
 
-		var usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
-		usertalkpage.setAppendText(notifytext);
-		usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
-		usertalkpage.setChangeTags(Twinkle.changeTags);
-		usertalkpage.setCreateOption('recreate');
-		usertalkpage.setFollowRedirect(true, false);
-		usertalkpage.append(function onNotifySuccess() {
+		var user = new Morebits.wiki.user(params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
+		user.setMessage(notifytext);
+		user.setReason('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
+		user.setChangeTags(Twinkle.changeTags);
+		// Notify everyone for BLPPROD
+		if (params.blp) {
+			user.setNotifyBots(true);
+			user.setNotifyIndef(true);
+		}
+
+		user.notify(function onNotifySuccess() {
 			// add nomination to the userspace log, if the user has enabled it
 			params.logInitialContrib = params.initialContrib;
 			def.resolve();

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1179,11 +1179,6 @@ Twinkle.speedy.callbacks = {
 			Morebits.status.warn('Notifying initial contributor: this user created their own user talk page; skipping notification');
 			initialContrib = null;
 
-		// quick hack to prevent excessive unwanted notifications, per request. Should actually be configurable on recipient page...
-		} else if ((initialContrib === 'Cyberbot I' || initialContrib === 'SoxBot') && params.normalizeds[0] === 'f2') {
-			Morebits.status.warn('Notifying initial contributor: page created procedurally by bot; skipping notification');
-			initialContrib = null;
-
 		// Check for already existing tags
 		} else if (Twinkle.speedy.hasCSD && params.warnUser && !confirm('The page is has a deletion-related tag, and thus the creator has likely been notified.  Do you want to notify them for this deletion as well?')) {
 			Morebits.status.info('Notifying initial contributor', 'canceled by user; skipping notification.');
@@ -1230,6 +1225,7 @@ Twinkle.speedy.callbacks = {
 			user.setMessage(notifytext);
 			user.setReason(editsummary);
 			user.setChangeTags(Twinkle.changeTags);
+			user.setNotifySkips(Twinkle.makeOptoutLink('csd'), Twinkle.optoutTemplates);
 			// Custom watchlist behavior
 			user.setPageobjectFunctions({setWatchlist: Twinkle.getPref('watchSpeedyUser')});
 			user.notify(function onNotifySuccess() {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1191,7 +1191,7 @@ Twinkle.speedy.callbacks = {
 		}
 
 		if (initialContrib) {
-			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')'),
+			var user = new Morebits.wiki.user(initialContrib, 'Notifying initial contributor (' + initialContrib + ')'),
 				notifytext, i, editsummary;
 
 			// special cases: "db" and "db-multiple"
@@ -1227,13 +1227,12 @@ Twinkle.speedy.callbacks = {
 				editsummary += ' of an attack page.';
 			}
 
-			usertalkpage.setAppendText(notifytext);
-			usertalkpage.setEditSummary(editsummary);
-			usertalkpage.setChangeTags(Twinkle.changeTags);
-			usertalkpage.setCreateOption('recreate');
-			usertalkpage.setWatchlist(Twinkle.getPref('watchSpeedyUser'));
-			usertalkpage.setFollowRedirect(true, false);
-			usertalkpage.append(function onNotifySuccess() {
+			user.setMessage(notifytext);
+			user.setReason(editsummary);
+			user.setChangeTags(Twinkle.changeTags);
+			// Custom watchlist behavior
+			user.setPageobjectFunctions({setWatchlist: Twinkle.getPref('watchSpeedyUser')});
+			user.notify(function onNotifySuccess() {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {
 					Twinkle.speedy.callbacks.user.addToLog(params, initialContrib);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -941,6 +941,7 @@ Twinkle.xfd.callbacks = {
 			wikipedia_user.setMessage(notifytext);
 			wikipedia_user.setReason(editSummary);
 			wikipedia_user.setChangeTags(Twinkle.changeTags);
+			wikipedia_user.setNotifySkips(Twinkle.makeOptoutLink('xfd'), Twinkle.optoutTemplates);
 			// Custom watchlist behavior
 			wikipedia_user.setPageobjectFunctions({setWatchlist: Twinkle.getPref('xfdWatchUser')});
 			if (noLog) {

--- a/morebits.js
+++ b/morebits.js
@@ -4693,7 +4693,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 	userName = Morebits.ip.sanitizeIPv6(userTitle.getMainText());
 
 	if (!currentAction) {
-		currentAction = 'Querying user "' + userName + '"';
+		currentAction = msg('querying-user', userName, 'Querying user "' + userName + '"');
 	}
 
 	/**
@@ -4881,7 +4881,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 			ctx.loadQuery.ellimit = 42;
 		}
 
-		ctx.userApi = new Morebits.wiki.api('Retrieving user information...', ctx.loadQuery, fnLoadSuccess, ctx.statusElement, ctx.onLoadFailure);
+		ctx.userApi = new Morebits.wiki.api(msg('fetching-userinfo', 'Retrieving user information...'), ctx.loadQuery, fnLoadSuccess, ctx.statusElement, ctx.onLoadFailure);
 		ctx.userApi.setParent(this);
 		ctx.userApi.post();
 	};
@@ -4904,7 +4904,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		// clients can do as they please.  This tells when the user
 		// was loaded, which is useful for time-based functions.
 		if (!ctx.loadTime) {
-			ctx.statusElement.error('Failed to retrieve current timestamp.');
+			ctx.statusElement.error(msg('failed-timestamp', 'Failed to retrieve current timestamp.'));
 			ctx.onLoadFailure(this);
 			return;
 		}
@@ -4913,10 +4913,10 @@ Morebits.wiki.user = function(userName, currentAction) {
 		response = response.query;
 
 		// Even if this is unnecessary (notification), an issue here
-		// is a likely indicates *something* went wrong.  The same
+		// likely indicates *something* went wrong.  The same
 		// as Morebits.wiki.page, though it's more necessary there.
 		if (!response.tokens.csrftoken || !response.tokens.userrightstoken) {
-			ctx.statusElement.error('Failed to retrieve tokens.');
+			ctx.statusElement.error(msg('failed-token', 'Failed to retrieve token.'));
 			ctx.onLoadFailure(this);
 			return;
 		}
@@ -4926,7 +4926,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		var user = response.users && response.users[0];
 		// Not sure scenario could lead to this, but might as well be safe
 		if (!user) {
-			ctx.statusElement.error('Failed to retrieve user ' + ctx.userName);
+			ctx.statusElement.error(msg('failed-userinfo', ctx.userName, 'Failed to retrieve user info for ' + ctx.userName));
 			ctx.onLoadFailure(this);
 			// force error to stay on the screen
 			++Morebits.wiki.numberOfActionsLeft;
@@ -5135,11 +5135,11 @@ Morebits.wiki.user = function(userName, currentAction) {
 		// If blocked and reblock is missing, assume we didn't know
 		// the user was already blocked, so ask to toggle
 		if (directBlock && !ctx.reblock) {
-			var message = ctx.userName + ' is already blocked (';
-			message += Morebits.string.isInfinity(this.getBlockExpiry()) ? 'indefinitely' : 'until ' + new Morebits.date(this.getBlockExpiry()).calendar();
-			message += '; by ' + this.getBlockingSysop() + '), would you like to override the block?';
+			var message = Morebits.string.isInfinity(this.getBlockExpiry())
+				? msg('already-blocked-indef', ctx.userName, this.getBlockingSysop(), ctx.userName + ' is already blocked (indefinitely; by ' + this.getBlockingSysop() + '), would you like to override the block?')
+				: msg('already-blocked', ctx.userName, this.getBlockExpiry(), this.getBlockingSysop(), ctx.userName + ' is already blocked (until ' +  new Morebits.date(this.getBlockExpiry()).calendar() + '; by ' + this.getBlockingSysop() + '), would you like to override the block?')
 			if (!confirm(message)) {
-				ctx.statusElement.error('Reblock aborted.');
+				ctx.statusElement.error(msg('reblock-aborted', 'Reblock aborted.'));
 				ctx.onBlockFailure(this);
 				return;
 			}
@@ -5149,7 +5149,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		// setExpiry allows arrays because userrights accepts it, but block doesn't
 		if (Array.isArray(ctx.expiry)) {
 			if (ctx.expiry.length !== 1) {
-				ctx.statusElement.error('You must provide a valid block expiration.');
+				ctx.statusElement.error(msg('invalid-block-expiry', 'You must provide a valid block expiration.'));
 				ctx.onBlockFailure(this);
 				return;
 			}
@@ -5159,16 +5159,14 @@ Morebits.wiki.user = function(userName, currentAction) {
 
 		// Check before indefing IPs or blocking sysops
 		if (ctx.isIP && Morebits.string.isInfinity(ctx.expiry) &&
-			!confirm(ctx.userName + ' is an IP address, do you really want to block it indefinitely?' +
-			'\n\nClick OK to proceed with the block, or Cancel to skip this block.')) {
-			ctx.statusElement.error('Infinite block of IP addressed was aborted.');
+			!confirm(msg('ip-indef-confirm', ctx.userName, ctx.userName + ' is an IP address, do you really want to block it indefinitely?' +
+			'\n\nClick OK to proceed with the block, or Cancel to abort.'))) {
+			ctx.statusElement.error(msg('ip-indef-aborted', 'Indefinite block of IP address was aborted.'));
 			ctx.onBlockFailure(this);
 			return;
 		} else if (this.isSysop() &&
-			!confirm(ctx.userName + ' is an administrator' +
-			(Morebits.string.isInfinity(ctx.grantedGroups.sysop) ? '' : ' (expires ' + new Morebits.date(ctx.grantedGroups.sysop).calendar('utc') + ' (UTC))') +
-			', are you sure you want to block them?  \n\nClick OK to proceed with the block, or Cancel to skip this block.')) {
-			ctx.statusElement.error('Block of administrator was aborted.');
+			!confirm(msg('admin-block-confirm', ctx.userName, ctx.userName + ' is an administrator, are you sure you want to block them?  \n\nClick OK to proceed with the block, or Cancel to abort.'))) {
+			ctx.statusElement.error(msg('admin-block-aborted', 'Block of administrator was aborted.'));
 			ctx.onBlockFailure(this);
 			return;
 		}
@@ -5194,7 +5192,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 					(Array.isArray(ctx.namespacerestrictions) && ctx.namespacerestrictions.indexOf(3) === -1 && ctx.namespacerestrictions.indexOf('3') === -1) ||
 					(typeof ctx.namespacerestrictions === 'string' && ctx.namespacerestrictions.split('|').indexOf('3') === -1) ||
 					(typeof ctx.namespacerestrictions === 'number' && ctx.namespacerestrictions !== 3))) {
-					ctx.statusElement.error('Partial blocks cannot prevent talk page access unless also restricting User talk space.');
+					ctx.statusElement.error(msg('partial-usertalk', 'Partial blocks cannot prevent talk page access unless also restricting User talk namespace.'));
 					ctx.onBlockFailure(this);
 					return;
 				}
@@ -5229,7 +5227,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 			}
 		}
 
-		ctx.blockApi = new Morebits.wiki.api('blocking user...', query, fnBlockSuccess, ctx.statusElement, fnBlockError);
+		ctx.blockApi = new Morebits.wiki.api(msg('blocking', 'blocking user...'), query, fnBlockSuccess, ctx.statusElement, fnBlockError);
 		ctx.blockApi.setParent(this);
 		ctx.blockApi.post();
 	};
@@ -5259,18 +5257,18 @@ Morebits.wiki.user = function(userName, currentAction) {
 		}
 
 		if (!ctx.isBlocked) {
-			ctx.statusElement.error('User is not blocked.');
+			ctx.statusElement.error(msg('not-blocked', 'User is not blocked.'));
 			ctx.onUnblockFailure(this);
 			return;
 		} else if (ctx.blockInfo.user !== ctx.userName) {
-			ctx.statusElement.error('User is not directly blocked, but rather ' + ctx.blockInfo.user + ' is.');
+			ctx.statusElement.error(msg('indirect-block', ctx.blockInfo.user, 'User is not directly blocked, but rather ' + ctx.blockInfo.user + ' is.'));
 			ctx.onUnblockFailure(this);
 			return;
 		}
 
 		var query = fnBaseAction('unblock');
 
-		ctx.unblockApi = new Morebits.wiki.api('unblocking user...', query, fnUnblockSuccess, ctx.statusElement, fnUnblockError);
+		ctx.unblockApi = new Morebits.wiki.api(msg('unblocking', 'unblocking user...'), query, fnUnblockSuccess, ctx.statusElement, fnUnblockError);
 		ctx.unblockApi.setParent(this);
 		ctx.unblockApi.post();
 	};
@@ -5360,13 +5358,13 @@ Morebits.wiki.user = function(userName, currentAction) {
 		ctx.onNotifyFailure = onFailure || emptyFunction;
 
 		if (ctx.isIPRange) {
-			ctx.statusElement.error('Cannot notify IP ranges');
+			ctx.statusElement.error(msg('notify-fail-iprange', 'Cannot notify IP ranges'));
 			ctx.onNotifyFailure(this);
 			return;
 		}
 		// Check underscores
 		if (ctx.notifySelf && ctx.userName === mw.config.get('wgUserName')) {
-			ctx.statusElement.error('Skipping self notification');
+			ctx.statusElement.error(msg('notify-self-skip', ctx.userName, 'You (' + ctx.userName + ') created this page; skipping user notification'));
 			ctx.onNotifyFailure(this);
 			return;
 		}
@@ -5383,7 +5381,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 	var fnProcessNotify = function() {
 		// Empty reason, message, and token handled by Morebits.wiki.page
 		if (!ctx.exists) {
-			ctx.statusElement.error('Cannot notify the user because the user does not exist');
+			ctx.statusElement.error(msg('notify-fail-noexist', 'Cannot notify the user because the user does not exist'));
 			ctx.onNotifyFailure(this);
 			return;
 		}
@@ -5392,7 +5390,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 			// More efficient to do a for loop, but this is prettier?
 			var tlDups = Morebits.array.dups(ctx.talkTemplates.concat(ctx.notifySkipTemplates));
 			if (tlDups.length) {
-				ctx.statusElement.error('User talk page transcludes ' + tlDups[0] + ', aborting notification');
+				ctx.statusElement.error(msg('notify-fail-template', tlDups[0], 'User talk page transcludes {{' + tlDups[0] + '}}, aborting notification'));
 				ctx.onNotifyFailure(this);
 				return;
 			}
@@ -5400,7 +5398,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 			// Should be without leading protocol; relying on mw.Uri could help
 			var elDups = Morebits.array.dups(ctx.talkLinks.concat(ctx.notifySkipLink));
 			if (elDups.length) {
-				ctx.statusElement.error('User has opted out of this notification, aborting');
+				ctx.statusElement.error(msg('notify-fail-optout', 'User has opted out of this notification, aborting'));
 				ctx.onNotifyFailure(this);
 				return;
 			}
@@ -5408,21 +5406,21 @@ Morebits.wiki.user = function(userName, currentAction) {
 		}
 
 		if (!ctx.notifyBots && this.isBot()) {
-			ctx.statusElement.error('User is a bot, aborting notification');
+			ctx.statusElement.error(msg('notify-fail-bot', 'User is a bot, aborting notification'));
 			ctx.onNotifyFailure(this);
 			return;
 		}
 		// Clients may find this most useful iff notalk or the block isn't brand new
 		// ctx.isBlocked intentionally used to account for any indef block, not just direct ones
 		if (!ctx.notifyIndef && ctx.isBlocked && !this.getPartial() && Morebits.string.isInfinity(this.getBlockExpiry())) {
-			ctx.statusElement.error('User is indefinitely blocked, aborting notification');
+			ctx.statusElement.error(msg('notify-fail-blocked', 'User is indefinitely blocked, aborting notification'));
 			ctx.onNotifyFailure(this);
 			return;
 		}
 
 		// Intentionally *not* ctx.talkTitle, as that may have followed a cross-namespace redirect
 		var exactTalkPage = mw.Title.newFromText(ctx.userName, 3).toText();
-		var usertalk = new Morebits.wiki.page(exactTalkPage, 'Notifying ' + ctx.userName);
+		var usertalk = new Morebits.wiki.page(exactTalkPage, msg('notifying-user', ctx.userName, 'Notifying ' + ctx.userName));
 		// Usurp status element into new object
 		usertalk.setStatusElement(ctx.statusElement);
 
@@ -5516,7 +5514,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		}
 
 		if ((!ctx.csrfToken && (action === 'block' || action === 'unblock')) || (!ctx.userrightsToken && action === 'change groups')) {
-			ctx.statusElement.error('Failed to retrieve token.');
+			ctx.statusElement.error(msg('failed-token', 'Failed to retrieve token.'));
 			onFailure(this);
 			return false;
 		}
@@ -5564,7 +5562,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 				if (ctx.watchlistExpiry) {
 					watch_query.expiry = ctx.watchlistExpiry;
 				}
-				new Morebits.wiki.api('Watching user page', watch_query).post();
+				new Morebits.wiki.api(msg('watching-user', 'Watching user page...'), watch_query).post();
 			}
 		}
 
@@ -5895,7 +5893,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 			}
 			// The API will kindly ignore underscores, but if we set this
 			// before loading the page, we'll need to be able to compare
-			// the results to this list.  Alternativey, we could do regex
+			// the results to this list.  Alternatively, we could do regex
 			// matching in fnProcessNotify rather than checking for dups.
 			ctx.notifySkipTemplates = Morebits.array.uniq(templates).map(function(template) {
 				return template.replace(/_/, ' ');

--- a/morebits.js
+++ b/morebits.js
@@ -102,6 +102,15 @@ Morebits.l10n = {
 	redirectTagAliases: ['#REDIRECT'],
 
 	/**
+	 * Additional regex used to identify usernames as likely unflagged bots.
+	 *
+	 * @constant
+	 * @default
+	 * @type {RegExp}
+	 */
+	botUsernameRegex: /bot\b/i,
+
+	/**
 	 * Takes a string as argument and checks if it is a timestamp or not
 	 * If not, it returns null. If yes, it returns an array of integers
 	 * in the format [year, month, date, hour, minute, second]
@@ -287,15 +296,6 @@ Morebits.namespaceRegex = function(namespaces) {
 	}
 	return regex;
 };
-
-/**
- * Additional regex used to identify usernames as likely unflagged bots.
- *
- * @constant
- * @default
- * @type {RegExp}
- */
-Morebits.botUsernameRegex = /bot\b/i;
 
 
 /* **************** Morebits.quickForm **************** */
@@ -6044,10 +6044,10 @@ Morebits.wiki.user = function(userName, currentAction) {
 	};
 	/**
 	 * @returns {boolean} - True if the user has the bot group or their
-	 * username matches {@link Morebits.botUsernameRegex}.
+	 * username matches {@link Morebits.l10n.botUsernameRegex}.
 	 */
 	this.isBot = function() {
-		return (ctx.grantedGroups && !!ctx.grantedGroups.bot) || (Morebits.botUsernameRegex && Morebits.botUsernameRegex.test(ctx.userName));
+		return (ctx.grantedGroups && !!ctx.grantedGroups.bot) || (Morebits.l10n.botUsernameRegex && Morebits.l10n.botUsernameRegex.test(ctx.userName));
 	};
 	/** @returns {string} - ISO 8601 timestamp at which the user was loaded. */
 	this.getLoadTime = function() {

--- a/morebits.js
+++ b/morebits.js
@@ -4721,7 +4721,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		callbackParameters: null,
 		statusElement: currentAction instanceof Morebits.status ? currentAction : new Morebits.status(currentAction),
 
-		// block paramters
+		// block parameters
 		hasBlockLog: null,
 		lastBlockLogEntry: null,
 		blockInfo: null, // If blocked, an object full of block parameters
@@ -4913,7 +4913,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		response = response.query;
 
 		// Even if this is unnecessary (notification), an issue here
-		// is a likley indicates *something* went wrong.  The same
+		// is a likely indicates *something* went wrong.  The same
 		// as Morebits.wiki.page, though it's more necessary there.
 		if (!response.tokens.csrftoken || !response.tokens.userrightstoken) {
 			ctx.statusElement.error('Failed to retrieve tokens.');
@@ -4927,7 +4927,7 @@ Morebits.wiki.user = function(userName, currentAction) {
 		// Not sure scenario could lead to this, but might as well be safe
 		if (!user) {
 			ctx.statusElement.error('Failed to retrieve user ' + ctx.userName);
-			ctx.onloadFailure(this);
+			ctx.onLoadFailure(this);
 			// force error to stay on the screen
 			++Morebits.wiki.numberOfActionsLeft;
 			return;

--- a/tests/morebits.js
+++ b/tests/morebits.js
@@ -1,18 +1,18 @@
-QUnit.module('constants');
-QUnit.test('userIsSysop', assert => {
-	assert.true(Morebits.userIsSysop, 'Is sysop');
-});
-QUnit.test('pageNameNorm', assert => {
-	assert.strictEqual(Morebits.pageNameNorm, 'Macbeth, King of Scotland', 'Normalized page title');
-});
-
-QUnit.module('methods');
+QUnit.module('Morebits methods');
 QUnit.test('userIsInGroup', assert => {
 	assert.true(Morebits.userIsInGroup('sysop'), 'Sysop');
 	assert.true(Morebits.userIsInGroup('interface-admin'), 'Int-Admin');
 	assert.false(Morebits.userIsInGroup('Founder'), 'Founder');
 });
-
+QUnit.test('userIsSysop', assert => {
+	assert.true(Morebits.userIsSysop, 'Is sysop');
+});
+QUnit.test('isPageRedirect', assert => {
+	assert.false(Morebits.isPageRedirect(), 'Is redirect');
+});
+QUnit.test('pageNameNorm', assert => {
+	assert.strictEqual(Morebits.pageNameNorm, 'Macbeth, King of Scotland', 'Normalized page title');
+});
 QUnit.test('pageNameRegex', assert => {
 	assert.strictEqual(Morebits.pageNameRegex(mw.config.get('wgPageName')), '[Mm]acbeth,[_ ]King[_ ]of[_ ]Scotland', 'First character and spaces');
 	assert.strictEqual(Morebits.pageNameRegex(''), '', 'Empty');
@@ -26,8 +26,4 @@ QUnit.test('namespaceRegex', assert => {
 	assert.strictEqual(Morebits.namespaceRegex([4, 5]), '(?:[Ww][Ii][Kk][Ii][Pp][Ee][Dd][Ii][Aa]|[Ww][Ii][Kk][Ii][Pp][Ee][Dd][Ii][Aa][_ ][Tt][Aa][Ll][Kk]|[Ww][Pp]|[Ww][Tt]|[Pp][Rr][Oo][Jj][Ee][Cc][Tt]|[Pp][Rr][Oo][Jj][Ee][Cc][Tt][_ ][Tt][Aa][Ll][Kk])', 'Project and project talk');
 	assert.strictEqual(Morebits.namespaceRegex(0), '', 'Main');
 	assert.strictEqual(Morebits.namespaceRegex(), '', 'Empty');
-});
-
-QUnit.test('isPageRedirect', assert => {
-	assert.false(Morebits.isPageRedirect(), 'Is redirect');
 });

--- a/twinkle.js
+++ b/twinkle.js
@@ -494,6 +494,16 @@ Twinkle.changeTags = 'twinkle';
 // Available for actions that don't (yet) support tags
 // currently: FlaggedRevs and PageTriage
 Twinkle.summaryAd = ' ([[WP:TW|TW]])';
+// Function to generate an appropriate module-specific optout link i.e. notwinkle.test/?module=xfd
+// Missing protocol defaults to http
+Twinkle.makeOptoutLink = function makeOptoutLink(module) {
+	if (!module) {
+		return '';
+	}
+	return 'notwinkle.test/?module=' + module;
+};
+// Templates which opt a user talk page out of certain notifications
+Twinkle.optoutTemplates = ['Template:Retired', 'Template:Deceased Wikipedian'];
 
 // Various hatnote templates, used when tagging (csd/xfd/tag/prod/protect) to
 // ensure MOS:ORDER


### PR DESCRIPTION
We have `Morebits.wiki.page`, but a user-specific class was missing from the library, meaning common actions like (un)blocking would be left to bespoke queries with `Morebits.wiki.api`.  Even more commonly, finding out information about a given user is often desired and those (equally-bespoke) queries get complicated depending on what's desired.  The ability *not* to notify bots or indef-blocked users is oft-requested, as is the ability to opt-out of Twinkle notifications.  To do that we need to actually know something about the user, for which `Morebits.wiki.page` is insufficient.

Key features of the `Morebits.wiki.user` class include:
- Simple loading of user info, allowing tools to easily access useful information (blocked status, user groups, registration time, etc.)
- Methods to block and unblock a user, as well as the ability to change user groups
- A `notify` method which checks users in order to skip bots or sitewide indef-blocked users, as well as usertalks with given templates or an opt-out link.

Its structure is very similar to `Morebits.wiki.page` but there are a few subtle differences and improvements.  The most notable difference is that here the user object is required to be `load`ed, so the methods, rather than checking if we need to query for protection/token/etc., will instead autoload the user if need be.  The only exception is when `notify`ing and you aren't checking for bot or indef-block status or optout templates/links; there's no need to `load` the user in that case.

Other things to note:
- The `load` success callback is optional, which while unlikely to make a difference writing tools should make single uses or testing easier
- The `notify` method uses `Morebits.wiki.page` (`append` or `newSection`) behind the scenes
- (un)block and user groups methods share success and error callbacks
- Added `Morebits.botUsernameRegex` to standardize a regex to match a "bot" username, set to `/bot\b` (see also #858 and #876)
- Answers/solves #593 (What bots should we avoid notifying?) as "all" (by default)
- Class is supported in `Morebits.batchOperation`
- Usable optout template example at [[User:Amorymeltzer/sandbox/el]]

With this PR, I've made use of it to:
- block: Get info, issue block
- xfd/csd/image/prod/tag/arv: Send notifications
- xfd/csd/image/prod/tag: Enable optout of notifications, don't notify {{deceased}} or {{retired}}
- talkback: Load {{no talkback}} optout preference
- arv: Load block status
- warn: Add note if blocked

talkback and shared need the `setMinorEdit` option, which could be done right now but hardly seems worth it, especially since we don't care about optouts for either.  Likewise for welcome, which also has the `topWelcome` pref, although it's possible the `auto` option might benefit.

(cc @MusikAnimal and @siddharthvp)