### PR TITLE
tag: move "Mark the page as patrolled/reviewed" to top

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -45,6 +45,20 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
+	if (document.getElementsByClassName('patrollink').length) {
+		form.append({
+			type: 'checkbox',
+			list: [
+				{
+					label: 'Mark the page as patrolled/reviewed',
+					value: 'patrol',
+					name: 'patrol',
+					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
+				}
+			]
+		});
+	}
+
 	form.append({
 		type: 'input',
 		label: 'Filter tag list:',
@@ -210,19 +224,6 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			break;
 	}
 
-	if (document.getElementsByClassName('patrollink').length) {
-		form.append({
-			type: 'checkbox',
-			list: [
-				{
-					label: 'Mark the page as patrolled/reviewed',
-					value: 'patrol',
-					name: 'patrol',
-					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
-				}
-			]
-		});
-	}
 	form.append({ type: 'submit', className: 'tw-tag-submit' });
 
 	var result = form.render();


### PR DESCRIPTION
For increased visibility. I didn't know this feature existed because it was hiding at the bottom. Also it is checked by default... if adding a tag is going to mark a page as reviewed by default, I want to know about it so I can uncheck it, as I may tag some pages without doing a complete notability review.

![2022-04-20_041621](https://user-images.githubusercontent.com/79697282/164220043-bfeede0f-4c89-4911-af2b-46953b721d7f.png)
