### PR TITLE
twinkle: add class to vector dropdown

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -279,7 +279,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
 				navigation = 'mw-panel';
 			}
-			outerNavClass = 'mw-portlet vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown' : 'tabs');
+			outerNavClass = 'mw-portlet vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown vector-menu-dropdown-noicon' : 'tabs');
 			innerDivClass = 'vector-menu-content';
 			break;
 		case 'modern':


### PR DESCRIPTION
Vector has changed the portlet HTML (again) and now requires
.vector-menu-dropdown-noicon for the portlet to display properly in
Vector and New Vector.

https://phabricator.wikimedia.org/T290994