### PR TITLE
twinkle: vector-2022: hovering should open menu

### DIFF
--- a/twinkle.css
+++ b/twinkle.css
@@ -11,8 +11,7 @@
  * In skin vector-2022, open the TW menu when mouse hovers over it. Credit to
  * [[en:User:Nardog]] for this fix.
  */
-#p-twinkle > .vector-menu-checkbox:hover ~ .vector-menu-content,
-#p-twinkle > .vector-menu-content:hover {
+#p-twinkle:hover > .vector-menu-content {
 	opacity: 1;
 	visibility: visible;
 	height: auto;

--- a/twinkle.css
+++ b/twinkle.css
@@ -11,8 +11,8 @@
  * In skin vector-2022, open the TW menu when mouse hovers over it. Credit to
  * [[en:User:Nardog]] for this fix.
  */
-.vector-menu-checkbox:hover ~ .vector-menu-content,
-.vector-menu-content:hover {
+#p-twinkle > .vector-menu-checkbox:hover ~ .vector-menu-content,
+#p-twinkle > .vector-menu-content:hover {
 	opacity: 1;
 	visibility: visible;
 	height: auto;

--- a/twinkle.css
+++ b/twinkle.css
@@ -1,9 +1,21 @@
 /**
  * Explicitly set width of TW menu so that we can use a hidden peer gadget
- * to add space where the TW menu would go before it loads.
+ * to add space where the TW menu would go before it loads. See
+ * twinkle-pagestyles.css
  */
 .skin-vector .vector-menu-dropdown #p-twinkle {
 	width: 3.24em;
+}
+
+/**
+ * In skin vector-2022, open the TW menu when mouse hovers over it. Credit to
+ * [[en:User:Nardog]] for this fix.
+ */
+.vector-menu-checkbox:hover ~ .vector-menu-content,
+.vector-menu-content:hover {
+	opacity: 1;
+	visibility: visible;
+	height: auto;
 }
 
 /* The additional box on user skin.js and twinklepreferences.js pages */


### PR DESCRIPTION
Fix #1674

This has a side effect of also making the "More" menu stay open on hover in vector-2022. Not sure if this is desirable, or if we should change the CSS to target the TW menu only.