### PR TITLE
warn: fix edit summary for uw-wrongsummary

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1104,7 +1104,7 @@ Twinkle.warn.messages = {
 		},
 		'uw-wrongsummary': {
 			label: 'Using inaccurate or inappropriate edit summaries',
-			summary: 'Warning: Using inaccurate or inappropriate edit summaries'
+			summary: 'Notice: Using inaccurate or inappropriate edit summaries'
 		}
 	},
 


### PR DESCRIPTION
If merged, this will change the edit summary for uw-wrongsummary from "Warning: Using inaccurate or inappropriate edit summaries" to "Notice: Using inaccurate or inappropriate edit summaries" for consistency with the rest of the single notices