### PR TITLE
tag: remove px from form.size

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -49,7 +49,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		type: 'input',
 		label: 'Filter tag list:',
 		name: 'quickfilter',
-		size: '30px',
+		size: '30',
 		event: function twinkletagquickfilter() {
 			// flush the DOM of all existing underline spans
 			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
@@ -161,7 +161,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 				label: 'Reason',
 				name: 'reason',
 				tooltip: 'Optional reason to be appended in edit summary. Recommended when removing tags.',
-				size: '60px'
+				size: '60'
 			});
 
 			break;


### PR DESCRIPTION
In code like this:

````
form.append({
	type: 'input',
	label: 'Reason',
	name: 'reason',
	tooltip: 'Optional reason to be appended in edit summary. Recommended when removing tags.',
	size: '60px'
});
````

The px is incorrect. The form item isn't 60 pixels high or wide, it is 60 characters wide. The px can be deleted.

https://www.w3schools.com/tags/att_input_size.asp