### PR TITLE
xfd: better targeting for RM/TR

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,7 +2016,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var hiddenCommentRE = /---- and enter on a new line.* -->/;
+			var hiddenCommentRE = /==== ?Uncontroversial technical requests ?====(?:.|\n)*? -->/i;
 			var newtext = text.replace(hiddenCommentRE, '$&\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');


### PR DESCRIPTION
Requested by LaundryPizza03 at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#RM/TR

Changing the wikicode comment at https://en.wikipedia.org/wiki/Wikipedia:Requested_moves/Technical_requests#Uncontroversial_technical_requests breaks Twinkle. I've rewritten the RegEx to be a little more forgiving about when this comment is changed.

I used a not-so-pretty `(?:.|\n)` hack to get around ES5's lack of RegEx /s support.

Test case 1 (original, works with old and new code):
<img width="713" alt="image" src="https://user-images.githubusercontent.com/79697282/179309644-01f8f6a1-f984-4e91-b909-e5c168c081a0.png">

Test case 2 (new, works with new code only):
<img width="722" alt="image" src="https://user-images.githubusercontent.com/79697282/179309678-3488f57f-ef59-41a2-99f5-1db5f20552cb.png">