### PR TITLE
tb: rename OTRS noticeboard to VRT noticeboard

### DIFF
--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -299,10 +299,10 @@ Twinkle.talkback.noticeboards = {
 		text: "== Teahouse talkback: you've got messages! ==\n{{WP:Teahouse/Teahouse talkback|WP:Teahouse/Questions|$SECTION|ts=~~~~}}",
 		editSummary: 'You have replies at the [[Wikipedia:Teahouse/Questions|Teahouse question board]]'
 	},
-	otrs: {
-		label: 'WP:OTRS/N (OTRS noticeboard)',
-		text: '{{OTRSreply|1=$SECTION|2=~~~~}}',
-		editSummary: 'You have replies at the [[Wikipedia:OTRS noticeboard|OTRS noticeboard]]'
+	vrt: {
+		label: 'WP:VRTN (VRT noticeboard)',
+		text: '{{subst:VRTreply|1=$SECTION}}\n~~~~',
+		editSummary: 'You have replies at the [[Wikipedia:VRT noticeboard|VRT noticeboard]]'
 	}
 };
 


### PR DESCRIPTION
- Renames OTRS to VRT, bringing Twinkle into alignment with the rename that happened onwiki.
- Fixes an issue with [Template:VRTreply](https://en.wikipedia.org/wiki/Template:VRTreply) signatures showing up as ~~~~ instead of the user's signature. I modified the template onwiki and also Twinkle's code to get this working.

<img width="576" alt="2021-12-17_060525" src="https://user-images.githubusercontent.com/79697282/146556201-c908491a-0af1-4458-8d46-201ef0e314ef.png">
