### PR TITLE
fluff: Fix rollback links for top rev in history

### DIFF
--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -243,7 +243,7 @@ Twinkle.fluff.addLinks = {
 
 			// On first page of results, so add revert/rollback
 			// links to the top revision
-			if (!$('.mw-firstlink').length) {
+			if (!$('a.mw-firstlink').length) {
 				var first = histList.shift();
 				var vandal = $(first).find('.mw-userlink:not(.history-deleted)').text();
 


### PR DESCRIPTION
https://en.wikipedia.org/w/index.php?title=Wikipedia&action=history

![image](https://user-images.githubusercontent.com/7577245/192151077-5106bb72-291f-4e5a-8fe5-289a6b0d478c.png)

"First link" now wrapped by `<span>` with `.mw-firstlink` class on the first page of history. Use `a.mw-firstlink` to check clickable firstlink.

With this patch:
![image](https://user-images.githubusercontent.com/7577245/192151112-eb2cfe18-cfae-4a3d-b00d-1a7f84df0ae5.png)
