### PR TITLE
diff: Use mw.config to get revision id

### DIFF
--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -19,7 +19,7 @@ Twinkle.diff = function twinklediff() {
 	Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
 
 	// Show additional tabs only on diff pages
-	if (mw.util.getParamValue('diff')) {
+	if (mw.config.get('wgDiffNewId')) {
 		Twinkle.addPortletLink(function() {
 			Twinkle.diff.evaluate(false);
 		}, 'Since', 'tw-since', 'Show difference between last diff and the revision made by previous user');
@@ -27,8 +27,7 @@ Twinkle.diff = function twinklediff() {
 			Twinkle.diff.evaluate(true);
 		}, 'Since mine', 'tw-sincemine', 'Show difference between last diff and my last revision');
 
-		var oldid = /oldid=(.+)/.exec($('#mw-diff-ntitle1').find('strong a').first().attr('href'))[1];
-		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: oldid}), 'Current', 'tw-curdiff', 'Show difference to current revision');
+		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: mw.config.get('wgDiffNewId')}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
 


### PR DESCRIPTION
Use robuster way to get revision id. And wgDiffNewId is missing on deleted diff, fix #1561