### PR TITLE
xfd: fix "2nd AFD of article ending in number" bug

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1080,7 +1080,8 @@ Twinkle.xfd.callbacks = {
 					var match = order_re.exec(title);
 
 					// No match; A non-good value
-					if (!match) {
+					// Or the match is an unrealistically high number. Avoid false positives such as Wikipedia:Articles for deletion/The Basement (2014), by ignoring matches greater than 100
+					if (!match || match[1] > 100) {
 						continue;
 					}
 


### PR DESCRIPTION
Twinkle bug. Reported here: https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#2015th_nomination

Steps to reproduce:
- Create article Test (2000)
- Create article Wikipedia:Articles for deletion/Test (2000)
- Use Twinkle->XFD->AFD on article Test (2000). It will create an AFD called Wikipedia:Articles for deletion/Test (2001st nomination)

There's a complex RegEx that accepts (2000) and (2000th nom) and (2000th nomination). I hesitate to change it because if someone bothered to code it that way, these are probably AFD formats that were used in the past.

Instead, I opted to institute a maximum AFD number. I set 100 as the max. This should eliminate most year false positives.

<img width="259" alt="image" src="https://user-images.githubusercontent.com/79697282/146570072-b98f3079-d6f6-45f1-8e83-88aca17c5e28.png">