### PR TITLE
twinkle.js: fix addPortlet() in vector-2022

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -240,11 +240,11 @@ Twinkle.getPref = function twinkleGetPref(name) {
  *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
  *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
  *
- * @param String navigation -- id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
- * @param String id -- id of the portlet menu to create, preferably start with "p-".
- * @param String text -- name of the portlet menu to create. Visibility depends on the class used.
- * @param String type -- type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
- * @param Node nextnodeid -- the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
+ * @param {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel")
+ * @param {String} id id of the portlet menu to create, preferably start with "p-".
+ * @param {String} text name of the portlet menu to create. Visibility depends on the class used.
+ * @param {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu.
+ * @param {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end.
  *
  * @return Node -- the DOM node of the new item (a DIV element) or null
  */
@@ -291,7 +291,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 				outerNavClass += ' vector-menu-tabs';
 			}
 
-			innerDivClass = 'vector-menu-content';
+			innerDivClass = 'vector-menu-content vector-dropdown-content';
 			break;
 		case 'modern':
 			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
@@ -332,14 +332,16 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	var ul = document.createElement('ul');
 
 	if (skin === 'vector' || skin === 'vector-2022') {
+		heading.setAttribute('for', id + '-dropdown-checkbox');
 		ul.className = 'vector-menu-content-list';
-		heading.className = 'vector-menu-heading';
+		heading.className = 'vector-menu-heading vector-dropdown-label';
 
 		// add invisible checkbox to keep menu open when clicked
 		// similar to the p-cactions ("More") menu
 		if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
 			var chkbox = document.createElement('input');
-			chkbox.className = 'vector-menu-checkbox';
+			chkbox.id = id + '-dropdown-checkbox';
+			chkbox.className = 'vector-menu-checkbox vector-dropdown-checkbox';
 			chkbox.setAttribute('type', 'checkbox');
 			chkbox.setAttribute('aria-labelledby', id + '-label');
 			outerNav.appendChild(chkbox);


### PR DESCRIPTION
They way I coded it, this adds some (unnecessary) classes and changes IDs in vector 2010. But I don't think this will break anything. Doing it this way keeps the code simpler.

Tested in vector 2010 and vector 2022, works for displaying the menu correctly and for allowing you to click on a module name to open the module window.

Fixes #1815