### PR TITLE
morebits: render wikilink syntax and sanitize HTML in status and quickForm labels

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -131,7 +131,17 @@ Morebits.createHtml = function(input) {
 			fragment.appendChild(input[i]);
 		} else {
 			$.parseHTML(Morebits.createHtml.renderWikilinks(input[i])).forEach(function(node) {
-				fragment.appendChild(node);
+				if (node.nodeType === 3) { // text node
+					fragment.appendChild(node);
+				} else if (node.nodeType === 1) { // Element node, strip dangerous attributes
+					Array.prototype.slice.call(node.attributes).forEach(function(attr) {
+						// onclick, onerror, onload, etc
+						if (attr.name.indexOf('on') === 0) {
+							node.removeAttribute(attr.name);
+						}
+					});
+					fragment.appendChild(node);
+				} // any other node type is suspicious
 			});
 		}
 	}

--- a/morebits.js
+++ b/morebits.js
@@ -114,6 +114,48 @@ Morebits.pageNameRegex = function(pageName) {
 };
 
 /**
+ * Converts string or array of DOM nodes into an HTML fragment.
+ * Wikilink syntax (`[[...]]`) is transformed into HTML anchor.
+ * Used in Morebits.quickForm and Morebits.status
+ * @internal
+ * @param {string|Node|(string|Node)[]} input
+ * @returns {DocumentFragment}
+ */
+Morebits.createHtml = function(input) {
+	var fragment = document.createDocumentFragment();
+	if (!Array.isArray(input)) {
+		input = [ input ];
+	}
+	for (var i = 0; i < input.length; ++i) {
+		if (input[i] instanceof Node) {
+			fragment.appendChild(input[i]);
+		} else {
+			$.parseHTML(Morebits.createHtml.renderWikilinks(input[i])).forEach(function(node) {
+				fragment.appendChild(node);
+			});
+		}
+	}
+	return fragment;
+};
+
+/**
+ * Converts wikilinks to HTML anchor tags.
+ * @param text
+ * @returns {*}
+ */
+Morebits.createHtml.renderWikilinks = function (text) {
+	return text.replace(
+		/\[\[:?(?:([^|\]]+?)\|)?([^\]|]+?)\]\]/g,
+		function(_, target, text) {
+			if (!target) {
+				target = text;
+			}
+			return '<a target="_blank" href="' + mw.util.getUrl(target) +
+				'" title="' + target.replace(/"/g, '&#34;') + '">' + text + '</a>';
+		});
+};
+
+/**
  * Create a string for use in regex matching all namespace aliases, regardless
  * of the capitalization and underscores/spaces.  Doesn't include the optional
  * leading `:`, but if there's more than one item, wraps the list in a
@@ -300,23 +342,6 @@ Morebits.quickForm.element.prototype.render = function QuickFormElementRender(in
 	return currentNode[0];
 };
 
-/**
- * Render the label for a quickform element.
- * @param {HTMLElement} labelElement
- * @param {Node|string|(Node|string)[]} input
- */
-Morebits.quickForm.element.prototype.generateLabel = function QuickFromElementGenerateLabel(labelElement, input) {
-	if (!Array.isArray(input)) {
-		input = [ input ];
-	}
-	for (var i = 0; i < input.length; ++i) {
-		if (typeof input[i] === 'string') {
-			labelElement.appendChild(document.createTextNode(input[i]));
-		} else if (input[i] instanceof Node) {
-			labelElement.appendChild(input[i]);
-		}
-	}
-};
 
 /** @memberof Morebits.quickForm.element */
 Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(data, in_id) {
@@ -350,7 +375,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			if (data.label) {
 				label = node.appendChild(document.createElement('label'));
 				label.setAttribute('for', id);
-				this.generateLabel(label, data.label);
+				label.appendChild(Morebits.createHtml(data.label));
 			}
 			var select = node.appendChild(document.createElement('select'));
 			if (data.event) {
@@ -415,7 +440,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 		case 'field':
 			node = document.createElement('fieldset');
 			label = node.appendChild(document.createElement('legend'));
-			this.generateLabel(label, data.label);
+			label.appendChild(Morebits.createHtml(data.label));
 			if (data.name) {
 				node.setAttribute('name', data.name);
 			}
@@ -463,7 +488,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					}
 					label = cur_div.appendChild(document.createElement('label'));
 
-					this.generateLabel(label, current.label);
+					label.appendChild(Morebits.createHtml(current.label));
 					label.setAttribute('for', cur_id);
 					if (current.tooltip) {
 						Morebits.quickForm.element.generateTooltip(label, current);
@@ -549,7 +574,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 
 			if (data.label) {
 				label = node.appendChild(document.createElement('label'));
-				this.generateLabel(label, data.label);
+				label.appendChild(Morebits.createHtml(data.label));
 				label.setAttribute('for', data.id || id);
 			}
 
@@ -590,7 +615,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 
 			label = node.appendChild(document.createElement('h5'));
-			this.generateLabel(label, data.label);
+			label.appendChild(Morebits.createHtml(data.label));
 			var listNode = node.appendChild(document.createElement('div'));
 
 			var more = this.compute({
@@ -690,7 +715,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			break;
 		case 'header':
 			node = document.createElement('h5');
-			this.generateLabel(node, data.label);
+			node.appendChild(Morebits.createHtml(data.label));
 			break;
 		case 'div':
 			node = document.createElement('div');
@@ -700,7 +725,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			if (data.label) {
 				var result = document.createElement('span');
 				result.className = 'quickformDescription';
-				this.generateLabel(result, data.label);
+				result.appendChild(Morebits.createHtml(data.label));
 				node.appendChild(result);
 			}
 			break;
@@ -737,7 +762,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			if (data.label) {
 				label = node.appendChild(document.createElement('h5'));
 				var labelElement = document.createElement('label');
-				this.generateLabel(labelElement, data.label);
+				labelElement.appendChild(Morebits.createHtml(data.label));
 				labelElement.setAttribute('for', data.id || id);
 				label.appendChild(labelElement);
 			}
@@ -5034,7 +5059,7 @@ Morebits.userspaceLogger = function(logPageName) {
 
 Morebits.status = function Status(text, stat, type) {
 	this.textRaw = text;
-	this.text = this.codify(text);
+	this.text = Morebits.createHtml(text);
 	this.type = type || 'status';
 	this.generate();
 	if (stat) {
@@ -5102,33 +5127,6 @@ Morebits.status.prototype = {
 	},
 
 	/**
-	 * Create a document fragment with the status text, parsing as HTML.
-	 * Runs upon construction for text (part before colon) and upon
-	 * render/update for status (part after colon).
-	 *
-	 * @param {(string|Element|Array)} obj
-	 * @returns {DocumentFragment}
-	 */
-	codify: function(obj) {
-		if (!Array.isArray(obj)) {
-			obj = [ obj ];
-		}
-		var result;
-		result = document.createDocumentFragment();
-		for (var i = 0; i < obj.length; ++i) {
-			if (obj[i] instanceof Element) {
-				result.appendChild(obj[i]);
-			} else {
-				$.parseHTML(obj[i]).forEach(function(elem) {
-					result.appendChild(elem);
-				});
-			}
-		}
-		return result;
-
-	},
-
-	/**
 	 * Update the status.
 	 *
 	 * @param {string} status - Part of status message after colon.
@@ -5137,7 +5135,7 @@ Morebits.status.prototype = {
 	 */
 	update: function(status, type) {
 		this.statRaw = status;
-		this.stat = this.codify(status);
+		this.stat = Morebits.createHtml(status);
 		if (type) {
 			this.type = type;
 			if (type === 'error') {

--- a/tests/mocking/mb_repl_head.js
+++ b/tests/mocking/mb_repl_head.js
@@ -10,6 +10,7 @@ global.document = window.document;
 
 global.HTMLFormElement = window.HTMLFormElement;
 global.Element = window.Element;
+global.Node = window.Node;
 
 global.jQuery = require('jquery');
 

--- a/tests/morebits.createHtml.js
+++ b/tests/morebits.createHtml.js
@@ -1,0 +1,20 @@
+QUnit.module('Morebits.createHtml');
+QUnit.test('renderWikilinks', assert => {
+	assert.strictEqual(
+		Morebits.createHtml.renderWikilinks('[[Main Page]]'),
+		`<a target="_blank" href="/wiki/Main_Page" title="Main Page">Main Page</a>`,
+		'simple link'
+	);
+	assert.strictEqual(
+		Morebits.createHtml.renderWikilinks('surrounding text [[Main Page|the main page]]'),
+		`surrounding text <a target="_blank" href="/wiki/Main_Page" title="Main Page">the main page</a>`,
+		'link with display text'
+	);
+	assert.strictEqual(
+		Morebits.createHtml.renderWikilinks('surrounding text [["Weird Al" Yankovic]]'),
+		`surrounding text <a target="_blank" href="/wiki/%22Weird_Al%22_Yankovic" title="&#34;Weird Al&#34; Yankovic">"Weird Al" Yankovic</a>`,
+		// jsdom in node turns " in title attribute into &#34; whereas Chrome seems turns it into &quot;
+		// but it works either way
+		'link with double quote'
+	);
+});

--- a/tests/morebits.createHtml.js
+++ b/tests/morebits.createHtml.js
@@ -1,4 +1,34 @@
 QUnit.module('Morebits.createHtml');
+
+// Fails due to broken JSDom setup.
+// TODO: replace QUnit with Jest
+QUnit.skip('createHtml', (assert) => {
+	let fragment = Morebits.createHtml('string');
+	assert.strictEqual(fragment.childNodes.length, 1);
+	assert.strictEqual(fragment.childNodes[0].nodeName, '#text');
+
+	fragment = Morebits.createHtml(Morebits.htmlNode('a', 'Anchor'));
+	assert.strictEqual(fragment.childNodes.length, 1);
+	assert.strictEqual(fragment.childNodes[0].nodeName, 'A');
+
+	fragment = Morebits.createHtml(['text', document.createElement('b')]);
+	assert.strictEqual(fragment.childNodes.length, 2);
+	assert.strictEqual(fragment.childNodes[0].nodeName, '#text');
+	assert.strictEqual(fragment.childNodes[1].nodeName, 'B');
+
+	fragment = Morebits.createHtml('Hi <script>alert("boom!")</script>');
+	assert.strictEqual(fragment.childNodes.length, 1);
+	assert.strictEqual(fragment.childNodes[0].nodeName, '#text');
+
+	fragment = Morebits.createHtml('Hi <a onclick="alert();" href="">text</a>');
+	assert.strictEqual(fragment.childNodes.length, 2);
+	assert.strictEqual(fragment.childNodes[1].nodeName, 'A');
+	// the onclick should have been scrubbed
+	assert.strictEqual(fragment.childNodes[1].attributes.length, 1);
+	assert.strictEqual(fragment.childNodes[1].attributes[0].name, 'href');
+
+});
+
 QUnit.test('renderWikilinks', assert => {
 	assert.strictEqual(
 		Morebits.createHtml.renderWikilinks('[[Main Page]]'),


### PR DESCRIPTION
Makes it much easier to include wikilinks in status messages and quickForm labels. Also de-duplicates some code in the two clases.

If literal `[[...]]` are to be included in status for whatever reason, that can still be done using the HTML entities `&#91;&#91;...&#93;&#93;`

$.parseHTML() removes <script> tags in the parsed output, so there should be no security issues.

A `Morebits.createHtml` function is added. This obsoletes `Morebits.status.prototype.codify` which is hence removed.

----

2nd commit: morebits: createHtml: sanitize html attributes 

Removes attributes that are used for executing scripts (onclick, onerror, etc). Also disallows anything that isn't a text node or Element node.
