### PR TITLE
Rename usage of Ultraviolet to RedWarn

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -482,7 +482,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 						label: 'Notify users of the template',
 						value: 'devpages',
 						name: 'devpages',
-						tooltip: 'A notification template will be sent to Twinkle, AWB, and RedWarn if this is true.',
+						tooltip: 'A notification template will be sent to Twinkle, AWB, and Ultraviolet if this is true.',
 						checked: true
 					}
 				]
@@ -1349,7 +1349,7 @@ Twinkle.xfd.callbacks = {
 				var categoryNotificationPageMap = {
 					'Templates used by Twinkle': 'Wikipedia talk:Twinkle',
 					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
-					'Templates used by RedWarn': 'Wikipedia talk:RedWarn'
+					'Templates used by Ultraviolet': 'Wikipedia talk:RedWarn'
 				};
 				$.each(categoryNotificationPageMap, function(category, page) {
 					if (inCategories.indexOf(category) !== -1) {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1349,7 +1349,7 @@ Twinkle.xfd.callbacks = {
 				var categoryNotificationPageMap = {
 					'Templates used by Twinkle': 'Wikipedia talk:Twinkle',
 					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
-					'Templates used by Ultraviolet': 'Wikipedia talk:RedWarn'
+					'Templates used by Ultraviolet': 'Wikipedia talk:Ultraviolet'
 				};
 				$.each(categoryNotificationPageMap, function(category, page) {
 					if (inCategories.indexOf(category) !== -1) {


### PR DESCRIPTION
The talk page name is kept the same because it is currently a redirect; it can be changed in a later commit.