### PR TITLE
add i18n support for morebits

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -5462,7 +5462,7 @@ Morebits.batchOperation = function(currentAction) {
 		},
 
 		// internal counters, etc.
-		statusElement: new Morebits.status(currentAction || 'Performing batch operation'),
+		statusElement: new Morebits.status(currentAction || msg('batch-starting', 'Performing batch operation')),
 		worker: null, // function that executes for each item in pageList
 		postFinish: null, // function that executes when the whole batch has been processed
 		countStarted: 0,
@@ -5529,7 +5529,7 @@ Morebits.batchOperation = function(currentAction) {
 
 		var total = ctx.pageList.length;
 		if (!total) {
-			ctx.statusElement.info('no pages specified');
+			ctx.statusElement.info(msg('batch-no-pages', 'no pages specified'));
 			ctx.running = false;
 			if (ctx.postFinish) {
 				ctx.postFinish();
@@ -5926,7 +5926,7 @@ Morebits.simpleWindow.prototype = {
 		$(this.content).find('input[type="submit"], button[type="submit"]').each(function(key, value) {
 			value.style.display = 'none';
 			var button = document.createElement('button');
-			button.textContent = value.hasAttribute('value') ? value.getAttribute('value') : value.textContent ? value.textContent : 'Submit Query';
+			button.textContent = value.hasAttribute('value') ? value.getAttribute('value') : value.textContent ? value.textContent : msg('submit', 'Submit Query');
 			button.className = value.className || 'submitButtonProxy';
 			// here is an instance of cheap coding, probably a memory-usage hit in using a closure here
 			button.addEventListener('click', function() {
@@ -5974,7 +5974,7 @@ Morebits.simpleWindow.prototype = {
 		var $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
 			var bullet = document.createElement('span');
-			bullet.textContent = ' \u2022 ';  // U+2022 BULLET
+			bullet.textContent = msg('spaced-bullet', ' \u2022 ');  // U+2022 BULLET
 			if (prep) {
 				$footerlinks.prepend(bullet);
 			} else {

--- a/morebits.js
+++ b/morebits.js
@@ -2357,7 +2357,7 @@ Morebits.wiki.api.prototype = {
 					// as the first argument to the callback (for legacy code)
 					this.onSuccess.call(this.parent, this);
 				} else {
-					this.statelem.info('done');
+					this.statelem.info(msg('done', 'done'));
 				}
 
 				Morebits.wiki.actionCompleted();
@@ -5557,13 +5557,6 @@ Morebits.batchOperation = function(currentAction) {
 	 */
 	this.workerSuccess = function(arg) {
 
-		var createPageLink = function(pageName) {
-			var link = document.createElement('a');
-			link.setAttribute('href', mw.util.getUrl(pageName));
-			link.appendChild(document.createTextNode(pageName));
-			return link;
-		};
-
 		if (arg instanceof Morebits.wiki.api || arg instanceof Morebits.wiki.page) {
 			// update or remove status line
 			var statelem = arg.getStatusElement();
@@ -5571,10 +5564,10 @@ Morebits.batchOperation = function(currentAction) {
 				if (arg.getPageName || arg.pageName || (arg.query && arg.query.title)) {
 					// we know the page title - display a relevant message
 					var pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
-					statelem.info(['completed (', createPageLink(pageName), ')']);
+					statelem.info(msg('batch-done-page', pageName, 'completed ([[' + pageName + ']]'));
 				} else {
 					// we don't know the page title - just display a generic message
-					statelem.info('done');
+					statelem.info(msg('done', 'done'));
 				}
 			} else {
 				// remove the status line automatically produced by Morebits.wiki.*
@@ -5582,7 +5575,7 @@ Morebits.batchOperation = function(currentAction) {
 			}
 
 		} else if (typeof arg === 'string' && ctx.options.preserveIndividualStatusLines) {
-			new Morebits.status(arg, ['done (', createPageLink(arg), ')']);
+			new Morebits.status(arg, msg('batch-done-page', arg, 'done ([[' + arg + ']])'));
 		}
 
 		ctx.countFinishedSuccess++;
@@ -5616,7 +5609,8 @@ Morebits.batchOperation = function(currentAction) {
 		// update overall status line
 		var total = ctx.pageList.length;
 		if (ctx.countFinished < total) {
-			ctx.statusElement.status(parseInt(100 * ctx.countFinished / total, 10) + '%');
+			var progress = Math.round(100 * ctx.countFinished / total);
+			ctx.statusElement.status(msg('n-percent', progress, progress + '%'));
 
 			// start a new chunk if we're close enough to the end of the previous chunk, and
 			// we haven't already started the next one
@@ -5625,8 +5619,8 @@ Morebits.batchOperation = function(currentAction) {
 				fnStartNewChunk();
 			}
 		} else if (ctx.countFinished === total) {
-			var statusString = 'Done (' + ctx.countFinishedSuccess +
-				'/' + ctx.countFinished + ' actions completed successfully)';
+			var statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
+				'/' + ctx.countFinished + ' actions completed successfully)');
 			if (ctx.countFinishedSuccess < ctx.countFinished) {
 				ctx.statusElement.warn(statusString);
 			} else {
@@ -5974,7 +5968,7 @@ Morebits.simpleWindow.prototype = {
 		var $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
 			var bullet = document.createElement('span');
-			bullet.textContent = msg('spaced-bullet', ' \u2022 ');  // U+2022 BULLET
+			bullet.textContent = msg('bullet-separator', ' \u2022 ');  // U+2022 BULLET
 			if (prep) {
 				$footerlinks.prepend(bullet);
 			} else {


### PR DESCRIPTION
Adds `Morebits.i18n` which allows plugging in an i18n library through which localised messages can be provided.

The English fallbacks continue to be part of the source code so for using morebits in English no i18n library is required. That is, the changes here are backward-compatible.

Messages in code now become:
```js
msg('msg-name', ...messageParams, fallbackEnglishMessage)
```

where the `fallbackEnglishMessage` is a string that directly uses the message params. That is, it is
```js
msg('deleting-pages', numPages, 'Deleting ' + numPages + ' page' + (numPages > 1 ? 's ' : ' '))
```
instead of
```js
msg('deleting-pages', numPages, 'Deleting $1 {{plural:$1|page|pages}}'
```
The latter would have been nicer but for that I'd have to rewrite all the messages and also then an i18n library would be required to use morebits. Maybe something to think about for the future – but not required for the twinkle-core project.

In case of some messages where a MediaWiki message exists - such as the month names - our message names match the ones in mediawiki.

I've skipped the messages that only the programmers should see -- such as parameter validations for functions, isSysop check for admin-only operations, etc.