### PR TITLE
speedy: handle blacklisted sites for G12 nominations

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1506,7 +1506,7 @@ Twinkle.speedy.callbacks = {
 					if (!g12) {
 						return;
 					}
-					var matches = text.match(/^([\s\S]*)(\{\{db-copyvio\|[^\}]*\}\})([\s\S]*)$/i);
+					var matches = text.match(/^([\s\S]*)(\{\{db-copyvio\|[^}]*\}\})([\s\S]*)$/i);
 					// Matches should have 3 chunks, and the middle chunk should be the {{db-copyvio}} tag that Twinkle added to the page. This is where we want to remove http(s):// from the URLs in the parameters of the tag.
 					// Using [\s\S]* as a workaround for no RegEx /s flag in ES5.
 					if (matches.length !== 3) {


### PR DESCRIPTION
fixes #1111 Handle blacklisted sites for G12 nominations

I've marked this as a draft since it is not working yet. I wrote some code but it is not currently getting called. The code is probably in the wrong place. Any tips?

![2021-12-04_035627](https://user-images.githubusercontent.com/79697282/144708935-5d9df12d-823b-4481-a002-221e15394d2d.png)
