### PR TITLE
eslint: prefer startsWith and includes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,9 @@
 		"Map": "readonly"
 	},
 	"ignorePatterns": ["scripts/", "tests/", "lib/"],
+	"plugins": [
+		"lodash"
+	],
 	"rules": {
 		"no-console": "error",
 		"no-extra-parens": ["error", "all", { "nestedBinaryExpressions": false }],
@@ -41,9 +44,12 @@
 		"key-spacing": ["error", {"singleLine": {"beforeColon": false, "afterColon": true}}],
 		"keyword-spacing": ["error", { "after": true, "before": true}],
 		"linebreak-style": ["error", "unix"],
+		"lodash/prefer-includes": "warn",
+		"lodash/prefer-startswith": "warn",
 		"no-array-constructor": "error",
 		"no-bitwise": "error",
 		"no-mixed-operators": "error",
+		"no-nested-ternary": "error",
 		"no-new-object": "error",
 		"no-tabs": ["error", { "allowIndentationTabs": true }],
 		"no-trailing-spaces": "error",
@@ -57,8 +63,7 @@
 		"space-infix-ops": "error",
 		"space-unary-ops": "error",
 		"spaced-comment": ["error", "always", { "line": { "exceptions": ["-"] }, "block": { "balanced": true } }],
-		"switch-colon-spacing": "error",
-		"no-nested-ternary": "error"
+		"switch-colon-spacing": "error"
 	},
 	"reportUnusedDisableDirectives": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 			"name": "twinkle",
 			"devDependencies": {
 				"eslint": "^8.31.0",
+				"eslint-plugin-lodash": "github:wix/eslint-plugin-lodash",
 				"jest": "^27.0.6",
 				"mock-mediawiki": "^1.3.0",
 				"mwn": "^0.11.1"
@@ -2005,6 +2006,21 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/eslint-plugin-lodash": {
+			"version": "7.4.0",
+			"resolved": "git+ssh://git@github.com/wix/eslint-plugin-lodash.git#2d58f5ef9a5fa9b9749c50f0cf6db3d1dbd83a2f",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"eslint": ">=2"
 			}
 		},
 		"node_modules/eslint-scope": {
@@ -6705,6 +6721,14 @@
 						"p-limit": "^3.0.2"
 					}
 				}
+			}
+		},
+		"eslint-plugin-lodash": {
+			"version": "git+ssh://git@github.com/wix/eslint-plugin-lodash.git#2d58f5ef9a5fa9b9749c50f0cf6db3d1dbd83a2f",
+			"dev": true,
+			"from": "eslint-plugin-lodash@wix/eslint-plugin-lodash",
+			"requires": {
+				"lodash": "^4.17.21"
 			}
 		},
 		"eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"private": true,
 	"repository": "wikimedia-gadgets/twinkle",
 	"scripts": {
-	  	"start": "node scripts/dev-server.js",
+		"start": "node scripts/dev-server.js",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
 		"patchtest": "node scripts/patch-test.js",
@@ -15,6 +15,7 @@
 	},
 	"devDependencies": {
 		"eslint": "^8.31.0",
+		"eslint-plugin-lodash": "github:wix/eslint-plugin-lodash",
 		"jest": "^27.0.6",
 		"mock-mediawiki": "^1.3.0",
 		"mwn": "^0.11.1"


### PR DESCRIPTION
This patch introduces eslint rules that warn for `.indexOf(a) !== -1` and `.indexOf(a) === 0` type antipatterns. These are hard to read.

Now that we're using requiresES6 in the gadget file, we should be able to use `.startsWith(a)` and `.includes(a)`. Includes is technically above ES6, but the MediaWiki minifier should be OK with it because it's not new syntax.

