### PR TITLE
jest: fix snapshot tests

### DIFF
--- a/tests/__snapshots__/morebits.quickForm.js.snap
+++ b/tests/__snapshots__/morebits.quickForm.js.snap
@@ -71,7 +71,7 @@ exports[`quickform checkbox elements 1`] = `
 `;
 
 exports[`quickform getElements 1`] = `
-Array [
+[
   <input
     id="node_20_0"
     name="checkboxlist1"
@@ -89,7 +89,7 @@ Array [
 `;
 
 exports[`quickform getInputData 1`] = `
-Object {
+{
   "checkboxlist1": Array [
     "checkval2",
   ],

--- a/tests/__snapshots__/morebits.quickForm.js.snap
+++ b/tests/__snapshots__/morebits.quickForm.js.snap
@@ -90,7 +90,7 @@ exports[`quickform getElements 1`] = `
 
 exports[`quickform getInputData 1`] = `
 {
-  "checkboxlist1": Array [
+  "checkboxlist1": [
     "checkval2",
   ],
   "checkname1": true,


### PR DESCRIPTION
Related #1780

This patch should be merged after #1779. 1779 bumps the version of jest, creating the snapshot error. This patch fixes the snapshot error.