### PR TITLE
twinkle: notifications for CSD R3 should default to true

### DIFF
--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -73,7 +73,7 @@ Twinkle.config.commonSets = {
 		'r2', 'r3', 'r4',
 		'p1', 'p2'
 	],
-	csdAndDICriteria: {
+	csdAndImageDeletionCriteria: {
 		db: 'Custom rationale ({{db}})',
 		g1: 'G1', g2: 'G2', g3: 'G3', g4: 'G4', g5: 'G5', g6: 'G6', g7: 'G7', g8: 'G8', g10: 'G10', g11: 'G11', g12: 'G12', g13: 'G13', g14: 'G14',
 		a1: 'A1', a2: 'A2', a3: 'A3', a5: 'A5', a7: 'A7', a9: 'A9', a10: 'A10', a11: 'A11',
@@ -83,7 +83,7 @@ Twinkle.config.commonSets = {
 		r2: 'R2', r3: 'R3', r4: 'R4',
 		p1: 'P1', p2: 'P2'
 	},
-	csdAndDICriteriaDisplayOrder: [
+	csdAndImageDeletionCriteriaDisplayOrder: [
 		'db',
 		'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g7', 'g8', 'g10', 'g11', 'g12', 'g13', 'g14',
 		'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11',
@@ -547,8 +547,8 @@ Twinkle.config.sections = [
 				label: 'Allow editing of deletion summary when deleting under these criteria',
 				adminOnly: true,
 				type: 'set',
-				setValues: Twinkle.config.commonSets.csdAndDICriteria,
-				setDisplayOrder: Twinkle.config.commonSets.csdAndDICriteriaDisplayOrder
+				setValues: Twinkle.config.commonSets.csdAndImageDeletionCriteria,
+				setDisplayOrder: Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder
 			},
 
 			// TwinkleConfig.deleteTalkPageOnDelete (boolean)
@@ -610,8 +610,8 @@ Twinkle.config.sections = [
 				name: 'noLogOnSpeedyNomination',
 				label: 'Do not create a userspace log entry when tagging with these criteria',
 				type: 'set',
-				setValues: Twinkle.config.commonSets.csdAndDICriteria,
-				setDisplayOrder: Twinkle.config.commonSets.csdAndDICriteriaDisplayOrder
+				setValues: Twinkle.config.commonSets.csdAndImageDeletionCriteria,
+				setDisplayOrder: Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder
 			}
 		]
 	},

--- a/twinkle.js
+++ b/twinkle.js
@@ -100,9 +100,9 @@ Twinkle.defaultConfig = {
 	watchSpeedyUser: '1 month',
 
 	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
+	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
+	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
+	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
 	promptForSpeedyDeletionSummary: [],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,


### PR DESCRIPTION
Requested by Blaze Wolf, MB, and CX Zoom at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Default_preferences

For CSD R3, have "welcome page creator", "notify page creator when tagging", and "notify page creator when deleting" default to true instead of false.

Also refactor one vague variable name.

![image](https://user-images.githubusercontent.com/79697282/198153017-ca39e61c-73db-4de3-8223-9da9d151ecbe.png)
