### PR TITLE
tag: Escape redirect tags when creating regex

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1747,7 +1747,7 @@ Twinkle.tag.callbacks = {
 			var oldPageTags = '';
 			if (pageTags) {
 				pageTags.forEach(function(pageTag) {
-					var pageRe = new RegExp(pageTag, 'img');
+					var pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
 					pageText = pageText.replace(pageRe, '');
 					pageTag = pageTag.trim();
 					oldPageTags += '\n' + pageTag;


### PR DESCRIPTION
Since we're using the existing tags directly to create the regex, any tag with a parameter would lead to issues given the unescaped `|`.  Reported at [WT:TW](https://en.wikipedia.org/w/index.php?oldid=1013238981#Redirect_tagging_bug).