### PR TITLE
morebits: fix handling of hard errors

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -4064,6 +4064,9 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// hard error, give up
 		} else {
+			var response = ctx.saveApi.getResponse();
+			var errorData = response.error || // bc error format
+				response.errors[0].data; // html/wikitext/plaintext error format
 
 			switch (errorCode) {
 
@@ -4073,18 +4076,18 @@ Morebits.wiki.page = function(pageName, status) {
 					break;
 
 				case 'abusefilter-disallowed':
-					ctx.statusElement.error('The edit was disallowed by the edit filter: "' + ctx.saveApi.getResponse().error.abusefilter.description + '".');
+					ctx.statusElement.error('The edit was disallowed by the edit filter: "' + errorData.abusefilter.description + '".');
 					break;
 
 				case 'abusefilter-warning':
-					ctx.statusElement.error([ 'A warning was returned by the edit filter: "', ctx.saveApi.getResponse().error.abusefilter.description, '". If you wish to proceed with the edit, please carry it out again. This warning will not appear a second time.' ]);
+					ctx.statusElement.error([ 'A warning was returned by the edit filter: "', errorData.abusefilter.description, '". If you wish to proceed with the edit, please carry it out again. This warning will not appear a second time.' ]);
 					// We should provide the user with a way to automatically retry the action if they so choose -
 					// I can't see how to do this without creating a UI dependency on Morebits.wiki.page though -- TTO
 					break;
 
 				case 'spamblacklist':
 					// If multiple items are blacklisted, we only return the first
-					var spam = ctx.saveApi.getResponse().error.spamblacklist.matches[0];
+					var spam = errorData.spamblacklist.matches[0];
 					ctx.statusElement.error('Could not save the page because the URL ' + spam + ' is on the spam blacklist');
 					break;
 


### PR DESCRIPTION
In #1179, support for new error formats were added and used by default. However, the error handling code still assumes the legacy errorformat, which passes details of the first `error`, while in the newer ones we have an array `errors`.

Notes for testing:
On testwiki, add text "Trigger abuse filter warn" to any page (it triggers https://test.wikipedia.org/wiki/Special:AbuseFilter/256):
```js
var p = new Morebits.wiki.page('SD0001test', '');
p.setAppendText('trigger abuse filter warn');
p.setEditSummary('edit summary');
p.append();
```

Without this patch, we get:
<img width="958" alt="Screenshot 2022-10-21 at 11 03 53 PM" src="https://user-images.githubusercontent.com/31818903/197255413-adf60db9-432b-42fc-9db3-8d039fed070f.png">

The TypeError prevents any failure handling callback from running (one of the reasons why the callback approach is sub-optimal and we should be using promises everywhere).