### PR TITLE
block: read discretionary sanctions information from a wiki page

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -517,8 +517,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	// grab discretionary sanctions list from en-wiki
-	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent).then(function(dsinfo) {
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1560,17 +1559,16 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 	);
 
 	// grab discretionary sanctions list from en-wiki
-	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent).then(function(dsinfo) {
-		var sanctionCode = parent.selectedIndex;
-		var sanctionName = parent.options[sanctionCode].label;
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
+		var sanctionCode = this.selectedIndex;
+		var sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;
-		if (!parent.value) {
-			parent.form.reason.value = reason;
+		if (!this.value) {
+			this.form.reason.value = reason;
 		} else {
-			parent.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
+			this.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
 		}
-	});
+	}.bind(this));
 };
 
 Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -521,10 +521,10 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	new Morebits.wiki.getCachedWikitext('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(wikitext) {
 		var dsinfo = JSON.parse(wikitext);
 		var $select = $('[name="dstopic"]');
-		$.each(dsinfo, function(key, value) {
-			var $option = $('<option>').val(value.code).text(key).prop('label', key);
-			$select.append($option);
+		var $options = $.map(dsinfo, function (value, key) {
+			return $('<option>').val(value.code).text(key).prop('label', key);
 		});
+		$select.append($options);
 	});
 
 	// DS selection visible in either the template field set or preset,

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -517,7 +517,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	// grab discretionary sanctions list from en-wiki
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
+	Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1559,7 +1559,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 	);
 
 	// grab discretionary sanctions list from en-wiki
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
+	Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
 		var sanctionCode = this.selectedIndex;
 		var sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -517,26 +517,15 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	// grab discretionary sanctions list from en-wiki
-	var query = {
-		action: 'query',
-		prop: 'revisions',
-		titles: 'Template:Ds/topics.json',
-		rvslots: '*',
-		rvprop: 'content',
-		format: 'json',
-		smaxage: '86400', // cache for 1 day
-		maxage: '86400' // cache for 1 day
-	};
-	new Morebits.wiki.api('Get JSON list of discretionary sanctions', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+	var parent = this;
+	new Morebits.wiki.getCachedWikitext('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(wikitext) {
 		var dsinfo = JSON.parse(wikitext);
 		var $select = $('[name="dstopic"]');
 		$.each(dsinfo, function(key, value) {
 			var $option = $('<option>').val(value.code).text(key).prop('label', key);
 			$select.append($option);
 		});
-	}).post();
+	});
 
 	// DS selection visible in either the template field set or preset,
 	// joint settings saved here
@@ -1573,30 +1562,18 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 	);
 
 	// grab discretionary sanctions list from en-wiki
-	var query = {
-		action: 'query',
-		prop: 'revisions',
-		titles: 'Template:Ds/topics.json',
-		rvslots: '*',
-		rvprop: 'content',
-		format: 'json',
-		smaxage: '86400', // cache for 1 day
-		maxage: '86400' // cache for 1 day
-	};
-	var obj = this;
-	new Morebits.wiki.api('Get JSON list of discretionary sanctions', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+	var parent = this;
+	new Morebits.wiki.getCachedWikitext('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(wikitext) {
 		var dsinfo = JSON.parse(wikitext);
-		var sanctionCode = obj.selectedIndex;
-		var sanctionName = obj.options[sanctionCode].label;
+		var sanctionCode = parent.selectedIndex;
+		var sanctionName = parent.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;
-		if (!obj.value) {
-			obj.form.reason.value = reason;
+		if (!parent.value) {
+			parent.form.reason.value = reason;
 		} else {
-			obj.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
+			parent.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
 		}
-	}).post();
+	});
 };
 
 Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -517,7 +517,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	}
 
 	// grab discretionary sanctions list from en-wiki
-	Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
+	Twinkle.block.dsinfo = Morebits.wiki.getCachedJson('Template:Ds/topics.json');
+
+	Twinkle.block.dsinfo.then(function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1558,8 +1560,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 		new RegExp(' ?\\(\\[\\[' + Twinkle.block.dsReason + '\\]\\]\\)'), ''
 	);
 
