### PR TITLE
unlink: fix colon in title bug

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4927,7 +4927,7 @@ Morebits.wikitext.page.prototype = {
 
 		var mwTitle = mw.Title.newFromText(link_target);
 		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
-		var title = mwTitle.title;
+		var title = mwTitle.getMainText();
 
 		var link_regex_string = '';
 		if (ns) {

--- a/morebits.js
+++ b/morebits.js
@@ -4924,12 +4924,12 @@ Morebits.wikitext.page.prototype = {
 		if (link_target.indexOf(':') === 0) {
 			link_target = link_target.slice(1);
 		}
-		var link_re_string = '';
 
 		var mwTitle = new mw.Title.newFromText(link_target);
 		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
 		var title = mwTitle.title;
 
+		var link_re_string = '';
 		if (ns) {
 			link_re_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
 		}

--- a/morebits.js
+++ b/morebits.js
@@ -4935,15 +4935,14 @@ Morebits.wikitext.page.prototype = {
 		}
 		link_regex_string += Morebits.pageNameRegex(title);
 
-		// Allow for an optional leading colon, e.g. [[:User:Test]]
-		// Do not remove files and catgegories, just links to files and categories
-		// Files and Categories must have a leading colon, e.g. [[:File:Test.png]]
+		// For most namespaces, unlink both [[User:Test]] and [[:User:Test]]
+		// For files and categories, only unlink [[:Category:Test]]. Do not unlink [[Category:Test]]
 		var isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
 		var colon = isFileOrCategory ? ':' : ':?';
 
-		var link_simple_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
-		var link_named_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
-		this.text = this.text.replace(link_simple_regex, '$1').replace(link_named_regex, '$1');
+		var simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
+		var piped_link_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
+		this.text = this.text.replace(simple_link_regex, '$1').replace(piped_link_regex, '$1');
 		return this;
 	},
 

--- a/morebits.js
+++ b/morebits.js
@@ -4930,15 +4930,15 @@ Morebits.wikitext.page.prototype = {
 		var title = mwTitle.getMainText();
 
 		var link_regex_string = '';
-		if (namespaceID !== 1) {
+		if (namespaceID !== 0) {
 			link_regex_string = Morebits.namespaceRegex(namespaceID) + ':';
 		}
 		link_regex_string += Morebits.pageNameRegex(title);
 
 		// Allow for an optional leading colon, e.g. [[:User:Test]]
 		// Do not remove files and catgegories, just links to files and categories
-		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
-		var isFileOrCategory = [6, 14].indexOf(namespaceID) !== 0;
+		// Files and Categories must have a leading colon, e.g. [[:File:Test.png]]
+		var isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
 		var colon = isFileOrCategory ? ':' : ':?';
 
 		var link_simple_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');

--- a/morebits.js
+++ b/morebits.js
@@ -4926,18 +4926,20 @@ Morebits.wikitext.page.prototype = {
 		}
 
 		var mwTitle = mw.Title.newFromText(link_target);
-		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
+		var namespaceID = mwTitle.getNamespaceId();
 		var title = mwTitle.getMainText();
 
 		var link_regex_string = '';
-		if (ns) {
-			link_regex_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
+		if (namespaceID !== 1) {
+			link_regex_string = Morebits.namespaceRegex(namespaceID) + ':';
 		}
 		link_regex_string += Morebits.pageNameRegex(title);
 
 		// Allow for an optional leading colon, e.g. [[:User:Test]]
+		// Do not remove files and catgegories, just links to files and categories
 		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
-		var colon = new RegExp(Morebits.namespaceRegex([6, 14])).test(ns) ? ':' : ':?';
+		var isFileOrCategory = [6, 14].indexOf(namespaceID) !== 0;
+		var colon = isFileOrCategory ? ':' : ':?';
 
 		var link_simple_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
 		var link_named_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');

--- a/morebits.js
+++ b/morebits.js
@@ -4924,13 +4924,13 @@ Morebits.wikitext.page.prototype = {
 		if (link_target.indexOf(':') === 0) {
 			link_target = link_target.slice(1);
 		}
-		var link_re_string = '', ns = '', title = link_target;
+		var link_re_string = '';
 
-		var idx = link_target.indexOf(':');
-		if (idx > 0) {
-			ns = link_target.slice(0, idx);
-			title = link_target.slice(idx + 1);
+		var mwTitle = new mw.Title.newFromText(link_target);
+		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
+		var title = mwTitle.title;
 
+		if (ns) {
 			link_re_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
 		}
 		link_re_string += Morebits.pageNameRegex(title);

--- a/morebits.js
+++ b/morebits.js
@@ -4925,7 +4925,7 @@ Morebits.wikitext.page.prototype = {
 			link_target = link_target.slice(1);
 		}
 
-		var mwTitle = new mw.Title.newFromText(link_target);
+		var mwTitle = mw.Title.newFromText(link_target);
 		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
 		var title = mwTitle.title;
 

--- a/morebits.js
+++ b/morebits.js
@@ -4920,11 +4920,6 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeLink: function(link_target) {
-		// Remove a leading colon, to be handled later
-		if (link_target.indexOf(':') === 0) {
-			link_target = link_target.slice(1);
-		}
-
 		var mwTitle = mw.Title.newFromText(link_target);
 		var namespaceID = mwTitle.getNamespaceId();
 		var title = mwTitle.getMainText();

--- a/morebits.js
+++ b/morebits.js
@@ -4929,19 +4929,19 @@ Morebits.wikitext.page.prototype = {
 		var ns = mwTitle.getNamespacePrefix().slice(0, -1); // remove trailing colon
 		var title = mwTitle.title;
 
-		var link_re_string = '';
+		var link_regex_string = '';
 		if (ns) {
-			link_re_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
+			link_regex_string = Morebits.namespaceRegex(mw.config.get('wgNamespaceIds')[ns.toLowerCase().replace(/ /g, '_')]) + ':';
 		}
-		link_re_string += Morebits.pageNameRegex(title);
+		link_regex_string += Morebits.pageNameRegex(title);
 
 		// Allow for an optional leading colon, e.g. [[:User:Test]]
 		// Files and Categories become links with a leading colon, e.g. [[:File:Test.png]]
 		var colon = new RegExp(Morebits.namespaceRegex([6, 14])).test(ns) ? ':' : ':?';
 
-		var link_simple_re = new RegExp('\\[\\[' + colon + '(' + link_re_string + ')\\]\\]', 'g');
-		var link_named_re = new RegExp('\\[\\[' + colon + link_re_string + '\\|(.+?)\\]\\]', 'g');
-		this.text = this.text.replace(link_simple_re, '$1').replace(link_named_re, '$1');
+		var link_simple_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
+		var link_named_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
+		this.text = this.text.replace(link_simple_regex, '$1').replace(link_named_regex, '$1');
 		return this;
 	},
 

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -336,6 +336,20 @@ describe('Morebits.wikitext', () => {
 				input: 'O, [[File:Fee.svg]] she [[file:Fee.svg|doth|teach]] the [[File:fee.svg|torches]] to burn [[file:fee.svg]] bright!',
 				expected: 'O, [[File:Fee.svg|thumb]] she [[file:Fee.svg|doth|teach|thumb]] the [[File:fee.svg|torches|thumb]] to burn [[file:fee.svg|thumb]] bright!',
 				params: ['Fee.svg', 'thumb']
+			},
+			{
+				name: 'Don\'t unlink categories',
+				method: 'removeLink',
+				input: '[[:Category:Test]] should unlink, [[Category:Test]] should not.',
+				expected: 'Category:Test should unlink, [[Category:Test]] should not.',
+				params: ['Category:Test']
+			},
+			{
+				name: 'Handle article titles with colons',
+				method: 'removeLink',
+				input: 'Test [[Cyber Seduction: His Secret Life]] test.',
+				expected: 'Test Cyber Seduction: His Secret Life test.',
+				params: ['Cyber Seduction: His Secret Life']
 			}
 		];
 


### PR DESCRIPTION
Fixes #1503 unlink: mainspace pages with colon are parsed incorrectly