### PR TITLE
switch dependabot from monthly to yearly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "yearly"


### PR DESCRIPTION
The dependabot patches generate a lot of noise in emails, PR requests, etc. These are just dev dependencies, so I don't think they're worth much time and effort to keep updated. A yearly reminder should be enough.