### PR TITLE
morebits: i18n: add qqx support

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -62,6 +62,19 @@ Morebits.i18n = {
 		Morebits.i18n.parser = parser;
 	},
 	/**
+	 * QQX is a dummy "language" for documenting messages
+	 * @type {boolean}
+	 */
+	qqxMode: mw.util.getParamValue('uselang') === 'qqx',
+	/**
+	 * Get message key
+	 * @param msgName
+	 * @returns {string}
+	 */
+	getMessageQQX: function(msgName) {
+		return '(' + msgName + ')';
+	},
+	/**
 	 * @private
 	 * @returns {string}
 	 */
@@ -87,7 +100,7 @@ Morebits.i18n = {
 };
 
 // shortcut
-var msg = Morebits.i18n.getMessage;
+var msg = Morebits.i18n.qqxMode ? Morebits.i18n.getMessageQQX : Morebits.i18n.getMessage;
 
 
 /**


### PR DESCRIPTION
Using uselang=qqx in the URL will make morebits show its message names, just like in MediaWiki.