### PR TITLE
eslint: warn when using .done() or .fail()

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,18 @@
 		"space-unary-ops": "error",
 		"spaced-comment": ["error", "always", { "line": { "exceptions": ["-"] }, "block": { "balanced": true } }],
 		"switch-colon-spacing": "error",
-		"no-nested-ternary": "error"
+		"no-nested-ternary": "error",
+		"no-restricted-syntax": [
+			"warn",
+			{
+				"message": "Using .done() is discouraged. See https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript#Asynchronous_code",
+				"selector": "MemberExpression > Identifier[name=\"done\"]"
+			},
+			{
+				"message": "Using .fail() is discouraged. See https://www.mediawiki.org/wiki/Manual:Coding_conventions/JavaScript#Asynchronous_code",
+				"selector": "MemberExpression > Identifier[name=\"fail\"]"
+			}
+		]
 	},
 	"reportUnusedDisableDirectives": true
 }


### PR DESCRIPTION
eslint: warn when using .done() or .fail()

Using .done() and .fail() is a bad habit and can introduce extremely subtle bugs. [T238025](https://phabricator.wikimedia.org/T238025) comes to mind. That took years to track down the bug.

This repo doesn't have enough automated tests for me to feel comfortable doing mass refactoring. So setting to "warn" for now instead of "error".