### PR TITLE
set markTaggedPagesAsPatrolled default to false

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -153,7 +153,7 @@ Twinkle.defaultConfig = {
 	watchTaggedPages: '1 month',
 	watchMergeDiscussions: '1 month',
 	markTaggedPagesAsMinor: false,
-	markTaggedPagesAsPatrolled: true,
+	markTaggedPagesAsPatrolled: false,
 	tagArticleSortOrder: 'cat',
 	customTagList: [],
 	customFileTagList: [],


### PR DESCRIPTION
Applying a maintenance tag does not usually mean that the article has been thoroughly reviewed by the NPP. This assumption that "maintenance tag = NPP wants to mark it as reviewed" seems false to me.

This patch changes the default from true to false.

Users can always go into their preferences and change it back to true.