### PR TITLE
gitignore: add coverage folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ stash*.diff
 *.jsX
 .vscode/
 patch-test-loader.js
+coverage/
 
 # Windows
 Thumbs.db


### PR DESCRIPTION
Will fix /coverage/ files showing up in my VS Code when I search all files in the repo. VS Code not smart enough to read my global .gitignore for this.

/coverage/ is created when you run a jest unit test code coverage report.