### PR TITLE
xfd: place new TFDs at bottom of TFD daily log page, not at top

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1429,8 +1429,6 @@ Twinkle.xfd.callbacks = {
 		},
 		todaysList: function(pageobj) {
 			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
-
 			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
 			var text;
 
@@ -1439,12 +1437,7 @@ Twinkle.xfd.callbacks = {
 				text = '{{subst:TfD log}}\n' + added_data;
 			} else {
 				var old_text = pageobj.getPageText();
-
-				text = old_text.replace('-->', '-->\n' + added_data);
-				if (text === old_text) {
-					statelem.error('failed to find target spot for the discussion');
-					return;
-				}
+				text = old_text + '\n\n' + added_data;
 			}
 
 			pageobj.setPageText(text);


### PR DESCRIPTION
Fixes #1486 xfd: place new TFDs at bottom of TFD daily log page, not at top

![2021-12-11_163812](https://user-images.githubusercontent.com/79697282/145696233-2eb47323-2fd2-4be9-b8b3-2ed24448a7a3.png)
