### PR TITLE
Use DOM .focus() instead of jQuery

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -1696,7 +1696,7 @@ Morebits.select2 = {
 		target.select2('open');
 		var search = target.data('select2').dropdown.$search ||
 			target.data('select2').selection.$search;
-		// Use DOM .focus() to work around a jQuery 3.6.0 regression
+		// Use DOM .focus() to work around a jQuery 3.6.0 regression (https://github.com/select2/select2/issues/5993)
 		search[0].focus();
 	}
 

--- a/morebits.js
+++ b/morebits.js
@@ -1696,7 +1696,8 @@ Morebits.select2 = {
 		target.select2('open');
 		var search = target.data('select2').dropdown.$search ||
 			target.data('select2').selection.$search;
-		search.focus();
+		// Use DOM .focus() to work around a jQuery 3.6.0 regression
+		search[0].focus();
 	}
 
 };


### PR DESCRIPTION
The Select2 search box no longer gets focused when opened due to a jQuery 3.6.0 regression.
https://github.com/select2/select2/issues/5993
https://github.com/jquery/jquery/pull/4885

First reported here:
https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=1024931585#Warning_template_filter_no_longer_gets_focused