### PR TITLE
tag: fix bug where "mark as reviewed" shows up for everyone

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -52,7 +52,8 @@ Twinkle.tag.callback = function friendlytagCallback() {
 			action: 'pagetriagelist',
 			format: 'json',
 			page_id: mw.config.get('wgArticleId')
-		}).done(function(response) {
+		}).then(function(response) {
+			// figure out whether the article is marked as reviewed in PageTriage
 			var isReviewed = false;
 			var isOldPage = response.pagetriagelist.result !== 'success' || response.pagetriagelist.pages.length === 0;
 			var isMarkedAsReviewed = response.pagetriagelist.pages[0].patrol_status > 0;
@@ -60,6 +61,7 @@ Twinkle.tag.callback = function friendlytagCallback() {
 				isReviewed = true;
 			}
 
+			// if article is not marked as reviewed, show the "mark as reviewed" check box
 			if (!isReviewed) {
 				// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
 				var checkbox = new Morebits.quickForm.element({

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -46,35 +46,38 @@ Twinkle.tag.callback = function friendlytagCallback() {
 	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
 	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
-	new mw.Api().get({
-		action: 'pagetriagelist',
-		format: 'json',
-		page_id: mw.config.get('wgArticleId')
-	}).done(function(response) {
-		var isReviewed = false;
-		var isOldPage = response.pagetriagelist.result !== 'success' || response.pagetriagelist.pages.length === 0;
-		var isMarkedAsReviewed = response.pagetriagelist.pages[0].patrol_status > 0;
-		if (isOldPage || isMarkedAsReviewed) {
-			isReviewed = true;
-		}
+	let isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));
+	if (isPatroller) {
+		new mw.Api().get({
+			action: 'pagetriagelist',
+			format: 'json',
+			page_id: mw.config.get('wgArticleId')
+		}).done(function(response) {
+			var isReviewed = false;
+			var isOldPage = response.pagetriagelist.result !== 'success' || response.pagetriagelist.pages.length === 0;
+			var isMarkedAsReviewed = response.pagetriagelist.pages[0].patrol_status > 0;
+			if (isOldPage || isMarkedAsReviewed) {
+				isReviewed = true;
+			}
 
-		if (!isReviewed) {
-			// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
-			var checkbox = new Morebits.quickForm.element({
-				type: 'checkbox',
-				list: [
-					{
-						label: 'Mark the page as patrolled/reviewed',
-						value: 'patrol',
-						name: 'patrol',
-						checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
-					}
-				]
-			});
-			var html = checkbox.render();
-			$('.quickform').prepend(html);
-		}
-	});
+			if (!isReviewed) {
+				// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
+				var checkbox = new Morebits.quickForm.element({
+					type: 'checkbox',
+					list: [
+						{
+							label: 'Mark the page as patrolled/reviewed',
+							value: 'patrol',
+							name: 'patrol',
+							checked: Twinkle.getPref('markTaggedPagesAsPatrolled')
+						}
+					]
+				});
+				var html = checkbox.render();
+				$('.quickform').prepend(html);
+			}
+		});
+	}
 
 	form.append({
 		type: 'input',


### PR DESCRIPTION
PR #1667 that was just merged has a bug in it. I thought of the bug after merging it. The bug is that, in the tag module, "mark as reviewed" shows up for non-patrollers. The fix in this patch is...

```
let isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));`
if (isPatroller) {
    // do stuff
}