### PR TITLE
add back 2 welcome templates

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -248,6 +248,14 @@ Twinkle.welcome.templates = {
 				description: 'a welcome message with some helpful links and a plate of cookies',
 				syntax: '{{subst:welcome cookie}} ~~~~'
 			},
+			'welcome-graphical': {
+				description: 'colorful welcome message with table of about 20 links',
+				syntax: '$HEADER$ {{subst:W-graphical|$EXTRA$}}'
+			},
+			'welcome-menu': {
+				description: 'welcome message with large table of about 60 links',
+				syntax: '{{subst:WelcomeMenu}}'
+			},
 			'welcoming': {
 				description: 'welcome message with tutorial links and basic editing tips',
 				syntax: '{{subst:Welcoming}}'


### PR DESCRIPTION
Related #1463. Partial revert.

Tested. Besides the revert, changed code to use welcome templates directly instead of redirects.

Requested onwiki: https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Welcome-menu_template_missing_from_the_latest_iteration_of_the_drop-down_welcome_menu