### PR TITLE
tag: better detection of "not marked as reviewed"

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -59,7 +59,8 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		}
 
 		if (!isReviewed) {
-			form.append({
+			// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
+			var checkbox = new Morebits.quickForm.element({
 				type: 'checkbox',
 				list: [
 					{
@@ -70,6 +71,8 @@ Twinkle.tag.callback = function friendlytagCallback() {
 					}
 				]
 			});
+			var html = checkbox.render();
+			$('.quickform').prepend(html);
 		}
 	});
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -45,19 +45,33 @@ Twinkle.tag.callback = function friendlytagCallback() {
 
 	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
-	if (document.getElementsByClassName('patrollink').length) {
-		form.append({
-			type: 'checkbox',
-			list: [
-				{
-					label: 'Mark the page as patrolled/reviewed',
-					value: 'patrol',
-					name: 'patrol',
-					checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
-				}
-			]
-		});
-	}
+	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
+	new mw.Api().get({
+		action: 'pagetriagelist',
+		format: 'json',
+		page_id: mw.config.get('wgArticleId')
+	}).done(function(response) {
+		var isReviewed = false;
+		var isOldPage = response.pagetriagelist.result !== 'success' || response.pagetriagelist.pages.length === 0;
+		var isMarkedAsReviewed = response.pagetriagelist.pages[0].patrol_status > 0;
+		if (isOldPage || isMarkedAsReviewed) {
+			isReviewed = true;
+		}
+
+		if (!isReviewed) {
+			form.append({
+				type: 'checkbox',
+				list: [
+					{
+						label: 'Mark the page as patrolled/reviewed',
+						value: 'patrol',
+						name: 'patrol',
+						checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
+					}
+				]
+			});
+		}
+	});
 
 	form.append({
 		type: 'input',


### PR DESCRIPTION
Fix #1573

<s>Not working yet. Because of async, form is rendered before the "Mark the page as patrolled/reviewed" checkbox is appended.

Perhaps the pagetriagelist API query needs to run before friendlytagCallback(). Any suggestions on how to set that up? I'm good at async/await, but not so good at promises and callbacks.</s>