### PR TITLE
Remove one of the two newlines before SPI report

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -810,7 +810,7 @@ Twinkle.arv.processSock = function(params) {
 	Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 	// prepare the SPI report
-	var text = '\n\n{{subst:SPI report|socksraw=' +
+	var text = '\n{{subst:SPI report|socksraw=' +
 		params.sockpuppets.map(function(v) {
 			return '* {{' + (mw.util.isIPAddress(v, true) ? 'checkip' : 'checkuser') + '|1=' + v + '}}';
 		}).join('\n') + '\n|evidence=' + params.evidence + ' \n';


### PR DESCRIPTION
Causes excess rendered whitespace, and does not appear to be necessary for any formatting reason,

See e.g. https://en.wikipedia.org/w/index.php?oldid=1067910626 for excess whitespace before every section. N.B.: There was previously a template issue that was causing this to be even worse in the first section. I fixed that with https://en.wikipedia.org/w/index.php?diff=prev&oldid=1068308120.