### PR TITLE
protect: sanitized-css: don't tick <noinclude> check box

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -534,7 +534,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						name: 'noinclude',
 						label: 'Wrap protection template with &lt;noinclude&gt;',
 						tooltip: 'Will wrap the protection template in &lt;noinclude&gt; tags, so that it won\'t transclude',
-						checked: (isTemplateNamespace || (isWikipediaNamespace && isArticlesForDeletion)) && !isCode
+						checked: (isTemplateNamespace || isAFD) && !isCode
 					}
 				]
 			});

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1076,7 +1076,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 
 			// Default settings for adding <noinclude> tags to protection templates
 			var isTemplateEditorProtection = form.category.value === 'pp-template';
-			var isAFD = mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0;
+			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
 			var isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
 			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			if ((isTemplateEditorProtection || isAFD) && !isCode) {

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -519,8 +519,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 			});
 
 			var isTemplateNamespace = mw.config.get('wgNamespaceNumber') === 10;
-			var isWikipediaNamespace = mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project;
-			var isArticlesForDeletion = mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0;
+			var isAFD = mw.config.get('wgPageName').indexOf('Wikipedia:Articles for deletion/') === 0;
 			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			field1.append({
 				type: 'checkbox',

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -519,7 +519,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 			});
 
 			var isTemplateNamespace = mw.config.get('wgNamespaceNumber') === 10;
-			var isAFD = mw.config.get('wgPageName').indexOf('Wikipedia:Articles for deletion/') === 0;
+			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
 			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			field1.append({
 				type: 'checkbox',

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -520,7 +520,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 
 			var isTemplateNamespace = mw.config.get('wgNamespaceNumber') === 10;
 			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
-			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
+			var isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
 			field1.append({
 				type: 'checkbox',
 				list: [
@@ -1078,7 +1078,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			var isTemplateEditorProtection = form.category.value === 'pp-template';
 			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
 			var isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
-			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
+			var isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
 			if ((isTemplateEditorProtection || isAFD) && !isCode) {
 				form.noinclude.checked = true;
 			} else if (isCode || isNotTemplateNamespace) {

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -517,6 +517,11 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 				list: Twinkle.protect.protectionTags,
 				event: Twinkle.protect.formevents.tagtype
 			});
+
+			var isTemplateNamespace = mw.config.get('wgNamespaceNumber') === 10;
+			var isWikipediaNamespace = mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project;
+			var isArticlesForDeletion = mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0;
+			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			field1.append({
 				type: 'checkbox',
 				list: [
@@ -530,7 +535,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 						name: 'noinclude',
 						label: 'Wrap protection template with &lt;noinclude&gt;',
 						tooltip: 'Will wrap the protection template in &lt;noinclude&gt; tags, so that it won\'t transclude',
-						checked: mw.config.get('wgNamespaceNumber') === 10 || (mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0)
+						checked: (isTemplateNamespace || (isWikipediaNamespace && isArticlesForDeletion)) && !isCode
 					}
 				]
 			});
@@ -1074,9 +1079,10 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			var isTemplateEditorProtection = form.category.value === 'pp-template';
 			var isAFD = mw.config.get('wgNamespaceNumber') === mw.config.get('wgNamespaceIds').project && mw.config.get('wgTitle').indexOf('Articles for deletion/') === 0;
 			var isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
-			if (isTemplateEditorProtection || isAFD) {
+			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
+			if ((isTemplateEditorProtection || isAFD) && !isCode) {
 				form.noinclude.checked = true;
-			} else if (isNotTemplateNamespace) {
+			} else if (isCode || isNotTemplateNamespace) {
 				form.noinclude.checked = false;
 			}
 		}


### PR DESCRIPTION
Don't tick the "Wrap protection template with `<noinclude>`" check box by default if the content model is css, sanitized-css, or javascript.

![image](https://user-images.githubusercontent.com/79697282/185350858-a23b3763-1323-400b-8690-3662970bb1f3.png)