### PR TITLE
twinklewarn: Improve edit summaries for uw-paidX and uw-coi-username

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -568,19 +568,19 @@ Twinkle.warn.messages = {
 			'uw-paid': {
 				level1: {
 					label: 'Paid editing without disclosure under the Wikimedia Terms of Use',
-					summary: 'General note: Paid editing without disclosure under the Wikimedia Terms of Use'
+					summary: 'General note: Disclosure requirements for paid editing under the Wikimedia Terms of Use'
 				},
 				level2: {
 					label: 'Paid editing without disclosure under the Wikimedia Terms of Use',
-					summary: 'Caution: Paid editing without disclosure under the Wikimedia Terms of Use'
+					summary: 'Caution: Disclosure requirements for paid editing under the Wikimedia Terms of Use'
 				},
 				level3: {
 					label: 'Paid editing without disclosure under the Wikimedia Terms of Use',
-					summary: 'Warning: Paid editing without disclosure under the Wikimedia Terms of Use'
+					summary: 'Warning: Disclosure requirements for paid editing under the Wikimedia Terms of Use'
 				},
 				level4: {
 					label: 'Paid editing without disclosure under the Wikimedia Terms of Use',
-					summary: 'Final warning: Paid editing without disclosure under the Wikimedia Terms of Use'
+					summary: 'Final warning: Disclosure requirements for paid editing under the Wikimedia Terms of Use'
 				}
 			},
 			'uw-spam': {
@@ -1168,7 +1168,7 @@ Twinkle.warn.messages = {
 		},
 		'uw-coi-username': {
 			label: 'Username is against policy, and conflict of interest',
-			summary: 'Warning: Username and conflict of interest policy',
+			summary: 'Warning: Username and conflict of interest',
 			heading: 'Your username'
 		},
 		'uw-userpage': {


### PR DESCRIPTION
Fixing two issues:
- The uw-paidX templates are about a concern usually based on off-wiki evidence, and about a topic with legal implications. The template language is very carefully crafted not to directly state the apparent TOU violation as a fact, as doing so could be libellous, and as actual evidence of intentional disclosure omission would have to be handled by administrative action instead of a warning. Yet: The edit summary currently doesn't share this caution.
- The conflict of interest guideline is not a policy.