### PR TITLE
block: Add option to default to blocking the /64, off by default

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -110,7 +110,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 			name: 'block64',
 			event: Twinkle.block.callback.change_block64,
 			list: [{
-				checked: relevantUserName !== mw.config.get('wgRelevantUserName'), // In case the user closes and reopens the form
+				checked: Twinkle.getPref('defaultToBlock64'),
 				label: 'Block the /64 instead',
 				value: 'block64',
 				tooltip: Morebits.ip.isRange(mw.config.get('wgRelevantUserName')) ? 'Will eschew leaving a template.' : 'Any template issued will go to the original IP: ' + mw.config.get('wgRelevantUserName')
@@ -142,7 +142,13 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		// init the controls after user and block info have been fetched
 		var evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
-		result.actiontype[0].dispatchEvent(evt);
+
+		if (result.block64 && result.block64.checked) {
+			// Calls the same change_action event once finished
+			result.block64.dispatchEvent(evt);
+		} else {
+			result.actiontype[0].dispatchEvent(evt);
+		}
 	});
 };
 

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -213,6 +213,14 @@ Twinkle.config.sections = [
 		module: 'block',
 		adminOnly: true,
 		preferences: [
+			// TwinkleConfig.defaultToBlock64 (boolean)
+			// Whether to default to just blocking the /64 on or off
+			{
+				name: 'defaultToBlock64',
+				label: 'For IPv6 addressed, select the option to Just Block the /64 by default',
+				type: 'boolean'
+			},
+
 			// TwinkleConfig.defaultToPartialBlocks (boolean)
 			// Whether to default partial blocks on or off
 			{

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -217,7 +217,7 @@ Twinkle.config.sections = [
 			// Whether to default to just blocking the /64 on or off
 			{
 				name: 'defaultToBlock64',
-				label: 'For IPv6 addressed, select the option to Just Block the /64 by default',
+				label: 'For IPv6 addresses, select the option to block the /64 range by default',
 				type: 'boolean'
 			},
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -58,6 +58,7 @@ Twinkle.defaultConfig = {
 	spiWatchReport: 'yes',
 
 	// Block
+	defaultToBlock64: false,
 	defaultToPartialBlocks: false,
 	blankTalkpageOnIndefBlock: false,
 


### PR DESCRIPTION
Originally suggested at https://github.com/wikimedia-gadgets/twinkle/pull/1266#issue-551310264