### PR TITLE
arv: improve AN3 explanation text

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -447,7 +447,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 			work_area.append({
 				type: 'field',
 				name: 'diffs',
-				label: 'User\'s reverts',
+				label: 'User\'s reverts (within last 48 hours)',
 				tooltip: 'Select the edits you believe are reverts'
 			});
 			work_area.append({


### PR DESCRIPTION
In the AN3 modal, change "User's reverts" to "User's reverts (within last 48 hours)".

This is more intuitive to the user, as they may wonder why there are no reverts showing up in the box if they try to use it after 48 hours.

This happened to me while working on a bug report, and it took me awhile to track this down.

![2021-12-10_233102](https://user-images.githubusercontent.com/79697282/145668614-aeaf98ef-0cc8-4173-ae8f-3eef1b4db614.png)