### PR TITLE
Switch to {{socklist}} in SPI report

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -810,10 +810,10 @@ Twinkle.arv.processSock = function(params) {
 	Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 	// prepare the SPI report
-	var text = '\n\n{{subst:SPI report|socksraw=' +
-		params.sockpuppets.map(function(v) {
-			return '* {{' + (mw.util.isIPAddress(v, true) ? 'checkip' : 'checkuser') + '|1=' + v + '}}';
-		}).join('\n') + '\n|evidence=' + params.evidence + ' \n';
+	var text = '\n{{subst:SPI report|' +
+            params.sockpuppets.map(function(sock, index) {
+                return (index + 1) + '=' + sock;
+            }).join('|') + '\n|evidence=' + params.evidence + ' \n';
 
 	if (params.checkuser) {
 		text += '|checkuser=yes';


### PR DESCRIPTION
I've proposed this as the new default for {{SPI report}}, and think Twinkle should use it as well. It would eliminate the longstanding problem that Twinkle reports, because they use `{{{socksraw}}}`, do not generate editor interaction links. This way, {{SPI report}} need only pass usernames as numbered parameters, and {{sock list}} does all the heavy lifting. Also makes it easier for people to add more sox after the report is filed. See https://en.wikipedia.org/wiki/Template_talk:SPI_report#Proposed_change_to_sock_list.

Resolves #1505 by superseding, just because it coincidentally affects the same lines of code. I can remove the part that copies 1505 if y'all would prefer they stay two separate PRs.

Blocked until the relevant change is implemented to {{SPI report}} (pending consensus).

Obligatory disclaimer that I am not very good at JavaScript, and *think* this change should work but am not 100% sure.