### PR TITLE
Implement merger of vandal and ipvandal templates

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -575,7 +575,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					aivPage.getStatusElement().status('Adding new report...');
 					aivPage.setEditSummary('Reporting [[Special:Contributions/' + uid + '|' + uid + ']].');
 					aivPage.setChangeTags(Twinkle.changeTags);
-					aivPage.setAppendText('\n*{{' + (mw.util.isIPAddress(uid, true) ? 'IPvandal' : 'vandal') + '|' + (/=/.test(uid) ? '1=' : '') + uid + '}} &ndash; ' + reason);
+					aivPage.setAppendText('\n*{{vandal|' + (/=/.test(uid) ? '1=' : '') + uid + '}} &ndash; ' + reason);
 					aivPage.append();
 				});
 			});


### PR DESCRIPTION
A few months ago there was a decision at [TfD](https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2022_October_17#Template:IPvandal) to merge the Vandal and IPvandal templates used for reporting at AIV. The template itself can now detect if it is an ip or not and serve the links accordingly. This pull request makes it so twinkle always uses vandal. [Tested](https://en.wikipedia.org/w/index.php?title=Wikipedia:Administrator_intervention_against_vandalism&diff=prev&oldid=1140900978) and working.