### PR TITLE
dev-server: modify wgUserGroups to add sysop

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -18,6 +18,12 @@ const server = http.createServer(async (request, response) => {
 	const cssFiles = ['morebits.css', 'twinkle.css'];
 
 	let jsCode = `mw.loader.load(['jquery.ui', 'ext.gadget.select2']);`;
+
+	if (process.argv[2] !== '--no-sysop') {
+		// Pretend to be a sysop, if not one already - enables testing of sysop modules by non-sysops
+		jsCode += `if (mw.config.get('wgUserGroups').indexOf('sysop') === -1) mw.config.get('wgUserGroups').push('sysop');`;
+	}
+
 	for (let file of jsFiles) {
 		jsCode += await readFile(file);
 	}


### PR DESCRIPTION
As many features are not applicable to non-sysops, this aids testing of those features by non-sysops. This is done by default but can be turned off with `--no-sysop` flag. (Use as `node server.js --no-sysop` or `npm start -- --no-sysop`)