### PR TITLE
tag: add {{Current related}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -714,6 +714,7 @@ Twinkle.tag.article.tagList = {
 		],
 		'Timeliness': [
 			{ tag: 'Current', description: 'documents a current event', excludeMI: true }, // Works but not intended for use in MI
+			{ tag: 'Current related', description: 'documents a topic affected by a current event', excludeMI: true }, // Works but not intended for use in MI
 			{ tag: 'Update', description: 'needs additional up-to-date information added' }
 		],
 		'Neutrality, bias, and factual accuracy': [


### PR DESCRIPTION
Requested by Firestar464 at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Add_{{Current_related}}_to_tag_feature