### PR TITLE
twinkle.css: Add 2px margin-right to checkboxes in prefs

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1112,7 +1112,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 							input.setAttribute('checked', 'checked');
 						}
 						label.appendChild(input);
-						label.appendChild(document.createTextNode(' ' + pref.label));
+						label.appendChild(document.createTextNode(pref.label));
 						cell.appendChild(label);
 						break;
 

--- a/twinkle.css
+++ b/twinkle.css
@@ -26,3 +26,8 @@
 #twinkle-config-headerbox.config-userskin-box {
 	width: 60%;
 }
+
+/* WP:TWPREFS */
+#twinkle-config-content input[type=checkbox] {
+	margin-right: 2px;
+}


### PR DESCRIPTION
There is 1 space after the checkboxes for type=boolean. But no spaces for type=enum.
So remove the space from type=boolean and use css to add margin to all checkboxes.

Similar to #1331