### PR TITLE
GitHub Actions: tag changes to twinklediff.js

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -16,6 +16,8 @@
   - modules/twinkleblock.js
 "Module: config":
   - modules/twinkleconfig.js
+"Module: diff":
+  - modules/twinklediff.js
 "Module: fluff":
   - modules/twinklefluff.js
 "Module: protect":


### PR DESCRIPTION
I notice we're missing a "Module: diff" label, so I went ahead and created it. This PR teaches the GitHub Actions labeler about this new label.