### PR TITLE
eslint: disallow nested ternaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -57,7 +57,8 @@
 		"space-infix-ops": "error",
 		"space-unary-ops": "error",
 		"spaced-comment": ["error", "always", { "line": { "exceptions": ["-"] }, "block": { "balanced": true } }],
-		"switch-colon-spacing": "error"
+		"switch-colon-spacing": "error",
+		"no-nested-ternary": "error"
 	},
 	"reportUnusedDisableDirectives": true
 }

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1481,7 +1481,16 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 			}
 
 			var blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
-			var registrationRestrict = blockSettings.forRegisteredOnly ? Twinkle.block.isRegistered : blockSettings.forAnonOnly ? !Twinkle.block.isRegistered : true;
+
+			var registrationRestrict;
+			if (blockSettings.forRegisteredOnly) {
+				registrationRestrict = Twinkle.block.isRegistered;
+			} else if (blockSettings.forAnonOnly) {
+				registrationRestrict = !Twinkle.block.isRegistered;
+			} else {
+				registrationRestrict = true;
+			}
+
 			if (!(blockSettings.templateName && show_template) && registrationRestrict) {
 				var templateName = blockSettings.templateName || blockPreset.value;
 				return {

--- a/morebits.js
+++ b/morebits.js
@@ -5981,7 +5981,15 @@ Morebits.simpleWindow.prototype = {
 		$(this.content).find('input[type="submit"], button[type="submit"]').each(function(key, value) {
 			value.style.display = 'none';
 			var button = document.createElement('button');
-			button.textContent = value.hasAttribute('value') ? value.getAttribute('value') : value.textContent ? value.textContent : msg('submit', 'Submit Query');
+
+			if (value.hasAttribute('value')) {
+				button.textContent = value.getAttribute('value');
+			} else if (value.textContent) {
+				button.textContent = value.textContent;
+			} else {
+				button.textContent = msg('submit', 'Submit Query');
+			}
+
 			button.className = value.className || 'submitButtonProxy';
 			// here is an instance of cheap coding, probably a memory-usage hit in using a closure here
 			button.addEventListener('click', function() {


### PR DESCRIPTION
Suggested in #1693

Have our linter disallow stuff like this, for readability reasons:

```
outerNavClass = navigation === 'mw-panel' ? 'portal' : type === 'menu' ? 'dropdown vector-menu-dropdown-noicon' : 'tabs';