### PR TITLE
prod: adjust deletion tag regex to avoid matching {{Deleted on Commons}}

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -257,7 +257,7 @@ Twinkle.prod.callbacks = {
 			var text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			var tag_re = /{{(?:db-?|delete|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			var tag_re = /{{(?:db-?|delete\b|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();


### PR DESCRIPTION
Reported at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#"prod"_doesn't_work_when_{{deleted_on_Commons}}_is_present