### PR TITLE
morebits: quickform: handle undefined label to fix bug in PROD

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -207,6 +207,9 @@ Morebits.pageNameRegex = function(pageName) {
  */
 Morebits.createHtml = function(input) {
 	var fragment = document.createDocumentFragment();
+	if (!input) {
+		return fragment;
+	}
 	if (!Array.isArray(input)) {
 		input = [ input ];
 	}


### PR DESCRIPTION
Undefined `data.label` was crashing PROD module before even the window is displayed.