### PR TITLE
tb: fix WP:NORN description

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -280,7 +280,7 @@ Twinkle.talkback.noticeboards = {
 		editSummary: 'You have replies at the [[Wikipedia:Help desk|Wikipedia help desk]]'
 	},
 	norn: {
-		label: 'WP:NORN (Reliable sources noticeboard)',
+		label: 'WP:NORN (No original research noticeboard)',
 		text: '{{subst:Norn-notice|thread=$SECTION}} ~~~~',
 		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/Noticeboard]]'
 	},

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -282,7 +282,7 @@ Twinkle.talkback.noticeboards = {
 	norn: {
 		label: 'WP:NORN (No original research noticeboard)',
 		text: '{{subst:Norn-notice|thread=$SECTION}} ~~~~',
-		editSummary: 'Notice of discussion at [[Wikipedia:Reliable sources/Noticeboard]]'
+		editSummary: 'Notice of discussion at [[Wikipedia:No original research/Noticeboard]]'
 	},
 	npovn: {
 		label: 'WP:NPOVN (Neutral point of view noticeboard)',


### PR DESCRIPTION
Fixes this incorrect description. WP:NORN is not the reliable sources noticeboard. It is the no original research noticeboard.

<img width="581" alt="2021-12-17_043652" src="https://user-images.githubusercontent.com/79697282/146547773-c6ba1404-c1e6-481d-a5d9-5a370f8f7dd9.png">

