### PR TITLE
BUG FIX: Use separate templates for two sections of WP:PNT

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1382,14 +1382,17 @@ Twinkle.tag.callbacks = {
 						var lang = params.translationLanguage;
 						var reason = params.translationComments;
 
-						var templateText = '{{subst:needtrans|pg=' + Morebits.pageNameNorm + '|Language=' +
-							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
+						var templateText;
 
 						var text, summary;
 						if (params.tags.indexOf('Rough translation') !== -1) {
+							templateText = '{{subst:duflu|pg=' + Morebits.pageNameNorm + '|Language=' +
+							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
 							text = old_text + '\n\n' + templateText;
 							summary = 'Translation cleanup requested on ';
 						} else {
+							templateText = '{{subst:needtrans|pg=' + Morebits.pageNameNorm + '|Language=' +
+							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
 							text = old_text.replace(/\n+(==\s?Translated pages that could still use some cleanup\s?==)/,
 								'\n\n' + templateText + '\n\n$1');
 							summary = 'Translation' + (lang ? ' from ' + lang : '') + ' requested on ';


### PR DESCRIPTION
In [a discussion](https://en.wikipedia.org/wiki/Wikipedia:Templates_for_discussion/Log/2020_October_31#Template:Duflu) to which I actually contributed but, I think, without understand the full context, it was agreed a couple of years ago to merge the English Wikipedia templates Duflu and Needtrans. It seems the main issue was that there was some overlap between the Twinkle functionality used for the two main sections of [[WP:PNT]], the [project page on "Pages needing translation to English"](https://en.wikipedia.org/wiki/Wikipedia:Pages_needing_translation_into_English).

Twinkle can be used to add an article not in English to a section at [[WP:PNT]] devoted to listing such pages. When an article is added, the default text under it was supplied by substing {{needtran}}, which generated a line reading "The language is (language name/"uncertain")." Twinkle can also add an article to a listing of rough translations needing cleanup. The template used there was {{duflu}} ("dual fluency"), which, when substed, read "The language was (language name/"uncertain")." Nearly the same, but not exactly, and the difference is important.

The changes made two years ago involved changing {{needtrans}} to display "was" rather than "is", to redirect {{duflu}} to {{needtrans}}, and to have {{needtrans}} inserted in both sections of [[WP:PNT]]. The result is wrong, because now, when a page needs translation, the message recorded has "was" instead of "is".

This pull request is to restore the old separation between the two messages, so that {{duflu}}, not {{needtrans}}, is substed for rough translations. Once this goes live, the following steps will be taken on the English Wikipedia end:
- Needtrans will need its text reset on English Wikipedia to read "The language _is_ ...".
- Duflu will need to be restored to its old text rather than redirecting.