### PR TITLE
diff/welcome: readability refactor

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -39,12 +39,16 @@ Twinkle.welcome.semiauto = function() {
 };
 
 Twinkle.welcome.normal = function() {
-	if (mw.util.getParamValue('diff')) {
+	var isDiff = mw.util.getParamValue('diff');
+	if (isDiff) {
 		// check whether the contributors' talk pages exist yet
-		var $oList = $('#mw-diff-otitle2').find('span.mw-usertoollinks a.new:contains(talk)').first();
-		var $nList = $('#mw-diff-ntitle2').find('span.mw-usertoollinks a.new:contains(talk)').first();
+		var $oldDiffUsernameLine = $('#mw-diff-otitle2');
+		var $newDiffUsernameLine = $('#mw-diff-ntitle2');
+		var $oldDiffHasRedlinkedTalkPage = $oldDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
+		var $newDiffHasRedlinkedTalkPage = $newDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
 
-		if ($oList.length > 0 || $nList.length > 0) {
+		var diffHasRedlinkedTalkPage = $oldDiffHasRedlinkedTalkPage.length > 0 || $newDiffHasRedlinkedTalkPage.length > 0;
+		if (diffHasRedlinkedTalkPage) {
 			var spanTag = function(color, content) {
 				var span = document.createElement('span');
 				span.style.color = color;
@@ -59,28 +63,28 @@ Twinkle.welcome.normal = function() {
 			welcomeLink.appendChild(spanTag('Black', ']'));
 			welcomeNode.appendChild(welcomeLink);
 
-			if ($oList.length > 0) {
-				var oHref = $oList.attr('href');
+			if ($oldDiffHasRedlinkedTalkPage.length > 0) {
+				var oHref = $oldDiffHasRedlinkedTalkPage.attr('href');
 
 				var oWelcomeNode = welcomeNode.cloneNode(true);
 				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + $.param({
 					friendlywelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
 				}));
-				$oList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
-				$oList[0].parentNode.parentNode.appendChild(oWelcomeNode);
+				$oldDiffHasRedlinkedTalkPage[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
+				$oldDiffHasRedlinkedTalkPage[0].parentNode.parentNode.appendChild(oWelcomeNode);
 			}
 
-			if ($nList.length > 0) {
-				var nHref = $nList.attr('href');
+			if ($newDiffHasRedlinkedTalkPage.length > 0) {
+				var nHref = $newDiffHasRedlinkedTalkPage.attr('href');
 
 				var nWelcomeNode = welcomeNode.cloneNode(true);
 				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + $.param({
 					friendlywelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
 				}));
-				$nList[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
-				$nList[0].parentNode.parentNode.appendChild(nWelcomeNode);
+				$newDiffHasRedlinkedTalkPage[0].parentNode.parentNode.appendChild(document.createTextNode(' '));
+				$newDiffHasRedlinkedTalkPage[0].parentNode.parentNode.appendChild(nWelcomeNode);
 			}
 		}
 	}

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -819,10 +819,10 @@ Twinkle.config.sections = [
 			},
 			{
 				name: 'quickWelcomeMode',
-				label: 'Clicking the "welcome" link on a diff page will',
+				label: 'Clicking the "welcome" link on a diff page (which only appears if the editor\'s user talk page has not been created yet) will',
 				helptip: 'If you choose to welcome automatically, the template you specify below will be used.',
 				type: 'enum',
-				enumValues: { auto: 'welcome automatically', norm: 'prompt you to select a template' }
+				enumValues: { auto: 'immediately post the welcome template specified below', norm: 'prompt you to select a template' }
 			},
 			{
 				name: 'quickWelcomeTemplate',


### PR DESCRIPTION
I had to dig into this code to explore a bug, and I found it confusing. This renames some variables, and changes the wording of some things on the Wikipedia:Twinkle/Preferences screen. Should be no change in functionality.