### PR TITLE
Revert "morebits: createHtml: sanitize html attributes"

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -180,17 +180,7 @@ Morebits.createHtml = function(input) {
 			fragment.appendChild(input[i]);
 		} else {
 			$.parseHTML(Morebits.createHtml.renderWikilinks(input[i])).forEach(function(node) {
-				if (node.nodeType === 3) { // text node
-					fragment.appendChild(node);
-				} else if (node.nodeType === 1) { // Element node, strip dangerous attributes
-					Array.prototype.slice.call(node.attributes).forEach(function(attr) {
-						// onclick, onerror, onload, etc
-						if (attr.name.indexOf('on') === 0) {
-							node.removeAttribute(attr.name);
-						}
-					});
-					fragment.appendChild(node);
-				} // any other node type is suspicious
+				fragment.appendChild(node);
 			});
 		}
 	}

--- a/tests/morebits.createHtml.js
+++ b/tests/morebits.createHtml.js
@@ -20,13 +20,6 @@ QUnit.skip('createHtml', (assert) => {
 	assert.strictEqual(fragment.childNodes.length, 1);
 	assert.strictEqual(fragment.childNodes[0].nodeName, '#text');
 
-	fragment = Morebits.createHtml('Hi <a onclick="alert();" href="">text</a>');
-	assert.strictEqual(fragment.childNodes.length, 2);
-	assert.strictEqual(fragment.childNodes[1].nodeName, 'A');
-	// the onclick should have been scrubbed
-	assert.strictEqual(fragment.childNodes[1].attributes.length, 1);
-	assert.strictEqual(fragment.childNodes[1].attributes[0].name, 'href');
-
 });
 
 QUnit.test('renderWikilinks', assert => {


### PR DESCRIPTION
No longer necessary to do this at runtime since twinkle-core now uses a script (https://github.com/wikimedia-gadgets/twinkle-core/blob/master/scripts/build-i18n.js) to sanitise messages at the build step itself, which is even better at sanitising than this code here. <script> tags are still removed here as that's a built into $.parseHTML().

Some of tests added in that commit are retained.