### PR TITLE
warn: ability to hide linked article and reason

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,4 +1,4 @@
-name: Morebits function tests
+name: Unit tests
 
 on:
   push:
@@ -24,5 +24,5 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-    - name: Morebits tests
+    - name: Unit tests
       run: npm run test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 
 module.exports = {
-	testMatch: ['**/tests/morebits*.js'],
+	testMatch: ['**/tests/morebits*.js', '**/tests/twinkle*.js'],
 	testEnvironment: 'jsdom',
 	setupFilesAfterEnv: ['mock-mediawiki', '<rootDir>/tests/jest.setup.js']
 };

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1191,9 +1191,9 @@ Twinkle.warn.messages = {
 };
 
 /**
-  * Reads Twinkle.warn.messages and returns a specified template's property (such as label, summary,
-  * suppressArticleInSummary, hideLinkedPage, or hideReason)
-  */
+ * Reads Twinkle.warn.messages and returns a specified template's property (such as label, summary,
+ * suppressArticleInSummary, hideLinkedPage, or hideReason)
+ */
 Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyName) {
 	var result;
 	var isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1399,8 +1399,24 @@ Twinkle.warn.callback.postCategoryCleanup = function twinklewarnCallbackPostCate
 };
 
 Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSubcategory(e) {
-	var main_group = e.target.form.main_group.value;
-	var value = e.target.form.sub_group.value;
+	var selected_main_group = e.target.form.main_group.value;
+	var selected_template = e.target.form.sub_group.value;
+
+	// If template shouldn't have a linked article, hide the linked article label and text box
+	if (selected_template === 'uw-editsummary2') {
+		e.target.form.article.value = '';
+		Morebits.quickForm.setElementVisibility(e.target.form.article.parentElement, false);
+	} else {
+		Morebits.quickForm.setElementVisibility(e.target.form.article.parentElement, true);
+	}
+
+	// If template shouldn't have an optional message, hide the optional message label and text box
+	if (selected_template === 'uw-editsummary2') {
+		e.target.form.reason.value = '';
+		Morebits.quickForm.setElementVisibility(e.target.form.reason.parentElement, false);
+	} else {
+		Morebits.quickForm.setElementVisibility(e.target.form.reason.parentElement, true);
+	}
 
 	// Tags that don't take a linked article, but something else (often a username).
 	// The value of each tag is the label next to the input field
@@ -1412,8 +1428,9 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 		'uw-aiv': 'Optional username that was reported (without User:) '
 	};
 
