### PR TITLE
Revert "Fixes after renaming of {{Rfd}} and Module:RfD"

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -257,7 +257,7 @@ Twinkle.prod.callbacks = {
 			var text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:Redirect for discussion/i;
+			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1440,7 +1440,7 @@ Twinkle.speedy.callbacks = {
 					return;
 				}
 
-				var xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(Redirect for discussion)/.exec(text);
+				var xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
 				if (xfd && !confirm('The deletion-related template {{' + xfd[1] + '}} was found on the page. Do you still want to add a CSD template?')) {
 					return;
 				}

--- a/morebits.js
+++ b/morebits.js
@@ -76,12 +76,12 @@ Morebits.sanitizeIPv6 = function (address) {
 /**
  * Determines whether the current page is a redirect or soft redirect. Fails
  * to detect soft redirects on edit, history, etc. pages.  Will attempt to
- * detect [[Module:Redirect for discussion]], with the same failure points.
+ * detect Module:RfD, with the same failure points.
  *
  * @returns {boolean}
  */
 Morebits.isPageRedirect = function() {
-	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-Redirect_for_discussion').length);
+	return !!(mw.config.get('wgIsRedirect') || document.getElementById('softredirect') || $('.box-RfD').length);
 };
 
 /**


### PR DESCRIPTION
The module rename was reverted due to causing issues with XfDcloser.

This reverts commit 61cace2eb53da954806f75161eccb53842c3a48c.