### PR TITLE
Rmtr order

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,8 +2016,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var placementRE = /===== ?Requests to revert undiscussed moves ?=====/i;
-			var newtext = text.replace(placementRE, Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n$&');
+			var placementRE = /\n\n?(===== ?Requests to revert undiscussed moves ?=====)/i;
+			var newtext = text.replace(placementRE, Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n$1');
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,8 +2016,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var hiddenCommentRE = /==== ?Uncontroversial technical requests ?====(?:.|\n)*? -->/i;
-			var newtext = text.replace(hiddenCommentRE, '$&\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
+			var placementRE = /===== ?Requests to revert undiscussed moves ?=====/i;
+			var newtext = text.replace(placementRE, Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n$&');
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,8 +2016,8 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var placementRE = /\n\n?(==== ?Requests to revert undiscussed moves ?====)/i;
-			var newtext = text.replace(placementRE, Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n$1');
+			var discussionWikitext = Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params);
+			var newtext = Twinkle.xfd.insertRMTR(text, discussionWikitext);
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;
@@ -2034,7 +2034,16 @@ Twinkle.xfd.callbacks = {
 	}
 };
 
-
+/**
+ * Given the wikitext of the WP:RM/TR page and the wikitext to insert, insert it at the bottom of the ==== Uncontroversial technical requests ==== section.
+ * @param {String} pageWikitext
+ * @param {String} wikitextToInsert Will typically be `{{subst:RMassist|1=From|2=To|reason=Reason}}`, which expands out to `* {{RMassist/core | 1 = From | 2 = To | discuss = yes | reason = Reason | sig = Signature | requester = YourUserName}}`
+ * @return {String}
+ */
+Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
+	var placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
+	return pageWikitext.replace(placementRE, '\n' + wikitextToInsert + '\n\n$1');
+};
 
 Twinkle.xfd.callback.evaluate = function(e) {
 	var form = e.target;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2038,7 +2038,7 @@ Twinkle.xfd.callbacks = {
  * Given the wikitext of the WP:RM/TR page and the wikitext to insert, insert it at the bottom of the ==== Uncontroversial technical requests ==== section.
  * @param {String} pageWikitext
  * @param {String} wikitextToInsert Will typically be `{{subst:RMassist|1=From|2=To|reason=Reason}}`, which expands out to `* {{RMassist/core | 1 = From | 2 = To | discuss = yes | reason = Reason | sig = Signature | requester = YourUserName}}`
- * @return {String}
+ * @return {String} pageWikitext
  */
 Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
 	var placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2016,7 +2016,7 @@ Twinkle.xfd.callbacks = {
 			var params = pageobj.getCallbackParameters();
 			var statelem = pageobj.getStatusElement();
 
-			var placementRE = /\n\n?(===== ?Requests to revert undiscussed moves ?=====)/i;
+			var placementRE = /\n\n?(==== ?Requests to revert undiscussed moves ?====)/i;
 			var newtext = text.replace(placementRE, Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params) + '\n$1');
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -7,6 +7,7 @@ mw.config.set({
 require('../morebits.js');
 require('../twinkle.js');
 require('../modules/twinklewarn.js');
+require('../modules/twinklexfd.js');
 global.Morebits = window.Morebits;
 
 global.assert = require('assert');

--- a/tests/twinklexfd.test.js
+++ b/tests/twinklexfd.test.js
@@ -1,0 +1,110 @@
+describe('modules/twinklexfd', () => {
+	describe('insertRMTR', () => {
+		test('0 rows, 1 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('0 rows, 1 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('0 rows, 2 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+
+
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('1 rows, 0 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('2 rows, 0 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+* {{RMassist/core3}}
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+* {{RMassist/core3}}
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('1 rows, 1 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+
+		test('1 rows, 2 line breaks', () => {
+			const pageWikitext =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+
+
+==== Requests to revert undiscussed moves ====`;
+			const wikitextToInsert = `* {{RMassist/core}}`;
+			const expected =
+`<!-- Insert the following code below, filling in page names and reason: {{subst:RMassist| current page title | new title | reason = reason for move}} and enter on a new line, at the bottom of the existing list; do not add spare lines between entries; do not add a bullet point; if you do not wish the request to be converted into an RM if contested, then add |discuss=no -->
+* {{RMassist/core2}}
+* {{RMassist/core}}
+
+==== Requests to revert undiscussed moves ====`;
+			expect(Twinkle.xfd.insertRMTR(pageWikitext, wikitextToInsert)).toBe(expected);
+		});
+	});
+});


### PR DESCRIPTION
Closes  #1718. Simply a regex change to place it above the header below. If you change  Tested [here](https://test.wikipedia.org/w/index.php?title=Wikipedia:Requested_moves/Technical_requests&diff=prev&oldid=559331). The regex may seem more complicated than necessary, but it's required to avoid spacing issues if we have extra newlines which were tested in the two edits before the linked one. 