### PR TITLE
tag: allow wrapping existing tags in {{multiple issues}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2012,14 +2012,6 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 	}
 
-	/*
-	// return if no tags selected
-	if (params.tags.length === 0 && params.existingTags.length === 0) {
-		alert('You must select at least one tag!');
-		return;
-	}
-	*/
-
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1467,7 +1467,7 @@ Twinkle.tag.callbacks = {
 
 		};
 
-		if (!params.tags.length) {
+		if (!params.tags.length && !params.existingTags.length) {
 			removeTags();
 			return;
 		}
@@ -2012,12 +2012,13 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 	}
 
-	// File/redirect: return if no tags selected
-	// Article: return if no tag is selected and no already present tag is deselected
-	if (params.tags.length === 0 && (Twinkle.tag.mode !== 'article' || params.tagsToRemove.length === 0)) {
+	/*
+	// return if no tags selected
+	if (params.tags.length === 0 && params.existingTags.length === 0) {
 		alert('You must select at least one tag!');
 		return;
 	}
+	*/
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2018,7 +2018,7 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 		return;
 	}
 
-	// Article: Return if zero tags present AND no new/existing selected. This prevents Twinkle from hanging when trying to submit.
+	// Article: Return if zero tags present in article AND no new/existing tags selected via the form. This prevents Twinkle from hanging when trying to submit.
 	if (Twinkle.tag.mode === 'article' && params.tags.length === 0 && (typeof params.existingTags === 'undefined' || params.existingTags.length === 0) && Twinkle.tag.status.numAdded === 0 && Twinkle.tag.status.numRemoved === 0) {
 		alert('You must select at least one tag!');
 		return;

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2024,8 +2024,6 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 		return;
 	}
 
-	// TODO: adding one redirect tag is freezing. fix.
-
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2013,11 +2013,18 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 	}
 
 	// File/redirect: return if no tags selected
-	// Article: do nothing. unlike file/redirect, article detects existing tags and checks the boxes. also unlike file/redirect, we want the user to be able to apply the {{multiple issues}} tag, which may be applied without adding/removing any tags.
-	if (params.tags.length === 0 && Twinkle.tag.mode !== 'article') {
+	if (Twinkle.tag.mode !== 'article' && params.tags.length === 0) {
 		alert('You must select at least one tag!');
 		return;
 	}
+
+	// Article: Return if zero tags present AND no new/existing selected. This prevents Twinkle from hanging when trying to submit.
+	if (Twinkle.tag.mode === 'article' && params.tags.length === 0 && (typeof params.existingTags === 'undefined' || params.existingTags.length === 0) && Twinkle.tag.status.numAdded === 0 && Twinkle.tag.status.numRemoved === 0) {
+		alert('You must select at least one tag!');
+		return;
+	}
+
+	// TODO: adding one redirect tag is freezing. fix.
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -2012,6 +2012,13 @@ Twinkle.tag.callback.evaluate = function friendlytagCallbackEvaluate(e) {
 			break;
 	}
 
+	// File/redirect: return if no tags selected
+	// Article: do nothing. unlike file/redirect, article detects existing tags and checks the boxes. also unlike file/redirect, we want the user to be able to apply the {{multiple issues}} tag, which may be applied without adding/removing any tags.
+	if (params.tags.length === 0 && Twinkle.tag.mode !== 'article') {
+		alert('You must select at least one tag!');
+		return;
+	}
+
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1263,10 +1263,13 @@ Twinkle.tag.callbacks = {
 			if (addedTags.length) {
 				summaryText = 'Added ' + makeSentence(addedTags);
 				summaryText += removedTags.length ? '; and removed ' + makeSentence(removedTags) : '';
-			} else {
+				summaryText += ' tag' + (addedTags.length + removedTags.length > 1 ? 's' : '');
+			} else if (removedTags.length) {
 				summaryText = 'Removed ' + makeSentence(removedTags);
+				summaryText += ' tag' + (addedTags.length + removedTags.length > 1 ? 's' : '');
+			} else {
+				summaryText = 'Added {{Multiple issues}} wrapper around maintenance tags';
 			}
-			summaryText += ' tag' + (addedTags.length + removedTags.length > 1 ? 's' : '');
 			if (params.reason) {
 				summaryText += ': ' + params.reason;
 			}


### PR DESCRIPTION
Fixes #1334 Article tagging - when tags already present and ungrouped, not able to group them

~~edit: Converted to draft. I found a bug involving Twinkle hanging when an article has no tags. I will debug and then resubmit.~~

edit2: Bug fixed. Resubmitting.