### PR TITLE
morebits: put 3px margin after input labels

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -47,7 +47,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	form.append({
 		type: 'input',
-		label: 'Filter tag list: ',
+		label: 'Filter tag list:',
 		name: 'quickfilter',
 		size: '30px',
 		event: function twinkletagquickfilter() {
@@ -484,7 +484,7 @@ var translationSubgroups = [
 		name: 'translationLanguage',
 		parameter: '1',
 		type: 'input',
-		label: 'Language of article (if known): ',
+		label: 'Language of article (if known):',
 		tooltip: 'Consider looking at [[WP:LRC]] for help. If listing the article at PNT, please try to avoid leaving this box blank, unless you are completely unsure.'
 	}
 ].concat(mw.config.get('wgNamespaceNumber') === 0 ? [
@@ -520,7 +520,7 @@ var getMergeSubgroups = function(tag) {
 		{
 			name: 'mergeTarget',
 			type: 'input',
-			label: 'Other article(s): ',
+			label: 'Other article(s):',
 			tooltip: 'If specifying multiple articles, separate them with pipe characters: Article one|Article two',
 			required: true
 		},
@@ -557,7 +557,7 @@ Twinkle.tag.article.tagList = {
 					name: 'cleanup',
 					parameter: 'reason',
 					type: 'input',
-					label: 'Specific reason why cleanup is needed: ',
+					label: 'Specific reason why cleanup is needed:',
 					tooltip: 'Required.',
 					size: 35,
 					required: true
@@ -574,7 +574,7 @@ Twinkle.tag.article.tagList = {
 					name: 'copyEdit',
 					parameter: 'for',
 					type: 'input',
-					label: '"This article may require copy editing for..." ',
+					label: '"This article may require copy editing for..."',
 					tooltip: 'e.g. "consistent spelling". Optional.',
 					size: 35
 				}
@@ -588,7 +588,7 @@ Twinkle.tag.article.tagList = {
 					name: 'closeParaphrasing',
 					parameter: 'source',
 					type: 'input',
-					label: 'Source: ',
+					label: 'Source:',
 					tooltip: 'Source that has been closely paraphrased'
 				}
 			},
@@ -600,7 +600,7 @@ Twinkle.tag.article.tagList = {
 					name: 'copypaste',
 					parameter: 'url',
 					type: 'input',
-					label: 'Source URL: ',
+					label: 'Source URL:',
 					tooltip: 'If known.',
 					size: 50
 				}
@@ -688,21 +688,21 @@ Twinkle.tag.article.tagList = {
 						name: 'expertNeeded',
 						parameter: '1',
 						type: 'input',
-						label: 'Name of relevant WikiProject: ',
+						label: 'Name of relevant WikiProject:',
 						tooltip: 'Optionally, enter the name of a WikiProject which might be able to help recruit an expert. Don\'t include the "WikiProject" prefix.'
 					},
 					{
 						name: 'expertNeededReason',
 						parameter: 'reason',
 						type: 'input',
-						label: 'Reason: ',
+						label: 'Reason:',
 						tooltip: 'Short explanation describing the issue. Either Reason or Talk link is required.'
 					},
 					{
 						name: 'expertNeededTalk',
 						parameter: 'talk',
 						type: 'input',
-						label: 'Talk discussion: ',
+						label: 'Talk discussion:',
 						tooltip: 'Name of the section of this article\'s talk page where the issue is being discussed. Do not give a link, just the name of the section. Either Reason or Talk link is required.'
 					}
 				]
@@ -793,14 +793,14 @@ Twinkle.tag.article.tagList = {
 					name: 'expandLanguageLangCode',
 					parameter: 'langcode',
 					type: 'input',
-					label: 'Language code: ',
+					label: 'Language code:',
 					tooltip: 'Language code of the language from which article is to be expanded from',
 					required: true
 				}, {
 					name: 'expandLanguageArticle',
 					parameter: 'otherarticle',
 					type: 'input',
-					label: 'Name of article: ',
+					label: 'Name of article:',
 					tooltip: 'Name of article to be expanded from, without the interwiki prefix'
 				}]
 			}
@@ -832,7 +832,7 @@ Twinkle.tag.article.tagList = {
 					name: 'histmergeOriginalPage',
 					parameter: 'originalpage',
 					type: 'input',
-					label: 'Other article: ',
+					label: 'Other article:',
 					tooltip: 'Name of the page that should be merged into this one (required).',
 					required: true
 				},
@@ -840,14 +840,14 @@ Twinkle.tag.article.tagList = {
 					name: 'histmergeReason',
 					parameter: 'reason',
 					type: 'input',
-					label: 'Reason: ',
+					label: 'Reason:',
 					tooltip: 'Short explanation describing the reason a history merge is needed. Should probably begin with "because" and end with a period.'
 				},
 				{
 					name: 'histmergeSysopDetails',
 					parameter: 'details',
 					type: 'input',
-					label: 'Extra details: ',
+					label: 'Extra details:',
 					tooltip: 'For complex cases, provide extra instructions for the reviewing administrator.'
 				}
 			]
@@ -908,13 +908,13 @@ Twinkle.tag.redirectList = {
 					{
 						name: 'altLangFrom',
 						type: 'input',
-						label: 'From language (two-letter code): ',
+						label: 'From language (two-letter code):',
 						tooltip: 'Enter the two-letter code of the language the redirect name is in; such as en for English, de for German'
 					},
 					{
 						name: 'altLangTo',
 						type: 'input',
-						label: 'To language (two-letter code): ',
+						label: 'To language (two-letter code):',
 						tooltip: 'Enter the two-letter code of the language the target name is in; such as en for English, de for German'
 					},
 					{
@@ -1073,14 +1073,14 @@ Twinkle.tag.fileList = {
 				{
 					type: 'input',
 					name: 'DoNotMoveToCommons_reason',
-					label: 'Reason: ',
+					label: 'Reason:',
 					tooltip: 'Enter the reason why this image should not be moved to Commons (required). If the file is PD in the US but not in country of origin, enter "US only"',
 					required: true
 				},
 				{
 					type: 'number',
 					name: 'DoNotMoveToCommons_expiry',
-					label: 'Expiration year: ',
+					label: 'Expiration year:',
 					min: new Morebits.date().getFullYear(),
 					tooltip: 'If this file can be moved to Commons beginning in a certain year, you can enter it here (optional).'
 				}
@@ -1092,7 +1092,7 @@ Twinkle.tag.fileList = {
 			subgroup: {
 				type: 'input',
 				name: 'keeplocalName',
-				label: 'Commons image name if different: ',
+				label: 'Commons image name if different:',
 				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
 			}
 		},
@@ -1102,7 +1102,7 @@ Twinkle.tag.fileList = {
 			subgroup: {
 				type: 'input',
 				name: 'nowcommonsName',
-				label: 'Commons image name if different: ',
+				label: 'Commons image name if different:',
 				tooltip: 'Name of the image on Commons (if different from local name), excluding the File: prefix:'
 			}
 		}
@@ -1120,7 +1120,7 @@ Twinkle.tag.fileList = {
 			subgroup: {
 				type: 'input',
 				name: 'cleanupimageReason',
-				label: 'Reason: ',
+				label: 'Reason:',
 				tooltip: 'Enter the reason for cleanup (required)',
 				required: true
 			}
@@ -1138,13 +1138,13 @@ Twinkle.tag.fileList = {
 				{
 					type: 'input',
 					name: 'renamemediaNewname',
-					label: 'New name: ',
+					label: 'New name:',
 					tooltip: 'Enter the new name for the image (optional)'
 				},
 				{
 					type: 'input',
 					name: 'renamemediaReason',
-					label: 'Reason: ',
+					label: 'Reason:',
 					tooltip: 'Enter the reason for the rename (optional)'
 				}
 			]
@@ -1185,7 +1185,7 @@ Twinkle.tag.fileList = {
 			subgroup: {
 				type: 'input',
 				name: 'ImagePoorQualityReason',
-				label: 'Reason: ',
+				label: 'Reason:',
 				tooltip: 'Enter the reason why this image is so bad (required)',
 				required: true
 			}
@@ -1196,7 +1196,7 @@ Twinkle.tag.fileList = {
 			subgroup: {
 				type: 'input',
 				name: 'lowQualityChemReason',
-				label: 'Reason: ',
+				label: 'Reason:',
 				tooltip: 'Enter the reason why the diagram is disputed (required)',
 				required: true
 			}
@@ -1211,7 +1211,7 @@ Twinkle.tag.fileList = {
 Twinkle.tag.fileList['Replacement tags'].forEach(function(el) {
 	el.subgroup = {
 		type: 'input',
-		label: 'Replacement file: ',
+		label: 'Replacement file:',
 		tooltip: 'Enter the name of the file which replaces this one (required)',
 		name: el.value.replace(/ /g, '_') + 'File',
 		required: true

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -130,7 +130,7 @@ Twinkle.welcome.callback = function friendlywelcomeCallback(uid) {
 	form.append({
 		type: 'select',
 		name: 'type',
-		label: 'Type of welcome: ',
+		label: 'Type of welcome:',
 		event: Twinkle.welcome.populateWelcomeList,
 		list: [
 			{ type: 'option', value: 'standard', label: 'Standard welcomes', selected: !mw.util.isIPAddress(mw.config.get('wgRelevantUserName')) },

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -45,7 +45,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 	var categories = form.append({
 		type: 'select',
 		name: 'category',
-		label: 'Select report type: ',
+		label: 'Select report type:',
 		event: Twinkle.arv.callback.changeCategory
 	});
 	categories.append({
@@ -150,7 +150,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 			work_area.append({
 				type: 'input',
 				name: 'page',
-				label: 'Primary linked page: ',
+				label: 'Primary linked page:',
 				tooltip: 'Leave blank to not link to the page in the report',
 				value: mw.util.getParamValue('vanarticle') || '',
 				event: function(e) {
@@ -167,7 +167,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 			work_area.append({
 				type: 'input',
 				name: 'badid',
-				label: 'Revision ID for target page when vandalised: ',
+				label: 'Revision ID for target page when vandalised:',
 				tooltip: 'Leave blank for no diff link',
 				value: mw.util.getParamValue('vanarticlerevid') || '',
 				disabled: !mw.util.getParamValue('vanarticle'),
@@ -180,7 +180,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 			work_area.append({
 				type: 'input',
 				name: 'goodid',
-				label: 'Last good revision ID before vandalism of target page: ',
+				label: 'Last good revision ID before vandalism of target page:',
 				tooltip: 'Leave blank for diff link to previous revision',
 				value: mw.util.getParamValue('vanarticlegoodrevid') || '',
 				disabled: !mw.util.getParamValue('vanarticle') || mw.util.getParamValue('vanarticlerevid')
@@ -216,7 +216,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 			work_area.append({
 				type: 'textarea',
 				name: 'reason',
-				label: 'Comment: '
+				label: 'Comment:'
 			});
 			work_area = work_area.render();
 			old_area.parentNode.replaceChild(work_area, old_area);
@@ -321,7 +321,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					type: 'dyninput',
 					name: 'sockpuppet',
 					label: 'Sockpuppets',
-					sublabel: 'Sock: ',
+					sublabel: 'Sock:',
 					tooltip: 'The username of the sockpuppet without the "User:" prefix',
 					min: 2
 				});

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -107,7 +107,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	form.append({
 		type: 'input',
 		name: 'reason',
-		label: 'Reason: ',
+		label: 'Reason:',
 		size: 60
 	});
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -142,7 +142,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 	form.append({
 		type: 'input',
 		name: 'reason',
-		label: 'Reason: ',
+		label: 'Reason:',
 		size: 60,
 		tooltip: 'For the protection log and page history.'
 	});

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -44,7 +44,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 	form.append({
 		type: 'input',
 		name: 'reason',
-		label: 'Reason: ',
+		label: 'Reason:',
 		size: 60
 	});
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -558,7 +558,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			field_template_options.append({
 				type: 'input',
 				name: 'template_expiry',
-				label: 'Period of blocking: ',
+				label: 'Period of blocking:',
 				value: '',
 				tooltip: 'The period the blocking is due for, for example 24 hours, 2 weeks, indefinite etc...'
 			});
@@ -566,7 +566,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		field_template_options.append({
 			type: 'input',
 			name: 'block_reason',
-			label: '"You have been blocked for ..." ',
+			label: '"You have been blocked for ..."',
 			tooltip: 'An optional reason, to replace the default generic reason. Only available for the generic block templates.',
 			value: Twinkle.block.field_template_options.block_reason
 		});

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -148,21 +148,21 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 			work_area.append({
 				type: 'input',
 				name: 'source',
-				label: 'Source: '
+				label: 'Source:'
 			});
 			break;
 		case 'disputed fair use rationale':
 			work_area.append({
 				type: 'textarea',
 				name: 'reason',
-				label: 'Concern: '
+				label: 'Concern:'
 			});
 			break;
 		case 'orphaned fair use':
 			work_area.append({
 				type: 'input',
 				name: 'replacement',
-				label: 'Replacement: ',
+				label: 'Replacement:',
 				tooltip: 'Optional file that replaces this one.  The "File:" prefix is optional.'
 			});
 			break;
@@ -170,7 +170,7 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 			work_area.append({
 				type: 'textarea',
 				name: 'reason',
-				label: 'Reason: '
+				label: 'Reason:'
 			});
 			break;
 		default:

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -552,7 +552,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 			field1.append({
 				type: 'select',
 				name: 'expiry',
-				label: 'Duration: ',
+				label: 'Duration:',
 				list: [
 					{ label: '', selected: true, value: '' },
 					{ label: 'Temporary', value: 'temporary' },
@@ -562,7 +562,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 			field1.append({
 				type: 'textarea',
 				name: 'reason',
-				label: 'Reason: '
+				label: 'Reason:'
 			});
 			break;
 		default:

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -488,7 +488,7 @@ Twinkle.speedy.customRationale = [
 		subgroup: {
 			name: 'reason_1',
 			type: 'input',
-			label: 'Rationale: ',
+			label: 'Rationale:',
 			size: 60
 		},
 		hideWhenMultiple: true
@@ -511,7 +511,7 @@ Twinkle.speedy.fileList = [
 		subgroup: {
 			name: 'redundantimage_filename',
 			type: 'input',
-			label: 'File this is redundant to: ',
+			label: 'File this is redundant to:',
 			tooltip: 'The "File:" prefix can be left off.'
 		}
 	},
@@ -556,7 +556,7 @@ Twinkle.speedy.fileList = [
 		subgroup: {
 			name: 'badfairuse_rationale',
 			type: 'input',
-			label: 'Optional explanation: ',
+			label: 'Optional explanation:',
 			size: 60
 		},
 		hideWhenMultiple: true
@@ -568,7 +568,7 @@ Twinkle.speedy.fileList = [
 		subgroup: {
 			name: 'commons_filename',
 			type: 'input',
-			label: 'Filename on Commons: ',
+			label: 'Filename on Commons:',
 			value: Morebits.pageNameNorm,
 			tooltip: 'This can be left blank if the file has the same name on Commons as here. The "File:" prefix is optional.'
 		},
@@ -582,13 +582,13 @@ Twinkle.speedy.fileList = [
 			{
 				name: 'imgcopyvio_url',
 				type: 'input',
-				label: 'URL of the copyvio, including the "http://".  If the copyvio is of a non-internet source and you cannot provide a URL, you must use the deletion rationale box. ',
+				label: 'URL of the copyvio, including the "http://".  If the copyvio is of a non-internet source and you cannot provide a URL, you must use the deletion rationale box.',
 				size: 60
 			},
 			{
 				name: 'imgcopyvio_rationale',
 				type: 'input',
-				label: 'Deletion rationale for non-internet copyvios: ',
+				label: 'Deletion rationale for non-internet copyvios:',
 				size: 60
 			}
 		]
@@ -624,7 +624,7 @@ Twinkle.speedy.articleList = [
 		subgroup: {
 			name: 'foreign_source',
 			type: 'input',
-			label: 'Interwiki link to the article on the foreign-language wiki: ',
+			label: 'Interwiki link to the article on the foreign-language wiki:',
 			tooltip: 'For example, fr:Bonjour'
 		}
 	},
@@ -640,7 +640,7 @@ Twinkle.speedy.articleList = [
 		subgroup: {
 			name: 'transwiki_location',
 			type: 'input',
-			label: 'Link to where the page has been transwikied: ',
+			label: 'Link to where the page has been transwikied:',
 			tooltip: 'For example, https://en.wiktionary.org/wiki/twinkle or [[wikt:twinkle]]'
 		}
 	},
@@ -704,7 +704,7 @@ Twinkle.speedy.articleList = [
 		subgroup: {
 			name: 'a10_article',
 			type: 'input',
-			label: 'Article that is duplicated: '
+			label: 'Article that is duplicated:'
 		}
 	},
 	{
@@ -727,7 +727,7 @@ Twinkle.speedy.categoryList = [
 		subgroup: {
 			name: 'templatecat_rationale',
 			type: 'input',
-			label: 'Optional explanation: ',
+			label: 'Optional explanation:',
 			size: 60
 		}
 	},
@@ -747,7 +747,7 @@ Twinkle.speedy.userList = [
 		subgroup: mw.config.get('wgNamespaceNumber') === 3 && mw.config.get('wgTitle').indexOf('/') === -1 ? {
 			name: 'userreq_rationale',
 			type: 'input',
-			label: 'A mandatory rationale to explain why this user talk page should be deleted: ',
+			label: 'A mandatory rationale to explain why this user talk page should be deleted:',
 			tooltip: 'User talk pages are deleted only in highly exceptional circumstances. See WP:DELTALK.',
 			size: 60
 		} : null,
@@ -794,7 +794,7 @@ Twinkle.speedy.portalList = [
 		subgroup: {
 			name: 'p1_criterion',
 			type: 'input',
-			label: 'Article criterion that would apply: '
+			label: 'Article criterion that would apply:'
 		}
 	},
 	{
@@ -835,7 +835,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'repost_xfd',
 			type: 'input',
-			label: 'Page where the deletion discussion took place: ',
+			label: 'Page where the deletion discussion took place:',
 			tooltip: 'Must start with "Wikipedia:"',
 			size: 60
 		}
@@ -847,7 +847,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'banned_user',
 			type: 'input',
-			label: 'Username of banned user (if available): ',
+			label: 'Username of banned user (if available):',
 			tooltip: 'Should not start with "User:"'
 		}
 	},
@@ -859,12 +859,12 @@ Twinkle.speedy.generalList = [
 			{
 				name: 'move_page',
 				type: 'input',
-				label: 'Page to be moved here: '
+				label: 'Page to be moved here:'
 			},
 			{
 				name: 'move_reason',
 				type: 'input',
-				label: 'Reason: ',
+				label: 'Reason:',
 				size: 60
 			}
 		],
@@ -877,7 +877,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'xfd_fullvotepage',
 			type: 'input',
-			label: 'Page where the deletion discussion was held: ',
+			label: 'Page where the deletion discussion was held:',
 			tooltip: 'Must start with "Wikipedia:"',
 			size: 40
 		},
@@ -890,7 +890,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'copypaste_sourcepage',
 			type: 'input',
-			label: 'Original page that was copy-pasted here: '
+			label: 'Original page that was copy-pasted here:'
 		},
 		hideWhenMultiple: true
 	},
@@ -901,7 +901,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'g6_rationale',
 			type: 'input',
-			label: 'Rationale: ',
+			label: 'Rationale:',
 			size: 60
 		}
 	},
@@ -912,7 +912,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'author_rationale',
 			type: 'input',
-			label: 'Optional explanation: ',
+			label: 'Optional explanation:',
 			tooltip: 'Perhaps linking to where the author requested this deletion.',
 			size: 60
 		},
@@ -925,7 +925,7 @@ Twinkle.speedy.generalList = [
 		subgroup: {
 			name: 'g8_rationale',
 			type: 'input',
-			label: 'Optional explanation: ',
+			label: 'Optional explanation:',
 			size: 60
 		},
 		hideSubgroupWhenSysop: true
@@ -961,21 +961,21 @@ Twinkle.speedy.generalList = [
 			{
 				name: 'copyvio_url',
 				type: 'input',
-				label: 'URL (if available): ',
+				label: 'URL (if available):',
 				tooltip: 'If the material was copied from an online source, put the URL here, including the "http://" or "https://" protocol.',
 				size: 60
 			},
 			{
 				name: 'copyvio_url2',
 				type: 'input',
-				label: 'Additional URL: ',
+				label: 'Additional URL:',
 				tooltip: 'Optional. Should begin with "http://" or "https://"',
 				size: 60
 			},
 			{
 				name: 'copyvio_url3',
 				type: 'input',
-				label: 'Additional URL: ',
+				label: 'Additional URL:',
 				tooltip: 'Optional. Should begin with "http://" or "https://"',
 				size: 60
 			}

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -61,7 +61,7 @@ Twinkle.unlink.callback = function(presetReason) {
 	form.append({
 		type: 'input',
 		name: 'reason',
-		label: 'Reason: ',
+		label: 'Reason:',
 		value: presetReason ? presetReason : '',
 		size: 60
 	});

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -290,7 +290,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 		work_area.append({
 			type: 'textarea',
 			name: 'reason',
-			label: 'Reason: ',
+			label: 'Reason:',
 			value: oldreason,
 			tooltip: 'You can use wikimarkup in your reason. Twinkle will automatically sign your post.'
 		});
@@ -383,7 +383,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				type: 'select',
 				multiple: true,
 				name: 'delsortCats',
-				label: 'Choose deletion sorting categories: ',
+				label: 'Choose deletion sorting categories:',
 				tooltip: 'Select a few categories that are specifically relevant to the subject of the article. Be as precise as possible; categories like People and USA should only be used when no other categories apply.'
 			});
 
@@ -445,7 +445,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			var templateOrModule = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'module' : 'template';
 			work_area.append({
 				type: 'select',
-				label: 'Choose type of action wanted: ',
+				label: 'Choose type of action wanted:',
 				name: 'xfdcat',
 				event: function(e) {
 					var target = e.target,
@@ -455,7 +455,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						tfdtarget = new Morebits.quickForm.element({
 							name: 'tfdtarget',
 							type: 'input',
-							label: 'Other ' + templateOrModule + ' to be merged: ',
+							label: 'Other ' + templateOrModule + ' to be merged:',
 							tooltip: 'Required. Should not include the ' + Morebits.string.toUpperCaseFirstChar(templateOrModule) + ': namespace prefix.',
 							required: true
 						});
@@ -473,7 +473,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			work_area.append({
 				type: 'select',
 				name: 'templatetype',
-				label: 'Deletion tag display style: ',
+				label: 'Deletion tag display style:',
 				tooltip: 'Which <code>type=</code> parameter to pass to the TfD tag template.',
 				list: templateOrModule === 'module' ? [
 					{ type: 'option', value: 'module', label: 'Module', selected: true }
@@ -572,7 +572,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			var isCategory = mw.config.get('wgNamespaceNumber') === 14;
 			work_area.append({
 				type: 'select',
-				label: 'Choose type of action wanted: ',
+				label: 'Choose type of action wanted:',
 				name: 'xfdcat',
 				event: function(e) {
 					var value = e.target.value,
@@ -626,7 +626,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			work_area.append({
 				type: 'input',
 				name: 'cfdtarget',
-				label: 'Target category: ', // default, changed above
+				label: 'Target category:', // default, changed above
 				disabled: true,
 				required: true, // only when enabled
 				value: ''
@@ -644,7 +644,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			});
 			work_area.append({
 				type: 'select',
-				label: 'C2 sub-criterion: ',
+				label: 'C2 sub-criterion:',
 				name: 'xfdcat',
 				tooltip: 'See WP:CFDS for full explanations.',
 				list: [
@@ -660,7 +660,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			work_area.append({
 				type: 'input',
 				name: 'cfdstarget',
-				label: 'New name: ',
+				label: 'New name:',
 				value: '',
 				required: true
 			});
@@ -717,7 +717,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			work_area.append({
 				type: 'input',
 				name: 'newname',
-				label: 'New title: ',
+				label: 'New title:',
 				tooltip: 'Required for technical requests. Otherwise, if unsure of the appropriate title, you may leave it blank.'
 			});
 

--- a/morebits.js
+++ b/morebits.js
@@ -439,6 +439,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				label = node.appendChild(document.createElement('label'));
 				label.setAttribute('for', id);
 				label.appendChild(Morebits.createHtml(data.label));
+				label.style.marginRight = '3px';
 			}
 			var select = node.appendChild(document.createElement('select'));
 			if (data.event) {
@@ -639,6 +640,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				label = node.appendChild(document.createElement('label'));
 				label.appendChild(Morebits.createHtml(data.label));
 				label.setAttribute('for', data.id || id);
+				label.style.marginRight = '3px';
 			}
 
 			subnode = node.appendChild(document.createElement('input'));
@@ -730,6 +732,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				label = node.appendChild(document.createElement('label'));
 				label.appendChild(document.createTextNode(data.label));
 				label.setAttribute('for', id);
+				label.style.marginRight = '3px';
 			}
 
 			subnode = node.appendChild(document.createElement('input'));


### PR DESCRIPTION
For almost every input field label, such a margin was being artificially added till now by ending the label with a trailing space.

However, trailing spaces are not allowed on translatewiki.net (technical limitation) and so needs to be written as `&#32;` (https://phabricator.wikimedia.org/T278627#7019324) which unnecessarily obfuscates so many messages.