### PR TITLE
batchdelete: also delete redirect talk pages

### DIFF
--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -575,11 +575,9 @@ Twinkle.batchdelete.callbacks = {
 
 		var talkPages = [];
 		$.each(pages, function(i, page) {
-			var isTalkPage = page.ns % 2 === 1 && page.ns > 0;
+			var isTalkPage = mw.Title.isTalkNamespace(page.ns);
 			if (!isTalkPage) {
-				var talkPageTitle = page.ns === 0 ?
-					'Talk:' + page.title :
-					page.title.replace(/^([^:]+)(:.*)$/, '$1 talk$2');
+				var talkPageTitle = new mw.Title(page.title).getTalkPage().toText();
 				talkPages.push(talkPageTitle);
 			}
 		});


### PR DESCRIPTION
Related #1382 speedy/batchdelete: delete redirect talk pages as well

This PR provides code for the "batchdelete" part of the above ticket. I will code the speedy part in a future PR.

I chose to code this so that when someone selects the "delete redirects" check box, it will automatically delete the redirect talk pages.

The CSD log message for both redirects and redirect talk pages is now: "G8: Redirect or redirect talk page to deleted page "NovemTest1""

![2021-12-13_041855](https://user-images.githubusercontent.com/79697282/145811370-d0877dbb-2ed3-4e09-986b-f6e2ac36ddea.png)
![2021-12-14_010301](https://user-images.githubusercontent.com/79697282/145967155-d2eb441e-a764-44b4-92f9-9bd9650bfd64.png)
![2021-12-13_041537](https://user-images.githubusercontent.com/79697282/145812100-2861e641-23be-402d-8826-2c01c76dd837.png)
![2021-12-14_010352](https://user-images.githubusercontent.com/79697282/145967178-aca313b4-acd1-4de5-bbf4-e46a959e2bdc.png)