-	// grab discretionary sanctions list from en-wiki
-	Morebits.wiki.getCachedJson('Template:Ds/topics.json').then(function(dsinfo) {
+	Twinkle.block.dsinfo.then(function(dsinfo) {
 		var sanctionCode = this.selectedIndex;
 		var sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -516,6 +516,28 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 	}
 
+	// grab discretionary sanctions list from en-wiki
+	var query = {
+		action: 'query',
+		prop: 'revisions',
+		titles: 'Template:Ds/topics.json',
+		rvslots: '*',
+		rvprop: 'content',
+		format: 'json',
+		smaxage: '86400', // cache for 1 day
+		maxage: '86400' // cache for 1 day
+	};
+	new Morebits.wiki.api('Get JSON list of discretionary sanctions', query, function(apiobj) {
+		var response = apiobj.getResponse();
+		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+		var dsinfo = JSON.parse(wikitext);
+		var $select = $('[name="dstopic"]');
+		$.each(dsinfo, function(key, value) {
+			var $option = $('<option>').val(value.code).text(key).prop('label', key);
+			$select.append($option);
+		});
+	}).post();
+
 	// DS selection visible in either the template field set or preset,
 	// joint settings saved here
 	var dsSelectSettings = {
@@ -525,9 +547,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		value: '',
 		tooltip: 'If selected, it will inform the template and may be added to the blocking message',
 		event: Twinkle.block.callback.toggle_ds_reason,
-		list: $.map(Twinkle.block.dsinfo, function(info, label) {
-			return {label: label, value: info.code};
-		})
+		list: ''
 	};
 	if (templateBox) {
 		field_template_options = new Morebits.quickForm.element({ type: 'field', label: 'Template options', name: 'field_template_options' });
@@ -1321,146 +1341,6 @@ Twinkle.block.blockPresetsInfo = {
 	}
 };
 
-// Codes and links for Discretionary Sanctions, see [[Template:Ds/topics]]
-// Used for uw-ae(p)block
-Twinkle.block.dsinfo = {
-	'': {
-		code: ''
-	},
-	'Abortion': {
-		code: 'ab',
-		page: 'Wikipedia:Arbitration/Requests/Case/Abortion'
-	},
-	'American politics post-1992': {
-		code: 'ap',
-		page: 'Wikipedia:Arbitration/Requests/Case/American politics 2'
-	},
-	'Ancient Egyptian race controversy': {
-		code: 'aerc',
-		page: 'Wikipedia:Requests for arbitration/Ancient Egyptian race controversy'
-	},
-	'Arab-Israeli conflict': {
-		code: 'a-i',
-		page: 'Wikipedia:Arbitration/Index/Palestine-Israel articles'
-	},
-	'Armenia, Azerbaijan, or related conflicts': {
-		code: 'a-a',
-		page: 'Wikipedia:Requests for arbitration/Armenia-Azerbaijan 2'
-	},
-	'Biographies of Living Persons (BLPs)': {
-		code: 'blp',
-		page: 'Wikipedia:Requests for arbitration/Editing of Biographies of Living Persons'
-	},
-	'Climate change': {
-		code: 'cc',
-		page: 'Wikipedia:Arbitration/Requests/Case/Climate change'
-	},
-	'Complementary and alternative medicine': {
-		code: 'com',
-		page: 'Wikipedia:Arbitration/Requests/Case/Acupuncture'
-	},
-	'Eastern Europe or the Balkans': {
-		code: 'e-e',
-		page: 'Wikipedia:Requests for arbitration/Eastern Europe'
-	},
-	'Electronic cigarettes': {
-		code: 'ecig',
-		page: 'Wikipedia:Arbitration/Requests/Case/Editor conduct in e-cigs articles'
-	},
-	'Falun Gong': {
-		code: 'fg',
-		page: 'Wikipedia:Requests for arbitration/Falun Gong'
-	},
-	'Gender-related dispute or controversy and associated people (includes GamerGate)': {
-		code: 'gas',
-		page: 'Wikipedia:Arbitration/Requests/Case/Gender and sexuality'
-	},
-	'Genetically modified organisms (GMO)': {
-		code: 'gmo',
-		page: 'Wikipedia:Arbitration/Requests/Case/Genetically modified organisms'
-	},
-	'Gun control': {
-		code: 'gc',
-		page: 'Wikipedia:Arbitration/Requests/Case/Gun control'
-	},
-	'Horn of Africa (Ethiopia, Somalia, Eritrea, Djibouti)': {
-		code: 'horn',
-		page: 'Wikipedia:Arbitration/Requests/Case/Horn of Africa'
-	},
-	'India, Pakistan, and Afghanistan': {
-		code: 'ipa',
-		page: 'Wikipedia:Requests for arbitration/India-Pakistan'
-	},
-	'Infoboxes': {
-		code: 'cid',
-		page: 'Wikipedia:Arbitration/Requests/Case/Civility in infobox discussions'
-	},
-	'Kurds and Kurdistan': {
-		code: 'kurd',
-		page: 'Wikipedia:Arbitration/Requests/Case/Kurds and Kurdistan'
-	},
-	'Landmark Worldwide': {
-		code: 'lw',
-		page: 'Wikipedia:Arbitration/Requests/Case/Landmark Worldwide'
-	},
-	'Liancourt Rocks': {
-		code: 'lr',
-		page: 'Wikipedia:Requests for arbitration/Liancourt Rocks'
-	},
-	'Manual of Style and article titles': {
-		code: 'mos',
-		page: 'Wikipedia:Arbitration/Requests/Case/Article titles and capitalisation'
-	},
-	'Muhammad': {
-		code: 'muh-im',
-		page: 'Wikipedia:Arbitration/Requests/Case/Muhammad images'
-	},
-	'Pharmaceutical drug prices (medicine)': {
-		code: 'med',
-		page: 'Wikipedia:Arbitration/Requests/Case/Medicine'
-	},
-	'Prem Rawat': {
-		code: 'pr',
-		page: 'Wikipedia:Requests for arbitration/Prem Rawat'
-	},
-	'Pseudoscience and fringe science': {
-		code: 'ps',
-		page: 'Wikipedia:Requests for arbitration/Pseudoscience'
-	},
-	'Race/ethnicity and human abilities, behaviour, and intelligence': {
-		code: 'r-i',
-		page: 'Wikipedia:Arbitration/Requests/Case/Race and intelligence'
-	},
-	'Scientology': {
-		code: 'sci',
-		page: 'Wikipedia:Requests for arbitration/Scientology'
-	},
-	'Senkaku Islands dispute': {
-		code: 'sen',
-		page: 'Wikipedia:Arbitration/Requests/Case/Senkaku Islands'
-	},
-	'September 11 attacks': {
-		code: '9/11',
-		page: 'Wikipedia:Requests for arbitration/September 11 conspiracy theories'
-	},
-	'Shakespeare authorship question': {
-		code: 'saq',
-		page: 'Wikipedia:Arbitration/Requests/Case/Shakespeare authorship question'
-	},
-	'Transcendental Meditation movement': {
-		code: 'tm',
-		page: 'Wikipedia:Arbitration/Requests/Case/Transcendental Meditation movement'
-	},
-	'The Troubles': {
-		code: 'tt',
-		page: 'Wikipedia:Requests for arbitration/The Troubles'
-	},
-	'Waldorf education': {
-		code: 'we',
-		page: 'Wikipedia:Requests for arbitration/Waldorf education'
-	}
-};
-
 Twinkle.block.transformBlockPresets = function twinkleblockTransformBlockPresets() {
 	// supply sensible defaults
 	$.each(Twinkle.block.blockPresetsInfo, function(preset, settings) {
@@ -1692,12 +1572,31 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 		new RegExp(' ?\\(\\[\\[' + Twinkle.block.dsReason + '\\]\\]\\)'), ''
 	);
 
-	Twinkle.block.dsReason = Twinkle.block.dsinfo[this.options[this.selectedIndex].label].page;
-	if (!this.value) {
-		this.form.reason.value = reason;
-	} else {
-		this.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
-	}
+	// grab discretionary sanctions list from en-wiki
+	var query = {
+		action: 'query',
+		prop: 'revisions',
+		titles: 'Template:Ds/topics.json',
+		rvslots: '*',
+		rvprop: 'content',
+		format: 'json',
+		smaxage: '86400', // cache for 1 day
+		maxage: '86400' // cache for 1 day
+	};
+	var obj = this;
+	new Morebits.wiki.api('Get JSON list of discretionary sanctions', query, function(apiobj) {
+		var response = apiobj.getResponse();
+		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+		var dsinfo = JSON.parse(wikitext);
+		var sanctionCode = obj.selectedIndex;
+		var sanctionName = obj.options[sanctionCode].label;
+		Twinkle.block.dsReason = dsinfo[sanctionName].page;
+		if (!obj.value) {
+			obj.form.reason.value = reason;
+		} else {
+			obj.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
+		}
+	}).post();
 };
 
 Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -518,7 +518,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent, function(dsinfo) {
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent).then(function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1561,7 +1561,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent, function(dsinfo) {
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent).then(function(dsinfo) {
 		var sanctionCode = parent.selectedIndex;
 		var sanctionName = parent.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -518,8 +518,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedWikitext('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(wikitext) {
-		var dsinfo = JSON.parse(wikitext);
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1562,8 +1561,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedWikitext('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(wikitext) {
-		var dsinfo = JSON.parse(wikitext);
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(dsinfo) {
 		var sanctionCode = parent.selectedIndex;
 		var sanctionName = parent.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -535,7 +535,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		label: 'DS topic',
 		value: '',
 		tooltip: 'If selected, it will inform the template and may be added to the blocking message',
-		event: Twinkle.block.callback.toggle_ds_reason,
+		event: Twinkle.block.callback.toggle_ds_reason
 	};
 	if (templateBox) {
 		field_template_options = new Morebits.quickForm.element({ type: 'field', label: 'Template options', name: 'field_template_options' });

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -536,7 +536,6 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		value: '',
 		tooltip: 'If selected, it will inform the template and may be added to the blocking message',
 		event: Twinkle.block.callback.toggle_ds_reason,
-		list: ''
 	};
 	if (templateBox) {
 		field_template_options = new Morebits.quickForm.element({ type: 'field', label: 'Template options', name: 'field_template_options' });

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -518,7 +518,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(dsinfo) {
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent, function(dsinfo) {
 		var $select = $('[name="dstopic"]');
 		var $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
@@ -1561,7 +1561,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 
 	// grab discretionary sanctions list from en-wiki
 	var parent = this;
-	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', 'Get JSON list of discretionary sanctions', parent, function(dsinfo) {
+	new Morebits.wiki.getCachedJson('Template:Ds/topics.json', parent, function(dsinfo) {
 		var sanctionCode = parent.selectedIndex;
 		var sanctionName = parent.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -356,8 +356,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			// grab deletion sort categories from en-wiki
 			var parent = this;
-			new Morebits.wiki.getCachedWikitext('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', 'Get JSON list of deletion sorting categories', parent, function(wikitext) {
-				var delsortCategories = JSON.parse(wikitext);
+			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', 'Get JSON list of deletion sorting categories', parent, function(delsortCategories) {
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
 					var $optgroup = $('<optgroup>').attr('label', groupname);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -356,7 +356,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			// grab deletion sort categories from en-wiki
 			var parent = this;
-			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', parent, function(delsortCategories) {
+			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', parent).then(function(delsortCategories) {
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
 					var $optgroup = $('<optgroup>').attr('label', groupname);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -356,7 +356,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			// grab deletion sort categories from en-wiki
 			var parent = this;
-			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', 'Get JSON list of deletion sorting categories', parent, function(delsortCategories) {
+			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', parent, function(delsortCategories) {
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
 					var $optgroup = $('<optgroup>').attr('label', groupname);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -355,8 +355,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			});
 
 			// grab deletion sort categories from en-wiki
-			var parent = this;
-			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', parent).then(function(delsortCategories) {
+			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
 					var $optgroup = $('<optgroup>').attr('label', groupname);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -355,7 +355,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			});
 
 			// grab deletion sort categories from en-wiki
-			new Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
+			Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
 					var $optgroup = $('<optgroup>').attr('label', groupname);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -354,20 +354,9 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				tooltip: 'Select a few categories that are specifically relevant to the subject of the article. Be as precise as possible; categories like People and USA should only be used when no other categories apply.'
 			});
 
-			// grab delsort categories from on-wiki
-			var query = {
-				action: 'query',
-				prop: 'revisions',
-				titles: 'Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json',
-				rvslots: '*',
-				rvprop: 'content',
-				format: 'json',
-				smaxage: '86400', // cache for 1 day
-				maxage: '86400' // cache for 1 day
-			};
-			new Morebits.wiki.api('Get JSON list of deletion sorting categories', query, function(apiobj) {
-				var response = apiobj.getResponse();
-				var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+			// grab deletion sort categories from en-wiki
+			var parent = this;
+			new Morebits.wiki.getCachedWikitext('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json', 'Get JSON list of deletion sorting categories', parent, function(wikitext) {
 				var delsortCategories = JSON.parse(wikitext);
 				var $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
@@ -378,7 +367,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						$delsortCat.append($option);
 					});
 				});
-			}).post();
+			});
 
 			appendReasonBox();
 			work_area = work_area.render();

--- a/morebits.js
+++ b/morebits.js
@@ -2472,7 +2472,7 @@ Morebits.wiki.api.prototype = {
 };
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
-Morebits.wiki.getCachedWikitext = function(title, description, parent, callback) {
+Morebits.wiki.getCachedJson = function(title, description, parent, callback) {
 	var query = {
 		action: 'query',
 		prop: 'revisions',
@@ -2486,7 +2486,8 @@ Morebits.wiki.getCachedWikitext = function(title, description, parent, callback)
 	new Morebits.wiki.api(description, query, function(apiobj) {
 		var response = apiobj.getResponse();
 		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
-		callback(wikitext, parent);
+		var json = JSON.parse(wikitext);
+		callback(json, parent);
 	}).post();
 };
 

--- a/morebits.js
+++ b/morebits.js
@@ -2472,7 +2472,7 @@ Morebits.wiki.api.prototype = {
 };
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
-Morebits.wiki.getCachedJson = function(title, parent) {
+Morebits.wiki.getCachedJson = function(title) {
 	var query = {
 		action: 'query',
 		prop: 'revisions',

--- a/morebits.js
+++ b/morebits.js
@@ -2472,7 +2472,7 @@ Morebits.wiki.api.prototype = {
 };
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
-Morebits.wiki.getCachedJson = function(title, parent, callback) {
+Morebits.wiki.getCachedJson = function(title, parent) {
 	var query = {
 		action: 'query',
 		prop: 'revisions',
@@ -2483,11 +2483,10 @@ Morebits.wiki.getCachedJson = function(title, parent, callback) {
 		smaxage: '86400', // cache for 1 day
 		maxage: '86400' // cache for 1 day
 	};
-	new Morebits.wiki.api('', query, function(apiobj) {
+	return new Morebits.wiki.api('', query, function(apiobj) {
 		var response = apiobj.getResponse();
 		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
-		var json = JSON.parse(wikitext);
-		callback(json, parent);
+		return JSON.parse(wikitext);
 	}).post();
 };
 

--- a/morebits.js
+++ b/morebits.js
@@ -2472,7 +2472,7 @@ Morebits.wiki.api.prototype = {
 };
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
-Morebits.wiki.getCachedJson = function(title, description, parent, callback) {
+Morebits.wiki.getCachedJson = function(title, parent, callback) {
 	var query = {
 		action: 'query',
 		prop: 'revisions',
@@ -2483,7 +2483,7 @@ Morebits.wiki.getCachedJson = function(title, description, parent, callback) {
 		smaxage: '86400', // cache for 1 day
 		maxage: '86400' // cache for 1 day
 	};
-	new Morebits.wiki.api(description, query, function(apiobj) {
+	new Morebits.wiki.api('', query, function(apiobj) {
 		var response = apiobj.getResponse();
 		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
 		var json = JSON.parse(wikitext);

--- a/morebits.js
+++ b/morebits.js
@@ -2483,11 +2483,11 @@ Morebits.wiki.getCachedJson = function(title, parent) {
 		smaxage: '86400', // cache for 1 day
 		maxage: '86400' // cache for 1 day
 	};
-	return new Morebits.wiki.api('', query, function(apiobj) {
+	return new Morebits.wiki.api('', query).post().then(function(apiobj) {
 		var response = apiobj.getResponse();
 		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
 		return JSON.parse(wikitext);
-	}).post();
+	});
 };
 
 var morebitsWikiApiUserAgent = 'morebits.js ([[w:WT:TW]])';

--- a/morebits.js
+++ b/morebits.js
@@ -2484,6 +2484,7 @@ Morebits.wiki.getCachedJson = function(title) {
 		maxage: '86400' // cache for 1 day
 	};
 	return new Morebits.wiki.api('', query).post().then(function(apiobj) {
+		apiobj.getStatusElement().unlink();
 		var response = apiobj.getResponse();
 		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
 		return JSON.parse(wikitext);

--- a/morebits.js
+++ b/morebits.js
@@ -2471,6 +2471,25 @@ Morebits.wiki.api.prototype = {
 
 };
 
+/** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
+Morebits.wiki.getCachedWikitext = function(title, description, parent, callback) {
+	var query = {
+		action: 'query',
+		prop: 'revisions',
+		titles: title,
+		rvslots: '*',
+		rvprop: 'content',
+		format: 'json',
+		smaxage: '86400', // cache for 1 day
+		maxage: '86400' // cache for 1 day
+	};
+	new Morebits.wiki.api(description, query, function(apiobj) {
+		var response = apiobj.getResponse();
+		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+		callback(wikitext, parent);
+	}).post();
+};
+
 var morebitsWikiApiUserAgent = 'morebits.js ([[w:WT:TW]])';
 /**
  * Set the custom user agent header, which is used for server-side logging.


### PR DESCRIPTION
- Fixes #1477 Read discretionary sanctions information from a wiki page
- I created the function `Morebits.wiki.getCachedWikitext(title, description, parent, callback)`, and I refactored the code to use the function in 3 places.
- I created https://en.wikipedia.org/wiki/Template:Ds/topics.json
- I added COVID-19 and Longevity to the list of discretionary sanctions

![image](https://user-images.githubusercontent.com/79697282/143776868-08700dcd-1f5b-40ba-9c7f-fb881866ed38.png)