### PR TITLE
fix "more" menu's styling in skin vector-2022

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -281,7 +281,16 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
 				navigation = 'mw-panel';
 			}
-			outerNavClass = 'mw-portlet vector-menu vector-menu-' + (navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown vector-menu-dropdown-noicon' : 'tabs');
+
+			outerNavClass = 'mw-portlet vector-menu';
+			if (navigation === 'mw-panel') {
+				outerNavClass += ' vector-menu-portal';
+			} else if (type === 'menu') {
+				outerNavClass += ' vector-menu-dropdown vector-dropdown vector-menu-dropdown-noicon';
+			} else {
+				outerNavClass += ' vector-menu-tabs';
+			}
+
 			innerDivClass = 'vector-menu-content';
 			break;
 		case 'modern':


### PR DESCRIPTION
Co-authored-by: @MusikAnimal

Bug report: https://en.wikipedia.org/wiki/Wikipedia:Village_pump_(technical)#Styling_for_the_TW_menu_gone%3F

MusikAnimal's hotfix: https://en.wikipedia.org/w/index.php?diff=1131811156

I also refactored this because I found it unreadable. The hotfix (included in this patch) is adding a "vector-dropdown" class when appropriate. The rest of the code changes (the refactoring) should be a no-op.