### PR TITLE
morebits: add $data attribute for quickForm elements

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -305,7 +305,7 @@ Morebits.quickForm.prototype.append = function QuickFormAppend(data) {
  * Create a new element for the the form.
  *
  * Index to Morebits.quickForm.element types:
- * - Global attributes: id, className, style, tooltip, extra, adminonly
+ * - Global attributes: id, className, style, tooltip, extra, $data, adminonly
  * - `select`: A combo box (aka drop-down).
  *     - Attributes: name, label, multiple, size, list, event, disabled
  *  - `option`: An element for a combo box.
@@ -864,6 +864,9 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 
 	if (data.extra) {
 		childContainer.extra = data.extra;
+	}
+	if (data.$data) {
+		$(childContainer).data(data.$data);
 	}
 	if (data.style) {
 		childContainer.setAttribute('style', data.style);


### PR DESCRIPTION
Till now there has been the the quickForm extra attribute which allowed attaching arbitrary data to DOM nodes. But this is discouraged for many reasons (https://stackoverflow.com/questions/7895560/javascript-dom-setting-custom-dom-element-properties, https://stackoverflow.com/questions/3095336/is-it-bad-practice-to-add-properties-to-dom-nodes).

Using JQuery data (https://api.jquery.com/data/) is better.

Support for `extra` attribute is nevertheless retained, though this is unused in Twinkle.