### PR TITLE
tag: remove {{r from historic name}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -928,7 +928,6 @@ Twinkle.tag.redirectList = {
 			{ tag: 'R from alternative name', description: 'redirect from a title that is another name, a pseudonym, a nickname, or a synonym' },
 			{ tag: 'R from ambiguous sort name', description: 'redirect from an ambiguous sort name to a page or list that disambiguates it' },
 			{ tag: 'R from former name', description: 'redirect from a former name or working title' },
-			{ tag: 'R from historic name', description: 'redirect from a name with a significant historic past as a region, city, etc. no longer known by that name' },
 			{ tag: 'R from incomplete name', description: 'R from incomplete name' },
 			{ tag: 'R from incorrect name', description: 'redirect from an erroneus name that is unsuitable as a title' },
 			{ tag: 'R from less specific name', description: 'redirect from a less specific title to a more specific, less general one' },

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -927,7 +927,7 @@ Twinkle.tag.redirectList = {
 			},
 			{ tag: 'R from alternative name', description: 'redirect from a title that is another name, a pseudonym, a nickname, or a synonym' },
 			{ tag: 'R from ambiguous sort name', description: 'redirect from an ambiguous sort name to a page or list that disambiguates it' },
-			{ tag: 'R from former name', description: 'redirect from a former name or working title' },
+			{ tag: 'R from former name', description: 'redirect from a former or historic name or a working title' },
 			{ tag: 'R from incomplete name', description: 'R from incomplete name' },
 			{ tag: 'R from incorrect name', description: 'redirect from an erroneus name that is unsuitable as a title' },
 			{ tag: 'R from less specific name', description: 'redirect from a less specific title to a more specific, less general one' },


### PR DESCRIPTION
Fixes #1401 Merged {{r from former name}} and {{r from historic name}}

{{R from former name}} was kept, {{R from historic name}} was redirected to {{R from former name}}. Therefore it seems like the easiest fix for this is to delete {{R from historic name}}.