### PR TITLE
twinkle: notifications for CSD C1 should default to true

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1782,7 +1782,7 @@ Twinkle.tag.callbacks = {
 			pageText = pageText.trim() + '\n\n{{Redirect category shell|' + tagText + oldPageTags + '\n}}';
 		}
 
-		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : 'rcat shell') + ' to redirect';
+		summaryText += (tags.length > 0 ? ' tag' + (tags.length > 1 ? 's' : ' ') : ' {{[[Template:Redirect category shell|Redirect category shell]]}}') + ' to redirect';
 
 		// avoid truncated summaries
 		if (summaryText.length > 499) {

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -247,11 +247,6 @@ Twinkle.arv.callback.changeCategory = function (e) {
 						tooltip: 'Promotional usernames are advertisements for a company, website or group. Please do not report these names to UAA unless the user has also made promotional edits related to the name.'
 					},
 					{
-						label: 'Username that implies shared use',
-						value: 'shared',
-						tooltip: 'Usernames that imply the likelihood of shared use (names of companies or groups, or the names of posts within organizations) are not permitted. Usernames are acceptable if they contain a company or group name but are clearly intended to denote an individual person, such as "Mark at WidgetsUSA", "Jack Smith at the XY Foundation", "WidgetFan87", etc.'
-					},
-					{
 						label: 'Offensive username',
 						value: 'offensive',
 						tooltip: 'Offensive usernames make harmonious editing difficult or impossible.'
@@ -590,27 +585,31 @@ Twinkle.arv.callback.evaluate = function(e) {
 		case 'username':
 			types = form.getChecked('arvtype').map(Morebits.string.toLowerCaseFirstChar);
 
-			var hasShared = types.indexOf('shared') > -1;
-			if (hasShared) {
-				types.splice(types.indexOf('shared'), 1);
-			}
-
+			// generate human-readable string, e.g. "misleading and promotional username"
 			if (types.length <= 2) {
 				types = types.join(' and ');
 			} else {
 				types = [ types.slice(0, -1).join(', '), types.slice(-1) ].join(' and ');
 			}
-			var article = 'a';
+
+			// a or an?
+			var adjective = 'a';
 			if (/[aeiouwyh]/.test(types[0] || '')) { // non 100% correct, but whatever, including 'h' for Cockney
-				article = 'an';
+				adjective = 'an';
 			}
+
+			// generate wikicode to place on [[WP:UAA]] page
 			reason = '*{{user-uaa|1=' + uid + '}} &ndash; ';
-			if (types.length || hasShared) {
-				reason += 'Violation of the username policy as ' + article + ' ' + types + ' username' +
-					(hasShared ? ' that implies shared use. ' : '. ');
+			if (types.length) {
+				reason += 'Violation of the username policy as ' + adjective + ' ' + types + ' username. ';
 			}
 			if (comment !== '') {
-				reason += Morebits.string.toUpperCaseFirstChar(comment) + '. ';
+				reason += Morebits.string.toUpperCaseFirstChar(comment);
+				var endsInPeriod = /\.$/.test(comment);
+				if (!endsInPeriod) {
+					reason += '.';
+				}
+				reason += ' ';
 			}
 			reason += '~~~~';
 			reason = reason.replace(/\r?\n/g, '\n*:');  // indent newlines

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1234,7 +1234,7 @@ Twinkle.block.blockPresetsInfo = {
 		nocreate: true,
 		pageParam: true,
 		reason: '{{uw-vaublock}} <!-- Username violation, vandalism-only account -->',
-		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]] and your username is a blatant violation of the [[WP:U|username policy]]'
+		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:DISRUPTONLY|used only for vandalism]] and your username is a blatant violation of the [[WP:U|username policy]]'
 	},
 	'uw-vblock': {
 		autoblock: true,
@@ -1250,8 +1250,8 @@ Twinkle.block.blockPresetsInfo = {
 		forRegisteredOnly: true,
 		nocreate: true,
 		pageParam: true,
-		reason: '[[WP:Vandalism-only account|Vandalism-only account]]',
-		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:VOA|used only for vandalism]]'
+		reason: '[[WP:DISRUPTONLY|Vandalism-only account]]',
+		summary: 'You have been indefinitely blocked from editing because your account is being [[WP:DISRUPTONLY|used only for vandalism]]'
 	},
 	'zombie proxy': {
 		expiry: '1 month',

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -73,7 +73,7 @@ Twinkle.config.commonSets = {
 		'r2', 'r3', 'r4',
 		'p1', 'p2'
 	],
-	csdAndDICriteria: {
+	csdAndImageDeletionCriteria: {
 		db: 'Custom rationale ({{db}})',
 		g1: 'G1', g2: 'G2', g3: 'G3', g4: 'G4', g5: 'G5', g6: 'G6', g7: 'G7', g8: 'G8', g10: 'G10', g11: 'G11', g12: 'G12', g13: 'G13', g14: 'G14',
 		a1: 'A1', a2: 'A2', a3: 'A3', a5: 'A5', a7: 'A7', a9: 'A9', a10: 'A10', a11: 'A11',
@@ -83,7 +83,7 @@ Twinkle.config.commonSets = {
 		r2: 'R2', r3: 'R3', r4: 'R4',
 		p1: 'P1', p2: 'P2'
 	},
-	csdAndDICriteriaDisplayOrder: [
+	csdAndImageDeletionCriteriaDisplayOrder: [
 		'db',
 		'g1', 'g2', 'g3', 'g4', 'g5', 'g6', 'g7', 'g8', 'g10', 'g11', 'g12', 'g13', 'g14',
 		'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11',
@@ -547,8 +547,8 @@ Twinkle.config.sections = [
 				label: 'Allow editing of deletion summary when deleting under these criteria',
 				adminOnly: true,
 				type: 'set',
-				setValues: Twinkle.config.commonSets.csdAndDICriteria,
-				setDisplayOrder: Twinkle.config.commonSets.csdAndDICriteriaDisplayOrder
+				setValues: Twinkle.config.commonSets.csdAndImageDeletionCriteria,
+				setDisplayOrder: Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder
 			},
 
 			// TwinkleConfig.deleteTalkPageOnDelete (boolean)
@@ -610,8 +610,8 @@ Twinkle.config.sections = [
 				name: 'noLogOnSpeedyNomination',
 				label: 'Do not create a userspace log entry when tagging with these criteria',
 				type: 'set',
-				setValues: Twinkle.config.commonSets.csdAndDICriteria,
-				setDisplayOrder: Twinkle.config.commonSets.csdAndDICriteriaDisplayOrder
+				setValues: Twinkle.config.commonSets.csdAndImageDeletionCriteria,
+				setDisplayOrder: Twinkle.config.commonSets.csdAndImageDeletionCriteriaDisplayOrder
 			}
 		]
 	},

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -244,15 +244,16 @@ Twinkle.fluff.addLinks = {
 			// On first page of results, so add revert/rollback
 			// links to the top revision
 			if (!$('a.mw-firstlink').length) {
-				var first = histList.shift();
-				var vandal = $(first).find('.mw-userlink:not(.history-deleted)').text();
+				var firstRow = histList.shift();
+				var firstUser = $(firstRow).find('.mw-userlink:not(.history-deleted)').text();
 
 				// Check for first username different than the top user,
 				// only apply rollback links if/when found
-				// for faster than every
+				// for() faster than every()
 				for (var i = 0; i < histList.length; i++) {
-					if ($(histList[i]).find('.mw-userlink').text() !== vandal) {
-						first.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(vandal, true));
+					var hasMoreThanOneUser = $(histList[i]).find('.mw-userlink').text() !== firstUser;
+					if (hasMoreThanOneUser) {
+						firstRow.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(firstUser, true));
 						break;
 					}
 				}

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1100,7 +1100,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto')) {
 		tagparams = {
 			tag: input.tagtype,
-			reason: (input.tagtype === 'pp-protected' || input.tagtype === 'pp-semi-protected' || input.tagtype === 'pp-move') && input.protectReason,
+			reason: false,
 			small: input.small,
 			noinclude: input.noinclude
 		};

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1431,7 +1431,7 @@ Twinkle.protect.callbacks = {
 		var text = protectedPage.getPageText();
 		var tag, summary;
 
-		var oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?/gi;
+		var oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?\s*/gi;
 		var re_result = oldtag_re.exec(text);
 		if (re_result) {
 			if (params.tag === 'none' || confirm('{{' + re_result[1] + '}} was found on the page. \nClick OK to remove it, or click Cancel to leave it there.')) {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1663,11 +1663,6 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form['csd.repost_xfd']) {
 					var deldisc = form['csd.repost_xfd'].value;
 					if (deldisc) {
-						if (!new RegExp('^:?' + Morebits.namespaceRegex(4) + ':', 'i').test(deldisc)) {
-							alert('CSD G4:  The deletion discussion page name, if provided, must start with "Wikipedia:".');
-							parameters = null;
-							return false;
-						}
 						currentParams.xfd = deldisc;
 					}
 				}
@@ -1702,11 +1697,6 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 				if (form['csd.xfd_fullvotepage']) {
 					var xfd = form['csd.xfd_fullvotepage'].value;
 					if (xfd) {
-						if (!new RegExp('^:?' + Morebits.namespaceRegex(4) + ':', 'i').test(xfd)) {
-							alert('CSD G6 (XFD):  The deletion discussion page name, if provided, must start with "Wikipedia:".');
-							parameters = null;
-							return false;
-						}
 						currentParams.fullvotepage = xfd;
 					}
 				}

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1055,8 +1055,8 @@ Twinkle.warn.messages = {
 			summary: 'Notice: Be careful when removing redlinks'
 		},
 		'uw-selfrevert': {
-			label: 'Reverting self tests',
-			summary: 'Notice: Reverting self tests'
+			label: 'Self-reverted editing tests',
+			summary: 'Notice: Self-reverted editing tests'
 		},
 		'uw-socialnetwork': {
 			label: 'Wikipedia is not a social network',

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,7 +2016,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var hiddenCommentRE = /---- and enter on a new line.* -->/;
+			var hiddenCommentRE = /==== ?Uncontroversial technical requests ?====(?:.|\n)*? -->/i;
 			var newtext = text.replace(hiddenCommentRE, '$&\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');

--- a/morebits.js
+++ b/morebits.js
@@ -2138,12 +2138,9 @@ Morebits.date.prototype = {
 
 // Allow native Date.prototype methods to be used on Morebits.date objects
 Object.getOwnPropertyNames(Date.prototype).forEach(function(func) {
-	// Exclude methods that collide with PageTriage's Date.js external, which clobbers native Date: [[phab:T268513]]
-	if (['add', 'getDayName', 'getMonthName'].indexOf(func) === -1) {
-		Morebits.date.prototype[func] = function() {
-			return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
-		};
-	}
+	Morebits.date.prototype[func] = function() {
+		return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
+	};
 });
 
 

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -17,7 +17,7 @@ const server = http.createServer(async (request, response) => {
 	const jsFiles = ['morebits.js', 'twinkle.js'].concat(moduleFiles.map(f => 'modules/' + f));
 	const cssFiles = ['morebits.css', 'twinkle.css'];
 
-	let jsCode = `mw.loader.load(['jquery.ui', 'ext.gadget.select2']);`;
+	let jsCode = `mw.loader.using(['jquery.ui', 'ext.gadget.select2']).then(function () {\n`;
 
 	if (process.argv[2] !== '--no-sysop') {
 		// Pretend to be a sysop, if not one already - enables testing of sysop modules by non-sysops
@@ -33,6 +33,7 @@ const server = http.createServer(async (request, response) => {
 		jsCode += `;mw.loader.addStyleTag(${css});`;
 	}
 	jsCode += `;console.log('Loaded debug version of Twinkle.');`;
+	jsCode += `});`; // End mw.loader.using
 	response.writeHead(200, { 'Content-Type': 'text/javascript; charset=utf-8' });
 	response.end(jsCode, 'utf-8');
 });

--- a/twinkle.js
+++ b/twinkle.js
@@ -490,6 +490,12 @@ Twinkle.load = function () {
 	if (isVector && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
 		$('#p-cactions').css('margin-right', 'initial');
 	}
+
+	// If using a skin with space for lots of modules, display a link to Twinkle Preferences
+	var usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
+	if (usingSkinWithDropDownMenu) {
+		Twinkle.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
+	}
 };
 
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -100,9 +100,9 @@ Twinkle.defaultConfig = {
 	watchSpeedyUser: '1 month',
 
 	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'u5', 'p1', 'p2' ],
+	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
+	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
+	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
 	promptForSpeedyDeletionSummary: [],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,

--- a/twinkle.js
+++ b/twinkle.js
@@ -100,9 +100,9 @@ Twinkle.defaultConfig = {
 	watchSpeedyUser: '1 month',
 
 	// these next two should probably be identical by default
-	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
-	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
-	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'r3', 'u5', 'p1', 'p2' ],
+	welcomeUserOnSpeedyDeletionNotification: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'c1', 'r3', 'u5', 'p1', 'p2' ],
+	notifyUserOnSpeedyDeletionNomination: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'c1', 'r3', 'u5', 'p1', 'p2' ],
+	warnUserOnSpeedyDelete: [ 'db', 'g1', 'g2', 'g3', 'g4', 'g6', 'g10', 'g11', 'g12', 'g13', 'g14', 'a1', 'a2', 'a3', 'a5', 'a7', 'a9', 'a10', 'a11', 'f1', 'f2', 'f3', 'f7', 'f9', 'f10', 'c1', 'r3', 'u5', 'p1', 'p2' ],
 	promptForSpeedyDeletionSummary: [],
 	deleteTalkPageOnDelete: true,
 	deleteRedirectsOnDelete: true,


### PR DESCRIPTION
Requested by DB1729 at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#%22Notify_page_creator_if_possible%22

For CSD C1, have "welcome page creator", "notify page creator when tagging", and "notify page creator when deleting" default to true instead of false.