### PR TITLE
morebits: status: render wikilink syntax

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -5132,13 +5132,30 @@ Morebits.status.prototype = {
 			if (obj[i] instanceof Element) {
 				result.appendChild(obj[i]);
 			} else {
-				$.parseHTML(obj[i]).forEach(function(elem) {
+				$.parseHTML(this.renderWikilinks(obj[i])).forEach(function(elem) {
 					result.appendChild(elem);
 				});
 			}
 		}
 		return result;
+	},
 
+	/**
+	 * Render wikilinks in given string to HTML form. That is, converts `[[Main Page|the main page]]`
+	 * to `<a target="_blank" href="/wiki/Main_Page" title="Main Page">the main page</a>`
+	 * @param {string} text
+	 * @returns {string}
+	 */
+	renderWikilinks: function(text) {
+		return text.replace(
+			/\[\[:?(?:([^|\]]+?)\|)?([^\]|]+?)\]\]/g,
+			function(_, target, text) {
+				if (!target) {
+					target = text;
+				}
+				return '<a target="_blank" href="' + mw.util.getUrl(target) +
+					'" title="' + target.replace(/"/g, '&#34;') + '">' + text + '</a>';
+			});
 	},
 
 	/**

--- a/tests/morebits.status.js
+++ b/tests/morebits.status.js
@@ -1,0 +1,23 @@
+QUnit.module('Morebits.status');
+QUnit.test('renderWikilinks', assert => {
+	var status = new Morebits.status('test', 'test');
+
+	assert.strictEqual(
+		status.renderWikilinks('[[Main Page]]'),
+		`<a target="_blank" href="/wiki/Main_Page" title="Main Page">Main Page</a>`,
+		'simple link'
+	);
+	assert.strictEqual(
+		status.renderWikilinks('surrounding text [[Main Page|the main page]]'),
+		`surrounding text <a target="_blank" href="/wiki/Main_Page" title="Main Page">the main page</a>`,
+		'link with display text'
+	);
+	assert.strictEqual(
+		status.renderWikilinks('surrounding text [["Weird Al" Yankovic]]'),
+		`surrounding text <a target="_blank" href="/wiki/%22Weird_Al%22_Yankovic" title="&#34;Weird Al&#34; Yankovic">"Weird Al" Yankovic</a>`,
+		// jsdom in node turns " in title attribute into &#34; whereas Chrome seems turns it into &quot;
+		// but it works either way
+		'link with double quote'
+	);
+
+});


### PR DESCRIPTION
Makes it much easier to include wikilinks in status messages. 

If literal `[[...]]` are to be included in status for whatever reason, that can still be done using the HTML entities `&#91;&#91;...&#93;&#93;`