### PR TITLE
fix twinkle menu background on vector-2022 zebra

### DIFF
--- a/twinkle.css
+++ b/twinkle.css
@@ -42,3 +42,12 @@
 #twinkle-config-content input[type=checkbox] {
 	margin-right: 2px;
 }
+
+/* Hotfix for T337893 */
+.vector-feature-zebra-design-enabled #p-twinkle .vector-menu-content-list {
+    background: white;
+    border: 1px solid #a2a9b1;
+}
+.vector-feature-zebra-design-enabled #p-twinkle .mw-list-item {
+    padding: 8px;
+}


### PR DESCRIPTION
Hotfix for https://phabricator.wikimedia.org/T337893. Already deployed by @MusikAnimal

Co-authored-by: MusikAnimal