### PR TITLE
protect: remove deleted template {{pp-create}}

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -760,7 +760,6 @@ Twinkle.protect.protectionTypesCreate = [
 	{
 		label: 'Create protection',
 		list: [
-			{ label: 'Generic ({{pp-create}})', value: 'pp-create' },
 			{ label: 'Offensive name', value: 'pp-create-offensive' },
 			{ label: 'Repeatedly recreated', selected: true, value: 'pp-create-salt' },
 			{ label: 'Recently deleted BLP', value: 'pp-create-blp' }
@@ -947,10 +946,6 @@ Twinkle.protect.protectionPresetsInfo = {
 	'pp-create-blp': {
 		create: 'extendedconfirmed',
 		reason: '[[WP:BLPDEL|Recently deleted BLP]]'
-	},
-	'pp-create': {
-		create: 'extendedconfirmed',
-		reason: '{{pp-create}}'
 	}
 };
 
@@ -1268,7 +1263,6 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				case 'pp-move-vandalism':
 					typename = 'move protection';
 					break;
-				case 'pp-create':
 				case 'pp-create-offensive':
 				case 'pp-create-blp':
 				case 'pp-create-salt':


### PR DESCRIPTION
To test, go to an uncreated page (redlink) and open the protect module. The default is {{pp-create-salt}}, which is a good default. This removes the option {{pp-create}} from the combo box, as this template was deleted at TFD.

Note that when I tried testing extended confirmed SALTing on testwiki, I got the error protect-invalidlevel. Correct me if I'm wrong, but I assume this is an issue with testwiki not having the extendedconfirmed user group. Sysop protection is tested and working.