### PR TITLE
Remove unneeded extra newline

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -406,7 +406,7 @@ Twinkle.prod.callbacks = {
 		usl.initialText =
 			"This is a log of all [[WP:PROD|proposed deletion]] tags applied or endorsed by this user using [[WP:TW|Twinkle]]'s PROD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
-			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].';
+			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].\n';
 
 		var logText = '# [[:' + Morebits.pageNameNorm + ']]';
 		var summaryText;

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -406,7 +406,7 @@ Twinkle.prod.callbacks = {
 		usl.initialText =
 			"This is a log of all [[WP:PROD|proposed deletion]] tags applied or endorsed by this user using [[WP:TW|Twinkle]]'s PROD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
-			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].\n';
+			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].';
 
 		var logText = '# [[:' + Morebits.pageNameNorm + ']]';
 		var summaryText;


### PR DESCRIPTION
Around New Year's Day every year, I always archive the CSD and PROD logs for the previous year prior to finding the first pages to tag for CSD and PROD respectively in the new year. In the case of the PROD log, I always have to remove an extra newline while transcluding the list of years on top of the log. This is annoying, so I am removing the extra newline in this commit so that there is just one blank line rather than two between "If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]]." and "=== Month Year ===" on the PROD log page.