### PR TITLE
warn: shorten {{Uw-nor}} edit summary

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -419,20 +419,20 @@ Twinkle.warn.messages = {
 			},
 			'uw-nor': {
 				level1: {
-					label: 'Adding original research, including unpublished syntheses of sources',
-					summary: 'General note: Adding original research, including unpublished syntheses of sources'
+					label: 'Adding original research',
+					summary: 'General note: Adding original research'
 				},
 				level2: {
-					label: 'Adding original research, including unpublished syntheses of sources',
-					summary: 'Caution: Adding original research, including unpublished syntheses of sources'
+					label: 'Adding original research',
+					summary: 'Caution: Adding original research'
 				},
 				level3: {
-					label: 'Adding original research, including unpublished syntheses of sources',
-					summary: 'Warning: Adding original research, including unpublished syntheses of sources'
+					label: 'Adding original research',
+					summary: 'Warning: Adding original research'
 				},
 				level4: {
-					label: 'Adding original research, including unpublished syntheses of sources',
-					summary: 'Final warning: Adding original research, including unpublished syntheses of sources'
+					label: 'Adding original research',
+					summary: 'Final warning: Adding original research'
 				}
 			},
 			'uw-notcensored': {


### PR DESCRIPTION
Requested by @nardog at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#%22including_unpublished_syntheses_of_sources%22

Deleted text isn't found in the {{Uw-nor}} text. I see no reason not to shorten it.