### PR TITLE
jest: fix missing files in code coverage report

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,10 @@
 module.exports = {
 	testMatch: ['**/tests/morebits*.js', '**/tests/twinkle*.js'],
 	testEnvironment: 'jsdom',
-	setupFilesAfterEnv: ['mock-mediawiki', '<rootDir>/tests/jest.setup.js']
+	setupFilesAfterEnv: ['mock-mediawiki', '<rootDir>/tests/jest.setup.js'],
+	collectCoverageFrom: [
+		'morebits.js',
+		'twinkle.js',
+		'modules/**/*.{js,jsx,ts,tsx}'
+	]
 };


### PR DESCRIPTION
The unit test code coverage report was not displaying files that had no tests. I think it's better to include all files, to capture the reality of our testing situation.

Before patch:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/79697282/210959687-65610944-b79a-41af-8bab-7451487889c9.png">

After patch:

<img width="1276" alt="image" src="https://user-images.githubusercontent.com/79697282/210959582-5a4b1101-ef70-4c92-bcd5-e4298c37df15.png">
