### PR TITLE
xfd: edit summaries should include log page section links

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -965,7 +965,7 @@ Twinkle.xfd.callbacks = {
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 			(Morebits.userIsSysop ? '\n\nThis log does not track XfD-related deletions made using Twinkle.' : '');
 
-		var editsummary = 'Logging ' + utils.toTLACase(params.venue) + ' nomination of [[:' + Morebits.pageNameNorm + ']].';
+		var editsummary = 'Logging [[' + params.discussionpage + '|' + utils.toTLACase(params.venue) + ' nomination]] of [[:' + Morebits.pageNameNorm + ']].';
 
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
 		var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
@@ -1439,7 +1439,7 @@ Twinkle.xfd.callbacks = {
 			}
 
 			pageobj.setPageText(text);
-			pageobj.setEditSummary('Adding ' + (params.xfdcat === 'tfd' ? 'deletion nomination' : 'merge listing') + ' of [[:' + Morebits.pageNameNorm + ']].');
+			pageobj.setEditSummary('/* ' + Morebits.pageNameNorm + ' */ Adding ' + (params.xfdcat === 'tfd' ? 'deletion nomination' : 'merge listing') + ' of [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');


### PR DESCRIPTION
Requested by CX Zoom at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Minor_feature_request%3A_Jump_to_section_from_XFD_edit_summary

1) For TFD, include a link to the daily log page section in the edit summary for the daily log page.

![image](https://user-images.githubusercontent.com/79697282/209220938-b14fb31d-ede2-4332-a47d-ae3ccefc406b.png)

2) For TFD, include a link to the daily log page section in the edit summary for the Twinkle user log page.

![image](https://user-images.githubusercontent.com/79697282/209221095-09d8a4a7-477d-4740-b0d4-47d87a58bb01.png)