### PR TITLE
speedy: fix bugs involving watchlist preferences

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2027,9 +2027,19 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	var watchPage = normalizeds.some(function(norm) {
-		return Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1 && Twinkle.getPref('watchSpeedyExpiry');
+	// analyse each criterion to determine whether to watch the page/notify the creator
+	var watchPage = normalizeds.some(function(csdCriteria) {
+		let isWatchingThisCriteria = ( Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1 );
+		let isWatchingAllCSDs = ( Twinkle.getPref('watchSpeedyExpiry') !== "no" );
+		let shouldWatchThis = ( isWatchingThisCriteria && isWatchingAllCSDs );
+		return shouldWatchThis;
 	});
+
+	// if we should watch the page, replace "true" with the duration we should watch for
+	if ( watchPage ) {
+		watchPage = Twinkle.getPref('watchSpeedyExpiry');
+	}
+
 	var notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2028,14 +2028,14 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
 	var watchPage = normalizeds.some(function(csdCriteria) {
-		let isWatchingThisCriteria = ( Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1 );
-		let isWatchingAllCSDs = ( Twinkle.getPref('watchSpeedyExpiry') !== "no" );
-		let shouldWatchThis = ( isWatchingThisCriteria && isWatchingAllCSDs );
+		var isWatchingThisCriteria = Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1 ;
+		var isWatchingAllCSDs = Twinkle.getPref('watchSpeedyExpiry') !== 'no' ;
+		var shouldWatchThis = isWatchingThisCriteria && isWatchingAllCSDs ;
 		return shouldWatchThis;
 	});
 
 	// if we should watch the page, replace "true" with the duration we should watch for
-	if ( watchPage ) {
+	if (watchPage) {
 		watchPage = Twinkle.getPref('watchSpeedyExpiry');
 	}
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2028,9 +2028,9 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
 	var watchPage = normalizeds.some(function(csdCriteria) {
-		var isWatchingThisCriteria = Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1 ;
-		var isWatchingAllCSDs = Twinkle.getPref('watchSpeedyExpiry') !== 'no' ;
-		var shouldWatchThis = isWatchingThisCriteria && isWatchingAllCSDs ;
+		var isWatchingThisCriteria = Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
+		var isWatchingAllCSDs = Twinkle.getPref('watchSpeedyExpiry') !== 'no';
+		var shouldWatchThis = isWatchingThisCriteria && isWatchingAllCSDs;
 		return shouldWatchThis;
 	});
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2027,7 +2027,6 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	// analyse each criterion to determine whether to watch the page/notify the creator
 	var watchPage = normalizeds.some(function(csdCriteria) {
 		let isWatchingThisCriteria = ( Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1 );
 		let isWatchingAllCSDs = ( Twinkle.getPref('watchSpeedyExpiry') !== "no" );

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2028,16 +2028,8 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
 	var watchPage = normalizeds.some(function(csdCriteria) {
-		var isWatchingThisCriteria = Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
-		var isWatchingAllCSDs = Twinkle.getPref('watchSpeedyExpiry') !== 'no';
-		var shouldWatchThis = isWatchingThisCriteria && isWatchingAllCSDs;
-		return shouldWatchThis;
-	});
-
-	// if we should watch the page, replace "true" with the duration we should watch for
-	if (watchPage) {
-		watchPage = Twinkle.getPref('watchSpeedyExpiry');
-	}
+		return Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
+	}) && Twinkle.getPref('watchSpeedyExpiry');
 
 	var notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&


### PR DESCRIPTION
Fixes #1427 All CSD tagged articles getting added to watchlist, despite selecting "don't add to watchlist"

Also fixes a bug where all CSD watchlisting was permanent, instead of taking into account the duration set in the user's preferences.