### PR TITLE
morebits: Fix commentOutImage for multiple files with same params

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4964,10 +4964,10 @@ Morebits.wikitext.page.prototype = {
 			if (links_re.test(allLinks[i])) {
 				var replacement = '<!-- ' + reason + allLinks[i] + ' -->';
 				unbinder.content = unbinder.content.replace(allLinks[i], replacement);
+				// unbind the newly created comments
+				unbinder.unbind('<!--', '-->');
 			}
 		}
-		// unbind the newly created comments
-		unbinder.unbind('<!--', '-->');
 
 		// Check for gallery images, i.e. instances that must start on a new line,
 		// eventually preceded with some space, and must include File: prefix

--- a/tests/morebits.wikitext.js
+++ b/tests/morebits.wikitext.js
@@ -151,8 +151,8 @@ describe('Morebits.wikitext', () => {
 			{
 				name: 'multiple',
 				method: 'commentOutImage',
-				input: 'O, [[File:Fee.svg]] she [[File:Fee.svg|doth|teach]] the [[File:Fee.svg|torches]] to burn bright!',
-				expected: 'O, <!-- [[File:Fee.svg]] --> she <!-- [[File:Fee.svg|doth|teach]] --> the <!-- [[File:Fee.svg|torches]] --> to burn bright!',
+				input: 'O, [[File:Fee.svg]] she [[File:Fee.svg|doth|teach]] the [[File:Fee.svg|torches]] to burn bright! [[File:Fee.svg]]',
+				expected: 'O, <!-- [[File:Fee.svg]] --> she <!-- [[File:Fee.svg|doth|teach]] --> the <!-- [[File:Fee.svg|torches]] --> to burn bright! <!-- [[File:Fee.svg]] -->',
 				params: ['Fee.svg']
 			},
 			{


### PR DESCRIPTION
It's required to unbind comments immediately after the replacement. Otherwise the first file will be replaced multiple times.
Fix https://en.wikipedia.org/w/index.php?title=User:Xiplus/sandbox&diff=prev&oldid=1096698125