### PR TITLE
ci: always run unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,18 +1,6 @@
 name: Unit tests
 
-on:
-  push:
-    paths:
-    - 'morebits.js'
-    - 'tests/**'
-    - 'package.json'
-    - 'package-lock.json'
-  pull_request:
-    paths:
-    - 'morebits.js'
-    - 'tests/**'
-    - 'package.json'
-    - 'package-lock.json'
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Fix #1778

It is cheap to run these, it would help detect breakage of the unit test suite quicker, and if we ever add integration tests or unit tests of additional modules, it would make sure these run for those.