### PR TITLE
update package-lock.json to be in sync with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,9 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "twinkle",
 			"devDependencies": {
 				"eslint": "^7.32.0",
-				"eslint-plugin-es5": "^1.5.0",
 				"jest": "^27.0.6",
 				"mock-mediawiki": "^1.2.2",
 				"mwn": "^0.11.1"
@@ -1998,15 +1998,6 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/eslint-plugin-es5": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
-			"integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
-			"dev": true,
-			"peerDependencies": {
-				"eslint": ">= 3.0.0"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -6657,13 +6648,6 @@
 					"dev": true
 				}
 			}
-		},
-		"eslint-plugin-es5": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es5/-/eslint-plugin-es5-1.5.0.tgz",
-			"integrity": "sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==",
-			"dev": true,
-			"requires": {}
 		},
 		"eslint-scope": {
 			"version": "5.1.1",


### PR DESCRIPTION
I probably should have done this in #1652 but I forgot

This is the result of running `npm install` instead of `npm ci`. This puts package-lock.json in alignment with package.json, without bumping any versions. Should be a no-op.