### PR TITLE
Revert "morebits.date: Don't import methods that collide with PageTriage (T268513)"

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -2138,12 +2138,9 @@ Morebits.date.prototype = {
 
 // Allow native Date.prototype methods to be used on Morebits.date objects
 Object.getOwnPropertyNames(Date.prototype).forEach(function(func) {
-	// Exclude methods that collide with PageTriage's Date.js external, which clobbers native Date: [[phab:T268513]]
-	if (['add', 'getDayName', 'getMonthName'].indexOf(func) === -1) {
-		Morebits.date.prototype[func] = function() {
-			return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
-		};
-	}
+	Morebits.date.prototype[func] = function() {
+		return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
+	};
 });
 
 


### PR DESCRIPTION
This reverts commit c6f2bd4f3809e3f59124949d31c791923d4a93f1.

The linked phab task has been resolved now - PageTriage is no longer using date.js external which messes up `Date.prototype`.