### PR TITLE
prod: should allow prod even if CSD template present

### DIFF
--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -251,12 +251,11 @@ Twinkle.prod.callbacks = {
 			var text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			var tag_re = /{{(?:db-?|delete\b|article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			var tag_re = /{{(?:article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();
 			}
-
 
 			// Remove tags that become superfluous with this action
 			text = text.replace(/{{\s*(userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:{{[^{}]*}}|[^{}])*)?}}\s*/gi, '');


### PR DESCRIPTION
By my reading, applying a prod to a page tagged with CSD is is allowed per WP:PROD. But Twinkle currently checks for a CSD template on the article page while prodding, and if detected, aborts the prod.

<img width="995" alt="image" src="https://user-images.githubusercontent.com/79697282/194321798-b2e339c9-a1e5-4e54-b49d-e3c3dbceaa80.png">