### PR TITLE
arv: remove "implies shared use"

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -247,11 +247,6 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						tooltip: 'Promotional usernames are advertisements for a company, website or group. Please do not report these names to UAA unless the user has also made promotional edits related to the name.'
 					},
 					{
-						label: 'Username that implies shared use',
-						value: 'shared',
-						tooltip: 'Usernames that imply the likelihood of shared use (names of companies or groups, or the names of posts within organizations) are not permitted. Usernames are acceptable if they contain a company or group name but are clearly intended to denote an individual person, such as "Mark at WidgetsUSA", "Jack Smith at the XY Foundation", "WidgetFan87", etc.'
-					},
-					{
 						label: 'Offensive username',
 						value: 'offensive',
 						tooltip: 'Offensive usernames make harmonious editing difficult or impossible.'
@@ -590,27 +585,31 @@ Twinkle.arv.callback.evaluate = function(e) {
 		case 'username':
 			types = form.getChecked('arvtype').map(Morebits.string.toLowerCaseFirstChar);
 
-			var hasShared = types.indexOf('shared') > -1;
-			if (hasShared) {
-				types.splice(types.indexOf('shared'), 1);
-			}
-
+			// generate human-readable string, e.g. "misleading and promotional username"
 			if (types.length <= 2) {
 				types = types.join(' and ');
 			} else {
 				types = [ types.slice(0, -1).join(', '), types.slice(-1) ].join(' and ');
 			}
-			var article = 'a';
+
+			// a or an?
+			var adjective = 'a';
 			if (/[aeiouwyh]/.test(types[0] || '')) { // non 100% correct, but whatever, including 'h' for Cockney
-				article = 'an';
+				adjective = 'an';
 			}
+
+			// generate wikicode to place on [[WP:UAA]] page
 			reason = '*{{user-uaa|1=' + uid + '}} &ndash; ';
-			if (types.length || hasShared) {
-				reason += 'Violation of the username policy as ' + article + ' ' + types + ' username' +
-					(hasShared ? ' that implies shared use. ' : '. ');
+			if (types.length) {
+				reason += 'Violation of the username policy as ' + adjective + ' ' + types + ' username. ';
 			}
 			if (comment !== '') {
-				reason += Morebits.string.toUpperCaseFirstChar(comment) + '. ';
+				reason += Morebits.string.toUpperCaseFirstChar(comment);
+				var endsInPeriod = /\.$/.test(comment);
+				if (!endsInPeriod) {
+					reason += '.';
+				}
+				reason += ' ';
 			}
 			reason += '~~~~';
 			reason = reason.replace(/\r?\n/g, '\n*:');  // indent newlines


### PR DESCRIPTION
Requested by Blaze Wolf and KylieTastic at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#%22Username_implies_shared_use%22

Removes "Username that implies shared use" option from ARV -> UAA, because this is not normally severe enough to report at [[WP:UAA]].

Also refactored a bit.

Also fixed a bug where Twinkle would place two periods sometimes when writing [[WP:UAA]] entries.

<img width="693" alt="image" src="https://user-images.githubusercontent.com/79697282/196835677-ac3ae2e1-f985-481e-a7cd-36802f07f2b8.png">
