### PR TITLE
morebits: createHtml: don't render wikilinks inside <code> tags

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -203,7 +203,10 @@ Morebits.createHtml = function(input) {
  * @returns {*}
  */
 Morebits.createHtml.renderWikilinks = function (text) {
-	return text.replace(
+	var ub = new Morebits.unbinder(text);
+	// Don't convert wikilinks within code tags as they're used for displaying wiki-code
+	ub.unbind('<code>', '</code>');
+	ub.content = ub.content.replace(
 		/\[\[:?(?:([^|\]]+?)\|)?([^\]|]+?)\]\]/g,
 		function(_, target, text) {
 			if (!target) {
@@ -212,6 +215,7 @@ Morebits.createHtml.renderWikilinks = function (text) {
 			return '<a target="_blank" href="' + mw.util.getUrl(target) +
 				'" title="' + target.replace(/"/g, '&#34;') + '">' + text + '</a>';
 		});
+	return ub.rebind();
 };
 
 /**

--- a/tests/morebits.createHtml.js
+++ b/tests/morebits.createHtml.js
@@ -47,4 +47,10 @@ QUnit.test('renderWikilinks', assert => {
 		// but it works either way
 		'link with double quote'
 	);
+
+	assert.strictEqual(
+		Morebits.createHtml.renderWikilinks('<code>[[CODE]]</code> [[Yankovic]]'),
+		`<code>[[CODE]]</code> <a target="_blank" href="/wiki/Yankovic" title="Yankovic">Yankovic</a>`,
+		'wikilink in <code> tag'
+	);
 });


### PR DESCRIPTION
Since code tags are used for displaying wiki-code (such as in unlink module).