### PR TITLE
config: handle ombox deprecation

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1010,7 +1010,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 		// (settings in that file will still work, but they will be overwritten by twinkleoptions.js settings)
 		if (window.TwinkleConfig || window.FriendlyConfig) {
 			var contentnotice = document.createElement('p');
-			contentnotice.innerHTML = '<table class="plainlinks ombox ombox-content"><tr><td class="mbox-image">' +
+			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="mbox-image">' +
 				'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" /></td>' +
 				'<td class="mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
 				'<p>To do this, you can <a href="' + mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/' + mw.config.get('skin') +

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1010,9 +1010,9 @@ Twinkle.config.init = function twinkleconfigInit() {
 		// (settings in that file will still work, but they will be overwritten by twinkleoptions.js settings)
 		if (window.TwinkleConfig || window.FriendlyConfig) {
 			var contentnotice = document.createElement('p');
-			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="mbox-image">' +
+			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="morebits-mbox-image">' +
 				'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" /></td>' +
-				'<td class="mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
+				'<td class="morebits-mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
 				'<p>To do this, you can <a href="' + mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/' + mw.config.get('skin') +
 				'.js', { action: 'edit' }) + '" target="_blank"><b>edit your personal skin javascript file</b></a> or <a href="' +
 				mw.util.getUrl('User:' + mw.config.get('wgUserName') + '/common.js', { action: 'edit'}) + '" target="_blank"><b>your common.js file</b></a>, removing all lines of code that refer to <code>TwinkleConfig</code> and <code>FriendlyConfig</code>.</p>' +

--- a/morebits.css
+++ b/morebits.css
@@ -287,3 +287,13 @@ table.morebits-ombox {
 table.morebits-ombox-content {
     border: 1px solid #f28500;
 }
+td.morebits-mbox-image {
+    border: none;
+    padding: 2px 0 2px 0.9em;
+    text-align: center;
+}
+th.morebits-mbox-text, td.morebits-mbox-text {
+    border: none;
+    padding: 0.25em 0.9em;
+    width: 100%;
+}

--- a/morebits.css
+++ b/morebits.css
@@ -275,3 +275,15 @@ body .ui-dialog.morebits-dialog .morebits-dialog-footerlinks a {
 .ui-icon-inline {
 	display: inline-block;
 }
+
+/* For styling message/warning boxes. Cannot use MediaWiki ombox class because it will be deprecated soon. */
+table.morebits-ombox {
+    margin: 4px 10%;
+    border-collapse: collapse;
+    border: 1px solid #a2a9b1;
+    background: #f8f9fa;
+    box-sizing: border-box;
+}
+table.morebits-ombox-content {
+    border: 1px solid #f28500;
+}


### PR DESCRIPTION
Requested by Izno at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#ombox_use_in_MediaWiki:Gadget-twinkleconfig.js

There is a message box in Twinkle that uses MediaWiki's ombox CSS class, but this will be deprecated soon. This patch copies the styling for this to Twinkle's morebits CSS stylesheet, eliminating a dependency.

![2022-05-06_173416](https://user-images.githubusercontent.com/79697282/167231196-9455d573-7978-4da3-9755-58a023c07905.png)

Could potentially add all the ombox styles, but I decided to just add the ones we use.