### PR TITLE
twinkle: change default warn from "level 1" to "all"

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -117,7 +117,7 @@ Twinkle.defaultConfig = {
 	unlinkNamespaces: [ '0', '10', '100', '118' ],
 
 	// Warn
-	defaultWarningGroup: '1',
+	defaultWarningGroup: '10',
 	combinedSingletMenus: false,
 	showSharedIPNotice: true,
 	watchWarnings: '1 month',


### PR DESCRIPTION
For user warnings, current default "warning group" is "level 1". This patch changes the default warning group to "all warning templates". I feel this is more intuitive, and saves a couple clicks when the user wants to select a non-level 1 warning template.

User can custom configure this in their preferences too, if they don't like the default.

I think `11: 'Auto-select level (1-4)'` would also be a reasonable default warning group, but I slightly prefer "all".

<img width="706" alt="image" src="https://user-images.githubusercontent.com/79697282/173773688-e3e9253f-daf8-48f2-8c54-146f532af64d.png">
