### PR TITLE
Tick the noinclude box when protecting a subpage of AfD

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -530,7 +530,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						name: 'noinclude',
 						label: 'Wrap protection template with <noinclude>',
 						tooltip: 'Will wrap the protection template in &lt;noinclude&gt; tags, so that it won\'t transclude',
-						checked: mw.config.get('wgNamespaceNumber') === 10 || (mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf("Articles for deletion/") === 0)
+						checked: mw.config.get('wgNamespaceNumber') === 10 || (mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0)
 					}
 				]
 			});

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -530,7 +530,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						name: 'noinclude',
 						label: 'Wrap protection template with <noinclude>',
 						tooltip: 'Will wrap the protection template in &lt;noinclude&gt; tags, so that it won\'t transclude',
-						checked: mw.config.get('wgNamespaceNumber') === 10
+						checked: mw.config.get('wgNamespaceNumber') === 10 || (mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf("Articles for deletion/") === 0)
 					}
 				]
 			});


### PR DESCRIPTION
Fixes #1432

This change means that subpages of AfD will have the checkbox ticked by default which wraps the page protection icon in a noinclude. See #1432 for why this is needed.

This change does that by checking if both the page namespace number is the project space number as defined by wgNamespaceIds and that wgTitle starts with "Articles for deletion/". I've not used the startsWith as it is not supported by IE 11 (and as far as I am aware Twinkle supports IE 11). Instead I checked to see if the string "Articles for deletion/" is found at index 0 inside wgTitle. If the index is 0, then the page name begins with the string and is a subpage of AfD. If it is not zero (i.e. -1 or above 0) then the check fails, and therefore is not a subpage of AfD.