### PR TITLE
speedy: Support G6 (db-moved)

### DIFF
--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -865,6 +865,12 @@ Twinkle.speedy.generalList = [
 		hideWhenMultiple: true
 	},
 	{
+		label: 'G6: Moved',
+		value: 'move',
+		tooltip: 'Holding up a page move until it was moved aside by a page mover',
+		hideWhenMultiple: true
+	},
+	{
 		label: 'G6: XfD',
 		value: 'xfd',
 		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn\'t actually deleted.',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1036,6 +1036,7 @@ Twinkle.speedy.normalizeHash = {
 	repost: 'g4',
 	banned: 'g5',
 	move: 'g6',
+	moved: 'g6',
 	xfd: 'g6',
 	movedab: 'g6',
 	copypaste: 'g6',


### PR DESCRIPTION
Fixes #1539 and adds support for Template:Db-moved, a custom version of Template:Db-move, with emphasis on those who have the page mover right. Please let me know if I missed anything that needs adding.