-	if (['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(main_group) !== -1) {
-		if (notLinkedArticle[value]) {
+	var hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
+	if (hasLevel) {
+		if (notLinkedArticle[selected_template]) {
 			if (Twinkle.warn.prev_article === null) {
 				Twinkle.warn.prev_article = e.target.form.article.value;
 			}
@@ -1422,7 +1439,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 
 			// change form labels according to the warning selected
 			Morebits.quickForm.setElementTooltipVisibility(e.target.form.article, false);
-			Morebits.quickForm.overrideElementLabel(e.target.form.article, notLinkedArticle[value]);
+			Morebits.quickForm.overrideElementLabel(e.target.form.article, notLinkedArticle[selected_template]);
 		} else if (e.target.form.article.notArticle) {
 			if (Twinkle.warn.prev_article !== null) {
 				e.target.form.article.value = Twinkle.warn.prev_article;
@@ -1437,12 +1454,12 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 	// add big red notice, warning users about how to use {{uw-[coi-]username}} appropriately
 	$('#tw-warn-red-notice').remove();
 	var $redWarning;
-	if (value === 'uw-username') {
+	if (selected_template === 'uw-username') {
 		$redWarning = $("<div style='color: red;' id='tw-warn-red-notice'>{{uw-username}} should <b>not</b> be used for <b>blatant</b> username policy violations. " +
 			"Blatant violations should be reported directly to UAA (via Twinkle's ARV tab). " +
 			'{{uw-username}} should only be used in edge cases in order to engage in discussion with the user.</div>');
 		$redWarning.insertAfter(Morebits.quickForm.getElementLabelObject(e.target.form.reasonGroup));
-	} else if (value === 'uw-coi-username') {
+	} else if (selected_template === 'uw-coi-username') {
 		$redWarning = $("<div style='color: red;' id='tw-warn-red-notice'>{{uw-coi-username}} should <b>not</b> be used for <b>blatant</b> username policy violations. " +
 			"Blatant violations should be reported directly to UAA (via Twinkle's ARV tab). " +
 			'{{uw-coi-username}} should only be used in edge cases in order to engage in discussion with the user.</div>');

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1190,14 +1190,18 @@ Twinkle.warn.messages = {
 	}
 };
 
-Twinkle.warn.getTemplateProperty = function(templateName, propertyName) {
+/**
+  * Reads Twinkle.warn.messages and returns a specified template's property (such as label, summary,
+  * suppressArticleInSummary, hideLinkedPage, or hideReason)
+  */
+Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyName) {
 	var result;
 	var isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);
 	if (isNumberedTemplate) {
 		var unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
 		var level = isNumberedTemplate[0];
 		var numberedWarnings = {};
-		$.each(Twinkle.warn.messages.levels, function(key, val) {
+		$.each(templates.levels, function(key, val) {
 			$.extend(numberedWarnings, val);
 		});
 		$.each(numberedWarnings, function(key) {
@@ -1209,7 +1213,7 @@ Twinkle.warn.getTemplateProperty = function(templateName, propertyName) {
 
 	// Non-level templates can also end in a number. So check this for all templates.
 	var otherWarnings = {};
-	$.each(Twinkle.warn.messages, function(key, val) {
+	$.each(templates, function(key, val) {
 		if (key !== 'levels') {
 			$.extend(otherWarnings, val);
 		}
@@ -1440,7 +1444,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 	var selected_template = e.target.form.sub_group.value;
 
 	// If template shouldn't have a linked article, hide the linked article label and text box
-	var hideLinkedPage = Twinkle.warn.getTemplateProperty(selected_template, 'hideLinkedPage');
+	var hideLinkedPage = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
 	if (hideLinkedPage) {
 		e.target.form.article.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.article.parentElement, false);
@@ -1449,7 +1453,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 	}
 
 	// If template shouldn't have an optional message, hide the optional message label and text box
-	var hideReason = Twinkle.warn.getTemplateProperty(selected_template, 'hideLinkedPage');
+	var hideReason = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
 	if (hideReason) {
 		e.target.form.reason.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.reason.parentElement, false);

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -5,6 +5,8 @@ mw.config.set({
 });
 
 require('../morebits.js');
+require('../twinkle.js');
+require('../modules/twinklewarn.js');
 global.Morebits = window.Morebits;
 
 global.assert = require('assert');

--- a/tests/twinklewarn.test.js
+++ b/tests/twinklewarn.test.js
@@ -1,0 +1,31 @@
+describe('modules/twinklewarn', () => {
+	describe('getTemplateProperty', () => {
+		test('leveled templates: should read property', () => {
+			expect(Twinkle.warn.getTemplateProperty('uw-vandalism1', 'label')).toBe('Vandalism');
+		});
+
+		test('leveled templates: non-existent property should be undefined', () => {
+			expect(Twinkle.warn.getTemplateProperty('uw-vandalism1', 'abc')).toBe(undefined);
+		});
+
+		test('leveled templates: non-existent template should be undefined', () => {
+			expect(Twinkle.warn.getTemplateProperty('abc1', 'def')).toBe(undefined);
+		});
+
+		test('non-level template: should read property', () => {
+			expect(Twinkle.warn.getTemplateProperty('uw-attack', 'suppressArticleInSummary')).toBe(true);
+		});
+
+		test('non-level template: non-existent property should be undefined', () => {
+			expect(Twinkle.warn.getTemplateProperty('uw-attack', 'abc')).toBe(undefined);
+		});
+
+		test('non-level template: non-existent template should be undefined', () => {
+			expect(Twinkle.warn.getTemplateProperty('abc', 'def')).toBe(undefined);
+		});
+
+		test('non-level template ending in number should read property', () => {
+			expect(Twinkle.warn.getTemplateProperty('uw-editsummary2', 'hideLinkedPage')).toBe(true);
+		});
+	});
+});

--- a/tests/twinklewarn.test.js
+++ b/tests/twinklewarn.test.js
@@ -1,31 +1,77 @@
 describe('modules/twinklewarn', () => {
 	describe('getTemplateProperty', () => {
+		let templates = {
+			levels: {
+				'Common warnings': {
+					'uw-vandalism': {
+						level1: {
+							label: 'Vandalism',
+							summary: 'General note: Unconstructive editing'
+						},
+						level2: {
+							label: 'Vandalism',
+							summary: 'Caution: Unconstructive editing'
+						},
+						level3: {
+							label: 'Vandalism',
+							summary: 'Warning: Vandalism'
+						},
+						level4: {
+							label: 'Vandalism',
+							summary: 'Final warning: Vandalism'
+						},
+						level4im: {
+							label: 'Vandalism',
+							summary: 'Only warning: Vandalism'
+						}
+					},
+				}
+			},
+
+			singlenotice: {
+				'uw-editsummary2': {
+					label: 'Experienced user not using edit summary',
+					summary: 'Notice: Not using edit summary',
+					hideLinkedPage: true,
+					hideReason: true
+				},
+			},
+			
+			singlewarn: {
+				'uw-attack': {
+					label: 'Creating attack pages',
+					summary: 'Warning: Creating attack pages',
+					suppressArticleInSummary: true
+				},
+			}
+		};
+
 		test('leveled templates: should read property', () => {
-			expect(Twinkle.warn.getTemplateProperty('uw-vandalism1', 'label')).toBe('Vandalism');
+			expect(Twinkle.warn.getTemplateProperty(templates, 'uw-vandalism1', 'label')).toBe('Vandalism');
 		});
 
 		test('leveled templates: non-existent property should be undefined', () => {
-			expect(Twinkle.warn.getTemplateProperty('uw-vandalism1', 'abc')).toBe(undefined);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'uw-vandalism1', 'abc')).toBe(undefined);
 		});
 
 		test('leveled templates: non-existent template should be undefined', () => {
-			expect(Twinkle.warn.getTemplateProperty('abc1', 'def')).toBe(undefined);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'abc1', 'def')).toBe(undefined);
 		});
 
 		test('non-level template: should read property', () => {
-			expect(Twinkle.warn.getTemplateProperty('uw-attack', 'suppressArticleInSummary')).toBe(true);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'uw-attack', 'suppressArticleInSummary')).toBe(true);
 		});
 
 		test('non-level template: non-existent property should be undefined', () => {
-			expect(Twinkle.warn.getTemplateProperty('uw-attack', 'abc')).toBe(undefined);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'uw-attack', 'abc')).toBe(undefined);
 		});
 
 		test('non-level template: non-existent template should be undefined', () => {
-			expect(Twinkle.warn.getTemplateProperty('abc', 'def')).toBe(undefined);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'abc', 'def')).toBe(undefined);
 		});
 
 		test('non-level template ending in number should read property', () => {
-			expect(Twinkle.warn.getTemplateProperty('uw-editsummary2', 'hideLinkedPage')).toBe(true);
+			expect(Twinkle.warn.getTemplateProperty(templates, 'uw-editsummary2', 'hideLinkedPage')).toBe(true);
 		});
 	});
 });


### PR DESCRIPTION
Fixes #1408
Fixes #1538
Related #1537

When warning a user with `uw-editsummary2`, hides the "linked page" and "reason" text boxes.

I also created infrastructure to easily mark other templates with `hideLinkedPage` and `hideReason`, if we need to in the future.

I also added unit tests. I changed some unit test configuration files so that in the future, if we want to unit test modules, it will be easier.

Also renamed a couple variables.

<img width="698" alt="image" src="https://user-images.githubusercontent.com/79697282/173931554-44de687e-2b8b-4c77-bd19-89f2627ae16c.png">