### PR TITLE
welcome: fix topWelcomes placement bug

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -630,7 +630,14 @@ Twinkle.welcome.callbacks = {
 		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
 
 		if (Twinkle.getPref('topWelcomes')) {
-			text = welcomeText + '\n\n' + text;
+			var hasTalkHeader = /^\{\{Talk header\}\}/i.test(text);
+			if (hasTalkHeader) {
+				text = text.replace(/^\{\{Talk header\}\}\n{0,2}/i, '');
+				text = '{{Talk header}}\n\n' + welcomeText + '\n\n' + text;
+				text = text.trim();
+			} else {
+				text = welcomeText + '\n\n' + text;
+			}
 		} else {
 			text += '\n' + welcomeText;
 		}

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -630,9 +630,9 @@ Twinkle.welcome.callbacks = {
 		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
 
 		if (Twinkle.getPref('topWelcomes')) {
-			var hasTalkHeader = /^\{\{Talk header\}\}/i.test(text);
+			var hasTalkHeader = /^\{\{Talk ?header\}\}/i.test(text);
 			if (hasTalkHeader) {
-				text = text.replace(/^\{\{Talk header\}\}\n{0,2}/i, '');
+				text = text.replace(/^\{\{Talk ?header\}\}\n{0,2}/i, '');
 				text = '{{Talk header}}\n\n' + welcomeText + '\n\n' + text;
 				text = text.trim();
 			} else {


### PR DESCRIPTION
Reported at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Welcome_messages_added_above_%22Talk_header%22

If you have the Twinkle preference topWelcomes set, and you try to place a welcome message on a page with {{Talk header}}, the order ends up being `welcomeText + {{Talk header}} + text`.

This patch fixes the order for simple cases.

<img width="383" alt="image" src="https://user-images.githubusercontent.com/79697282/146648614-cecde497-361e-4e6c-8527-53b896e948ce.png">
