### PR TITLE
dev-server: fix single apostrophes in CSS bug

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -29,6 +29,7 @@ const server = http.createServer(async (request, response) => {
 	}
 	for (let file of cssFiles) {
 		let css = (await readFile(file)).replace(/\s+/g, ' ');
+		css = css.replace(/'/g, "\\'"); // escape apostrophes
 		jsCode += `;mw.loader.addStyleTag('${css}');`;
 	}
 	jsCode += `;console.log('Loaded debug version of Twinkle.');`;

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -29,8 +29,8 @@ const server = http.createServer(async (request, response) => {
 	}
 	for (let file of cssFiles) {
 		let css = (await readFile(file)).replace(/\s+/g, ' ');
-		css = css.replace(/'/g, "\\'"); // escape apostrophes
-		jsCode += `;mw.loader.addStyleTag('${css}');`;
+		css = JSON.stringify(css); // escape double quotes and backslashes
+		jsCode += `;mw.loader.addStyleTag(${css});`;
 	}
 	jsCode += `;console.log('Loaded debug version of Twinkle.');`;
 	response.writeHead(200, { 'Content-Type': 'text/javascript; charset=utf-8' });


### PR DESCRIPTION
There is a SyntaxError in the dev version of Twinkle if you add any apostrophe in morebits.css. For example, if you want to add a comment such as `/* Don't do this. */`

This patch escapes single apostrophes, fixing the issue.

![2022-05-06_175432](https://user-images.githubusercontent.com/79697282/167231634-a9e791bb-aebb-4dc1-b857-51be2a2e6fa3.png)
