### PR TITLE
tag: add part and reason params for {{update}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -714,7 +714,24 @@ Twinkle.tag.article.tagList = {
 		],
 		'Timeliness': [
 			{ tag: 'Current', description: 'documents a current event', excludeMI: true }, // Works but not intended for use in MI
-			{ tag: 'Update', description: 'needs additional up-to-date information added' }
+			{ tag: 'Update', description: 'needs additional up-to-date information added',
+				subgroup: [
+					{
+						name: 'updatePart',
+						parameter: 'part',
+						type: 'input',
+						label: 'Part that needs updating:',
+						tooltip: 'Part that needs updating (e.g. to replace the word "article", often "section")'
+					},
+					{
+						name: 'updateReason',
+						parameter: 'reason',
+						type: 'input',
+						label: 'Reason:',
+						tooltip: 'Explanation why the article is out of date'
+					}
+				]
+			}
 		],
 		'Neutrality, bias, and factual accuracy': [
 			{ tag: 'Autobiography', description: 'autobiography and may not be written neutrally' },

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -719,12 +719,20 @@ Twinkle.tag.article.tagList = {
 			{ tag: 'Update', description: 'needs additional up-to-date information added',
 				subgroup: [
 					{
+						name: 'updatePart',
+						parameter: 'part',
+						type: 'input',
+						label: 'What part of the article:',
+						tooltip: 'Part that needs updating',
+						size: '45'
+					},
+					{
 						name: 'updateReason',
 						parameter: 'reason',
 						type: 'input',
 						label: 'Reason:',
 						tooltip: 'Explanation why the article is out of date',
-						size: '60px'
+						size: '55'
 					}
 				]
 			}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -717,13 +717,6 @@ Twinkle.tag.article.tagList = {
 			{ tag: 'Update', description: 'needs additional up-to-date information added',
 				subgroup: [
 					{
-						name: 'updatePart',
-						parameter: 'part',
-						type: 'input',
-						label: 'Part that needs updating:',
-						tooltip: 'Part that needs updating (e.g. to replace the word "article", often "section")'
-					},
-					{
 						name: 'updateReason',
 						parameter: 'reason',
 						type: 'input',

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -721,7 +721,8 @@ Twinkle.tag.article.tagList = {
 						parameter: 'reason',
 						type: 'input',
 						label: 'Reason:',
-						tooltip: 'Explanation why the article is out of date'
+						tooltip: 'Explanation why the article is out of date',
+						size: '60px'
 					}
 				]
 			}


### PR DESCRIPTION
Adding support for the suggested `part` and `reason` parameters of `{{update}}`. Tested on [the test wiki](https://test.wikipedia.org/w/index.php?title=Watty62_test&action=history).