### PR TITLE
Revert "xfd: place new TFDs at bottom of TFD daily log page, not at top"

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1420,6 +1420,8 @@ Twinkle.xfd.callbacks = {
 		},
 		todaysList: function(pageobj) {
 			var params = pageobj.getCallbackParameters();
+			var statelem = pageobj.getStatusElement();
+
 			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
 			var text;
 
@@ -1428,7 +1430,12 @@ Twinkle.xfd.callbacks = {
 				text = '{{subst:TfD log}}\n' + added_data;
 			} else {
 				var old_text = pageobj.getPageText();
-				text = old_text + '\n\n' + added_data;
+
+				text = old_text.replace('-->', '-->\n' + added_data);
+				if (text === old_text) {
+					statelem.error('failed to find target spot for the discussion');
+					return;
+				}
 			}
 
 			pageobj.setPageText(text);


### PR DESCRIPTION
Reverts wikimedia-gadgets/twinkle#1487

Per outcome of RFC at https://en.wikipedia.org/wiki/Wikipedia_talk:Templates_for_discussion#RfC:_Should_new_nominations_be_placed_at_top_or_bottom_of_daily_subpage?