### PR TITLE
fluff: make rollback links and separators selectable via CSS

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -103,11 +103,22 @@ Twinkle.fluff.linkBuilder = {
 			revNode.setAttribute('id', 'tw-revert');
 		}
 
-		var normNode = document.createElement('strong');
-		var vandNode = document.createElement('strong');
+		var separator = inline ? ' ' : ' || ';
+		var sepNode1 = document.createElement('span');
+		var sepText = document.createTextNode(separator);
+		sepNode1.setAttribute('class', 'tw-rollback-link-separator');
+		sepNode1.appendChild(sepText);
+
+		var sepNode2 = sepNode1.cloneNode(true);
+
+		var normNode = document.createElement('span');
+		var vandNode = document.createElement('span');
 
 		var normLink = Twinkle.fluff.linkBuilder.buildLink('SteelBlue', 'rollback');
 		var vandLink = Twinkle.fluff.linkBuilder.buildLink('Red', 'vandalism');
+
+		normLink.style.fontWeight = 'bold';
+		vandLink.style.fontWeight = 'bold';
 
 		$(normLink).click(function() {
 			Twinkle.fluff.revert('norm', vandal, rev, page);
@@ -118,10 +129,14 @@ Twinkle.fluff.linkBuilder = {
 			Twinkle.fluff.disableLinks(revNode);
 		});
 
-		vandNode.appendChild(vandLink);
-		normNode.appendChild(normLink);
+		normNode.setAttribute('class', 'tw-rollback-link-normal');
+		vandNode.setAttribute('class', 'tw-rollback-link-vandalism');
 
-		var separator = inline ? ' ' : ' || ';
+		normNode.appendChild(sepNode1);
+		vandNode.appendChild(sepNode2);
+
+		normNode.appendChild(normLink);
+		vandNode.appendChild(vandLink);
 
 		if (!inline) {
 			var agfNode = document.createElement('strong');
@@ -130,16 +145,15 @@ Twinkle.fluff.linkBuilder = {
 				Twinkle.fluff.revert('agf', vandal, rev, page);
 				// Twinkle.fluff.disableLinks(revNode); // rollbackInPlace not relevant for any inline situations
 			});
+			agfNode.setAttribute('class', 'tw-rollback-link-agf');
 			agfNode.appendChild(agfLink);
 			revNode.appendChild(agfNode);
 		}
-		revNode.appendChild(document.createTextNode(separator));
+
 		revNode.appendChild(normNode);
-		revNode.appendChild(document.createTextNode(separator));
 		revNode.appendChild(vandNode);
 
 		return revNode;
-
 	},
 
 	// Build [restore this revision] links

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -139,13 +139,14 @@ Twinkle.fluff.linkBuilder = {
 		vandNode.appendChild(vandLink);
 
 		if (!inline) {
-			var agfNode = document.createElement('strong');
+			var agfNode = document.createElement('span');
 			var agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
 			$(agfLink).click(function() {
 				Twinkle.fluff.revert('agf', vandal, rev, page);
 				// Twinkle.fluff.disableLinks(revNode); // rollbackInPlace not relevant for any inline situations
 			});
 			agfNode.setAttribute('class', 'tw-rollback-link-agf');
+			agfLink.style.fontWeight = 'bold';
 			agfNode.appendChild(agfLink);
 			revNode.appendChild(agfNode);
 		}


### PR DESCRIPTION
fix #1386

![twinklefluff-20210425-span](https://user-images.githubusercontent.com/66693882/115998917-f1f10680-a5e9-11eb-9642-670097db868e.png)
![twinklefluff-20210425-sep](https://user-images.githubusercontent.com/66693882/115998924-f6b5ba80-a5e9-11eb-9ec0-42d68271cc8c.png)
![twinklefluff-20210425-a](https://user-images.githubusercontent.com/66693882/115998926-f9181480-a5e9-11eb-8d54-633d4a56c989.png)

