### PR TITLE
tag: better edit summary for {{rcat shell}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1782,7 +1782,7 @@ Twinkle.tag.callbacks = {
 			pageText = pageText.trim() + '\n\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
 		}
 
-		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
+		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : ' {{[[Template:Redirect category shell|Redirect category shell]]}}') + ' to redirect';
 
 		// avoid truncated summaries
 		if (summaryText.length > 499) {


### PR DESCRIPTION
Requested by Qwerfjkl at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Adding_rcat_shell

Steps to reproduce:

* Create page with wikicode
```
#REDIRECT [[Gator In The Bay]]
{{R from miscapitalisation}}
```
* Twinkle -> Tag -> check "R from miscapitalization" -> submit

Before patch:
<img width="973" alt="image" src="https://user-images.githubusercontent.com/79697282/198155587-ccbcc68b-851e-4be5-afad-a92efe378dda.png">

After patch:
<img width="985" alt="image" src="https://user-images.githubusercontent.com/79697282/198155608-7b651040-ab77-4667-ae53-90dc869feee1.png">