### PR TITLE
xfd: clearer wording for "Notify users of the template"

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -479,10 +479,10 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				type: 'checkbox',
 				list: [
 					{
-						label: 'Notify users of the template',
+						label: 'Notify talk pages of affected user scripts',
 						value: 'devpages',
 						name: 'devpages',
-						tooltip: 'A notification template will be sent to Twinkle, AWB, and Ultraviolet if this is true.',
+						tooltip: 'A notification will be sent to Twinkle, AWB, and Ultraviolet\'s talk pages if those user scripts are marked as using this template.',
 						checked: true
 					}
 				]


### PR DESCRIPTION
I originally got "Notify users of the template" confused with "Notify page creator if possible". I have modified the text of the check box ("Notify users of the template") and the tooltip to be a bit clearer.

![image](https://user-images.githubusercontent.com/79697282/173580127-6a65d05e-5b2b-485a-85e1-a4d5add4efd8.png)
