### PR TITLE
Fix double punctuation issues at AIV

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -524,7 +524,11 @@ Twinkle.arv.callback.evaluate = function(e) {
 				reason += ' ' + types;
 			}
 			if (comment !== '') {
-				reason += (/([.?!;:]|^)$/.test(reason) ? '' : '.') + (reason === '' ? '' : ' ') + comment; // Ends sentence if needed, does nothing if empty string
+				var reasonNeedsPunctuation = /([.?!;:]|^)$/.test(reason);
+				reason += reasonNeedsPunctuation ? '' : '.';
+				var reasonIsBlank = reason === '';
+				reason += reasonIsBlank ? '' : ' ';
+				reason += comment;
 			}
 			reason = reason.trim();
 			if (!/[.?!;]$/.test(reason)) {

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -524,7 +524,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 				reason += ' ' + types;
 			}
 			if (comment !== '') {
-				reason += (reason === '' ? '' : '. ') + comment;
+				reason += (/([.?!;:]|^)$/.test(reason) ? '' : '.') + (reason === '' ? '' : ' ') + comment; // Ends sentence if needed, does nothing if empty string
 			}
 			reason = reason.trim();
 			if (!/[.?!;]$/.test(reason)) {

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -509,11 +509,9 @@ Twinkle.arv.callback.evaluate = function(e) {
 				}
 			}).join('; ');
 
-
 			if (form.page.value !== '') {
 				// Allow links to redirects, files, and categories
 				reason = 'On {{No redirect|:' + form.page.value + '}}';
-
 				if (form.badid.value !== '') {
 					reason += ' ({{diff|' + form.page.value + '|' + form.badid.value + '|' + form.goodid.value + '|diff}})';
 				}
@@ -523,17 +521,21 @@ Twinkle.arv.callback.evaluate = function(e) {
 			if (types) {
 				reason += ' ' + types;
 			}
+
 			if (comment !== '') {
-				var reasonNeedsPunctuation = /([.?!;:]|^)$/.test(reason);
-				reason += reasonNeedsPunctuation ? '' : '.';
+				var reasonEndsInPunctuationOrBlank = /([.?!;:]|^)$/.test(reason);
+				reason += reasonEndsInPunctuationOrBlank ? '' : '.';
 				var reasonIsBlank = reason === '';
 				reason += reasonIsBlank ? '' : ' ';
 				reason += comment;
 			}
+
 			reason = reason.trim();
-			if (!/[.?!;]$/.test(reason)) {
+			var reasonEndsInPunctuation = /[.?!;]$/.test(reason);
+			if (!reasonEndsInPunctuation) {
 				reason += '.';
 			}
+
 			reason += ' ~~~~';
 			reason = reason.replace(/\r?\n/g, '\n*:');  // indent newlines
 


### PR DESCRIPTION
Closes #1714 which is about some aiv reports including ":.". This can be reproduced ([example](https://test.wikipedia.org/w/index.php?title=Wikipedia:Administrator_intervention_against_vandalism&diff=prev&oldid=559081)) by giving a diff and no type. [Here](https://test.wikipedia.org/w/index.php?title=Wikipedia:Administrator_intervention_against_vandalism&oldid=559097) are tests for all three cases, reason needing to be terminated, reason not needing to be terminated and reason being empty until the comment is added. 