### PR TITLE
block: fix extra period in {{uw-botuhblock}} edit summary

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1023,7 +1023,7 @@ Twinkle.block.blockPresetsInfo = {
 		forRegisteredOnly: true,
 		nocreate: true,
 		reason: '{{uw-botuhblock}} <!-- Username implies a bot, hard block -->',
-		summary: 'You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]].'
+		summary: 'You have been indefinitely blocked from editing because your username is a blatant violation of the [[WP:U|username policy]]'
 	},
 	'uw-causeblock': {
 		expiry: 'infinity',


### PR DESCRIPTION
Reported by Mori Calliope fan at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#uw-botuhblock_produces_an_extra_period_in_the_edit_summary

Fix double period in {{uw-botuhblock}} edit summary

Untested since I don't want to hard block myself, but should be a low risk change

<img width="442" alt="image" src="https://user-images.githubusercontent.com/79697282/235548906-e7cab182-8b11-4ff5-8f9d-9e4086317267.png">
