### PR TITLE
move some css to morebits.css, rather than embed in js

### DIFF
--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -45,10 +45,6 @@ Twinkle.unlink.callback = function(presetReason) {
 	} else {
 		linkPlainAfter = Morebits.htmlNode('code', Morebits.pageNameNorm);
 	}
-	[linkTextBefore, linkTextAfter, linkPlainBefore, linkPlainAfter].forEach(function(node) {
-		node.style.fontFamily = 'monospace';
-		node.style.fontStyle = 'normal';
-	});
 
 	form.append({
 		type: 'div',

--- a/morebits.css
+++ b/morebits.css
@@ -110,6 +110,12 @@ form.quickform span.quickformDescription
 	font-style: italic;
 }
 
+form.quickform span.quickformDescription code
+{
+	font-style: normal;
+	font-family: monospace;
+}
+
 form.quickform .quickformSubgroup
 {
 	margin-bottom: .5em;


### PR DESCRIPTION
This applies to `<code>` elements within quickform divs, which should be shown in monospace font without italicisation.