### PR TITLE
twinkle.js: group all portlet code in a class

### DIFF
--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -15,7 +15,7 @@
 Twinkle.shared = function friendlyshared() {
 	if (mw.config.get('wgNamespaceNumber') === 3 && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
 		var username = mw.config.get('wgRelevantUserName');
-		Twinkle.addPortletLink(function() {
+		Twinkle.HTMLGenerator.addPortletLink(function() {
 			Twinkle.shared.callback(username);
 		}, 'Shared IP', 'friendly-shared', 'Shared IP tagging');
 	}

--- a/modules/friendlyshared.js
+++ b/modules/friendlyshared.js
@@ -15,7 +15,7 @@
 Twinkle.shared = function friendlyshared() {
 	if (mw.config.get('wgNamespaceNumber') === 3 && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
 		var username = mw.config.get('wgRelevantUserName');
-		Twinkle.HTMLGenerator.addPortletLink(function() {
+		Twinkle.MenuBuilder.addPortletLink(function() {
 			Twinkle.shared.callback(username);
 		}, 'Shared IP', 'friendly-shared', 'Shared IP tagging');
 	}

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -16,11 +16,11 @@ Twinkle.tag = function friendlytag() {
 	// redirect tagging
 	if (Morebits.isPageRedirect()) {
 		Twinkle.tag.mode = 'redirect';
-		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Tag redirect');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Tag redirect');
 	// file tagging
 	} else if (mw.config.get('wgNamespaceNumber') === 6 && !document.getElementById('mw-sharedupload') && document.getElementById('mw-imagepage-section-filehistory')) {
 		Twinkle.tag.mode = 'file';
-		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add maintenance tags to file');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add maintenance tags to file');
 	// article/draft article tagging
 	} else if ([0, 118].indexOf(mw.config.get('wgNamespaceNumber')) !== -1 && mw.config.get('wgCurRevisionId')) {
 		Twinkle.tag.mode = 'article';
@@ -29,7 +29,7 @@ Twinkle.tag = function friendlytag() {
 			// Disabled on latest diff because the diff slider could be used to slide
 			// away from the latest diff without causing the script to reload
 			!mw.config.get('wgDiffNewId');
-		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
 	}
 };
 

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -16,11 +16,11 @@ Twinkle.tag = function friendlytag() {
 	// redirect tagging
 	if (Morebits.isPageRedirect()) {
 		Twinkle.tag.mode = 'redirect';
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Tag redirect');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Tag redirect');
 	// file tagging
 	} else if (mw.config.get('wgNamespaceNumber') === 6 && !document.getElementById('mw-sharedupload') && document.getElementById('mw-imagepage-section-filehistory')) {
 		Twinkle.tag.mode = 'file';
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add maintenance tags to file');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add maintenance tags to file');
 	// article/draft article tagging
 	} else if ([0, 118].indexOf(mw.config.get('wgNamespaceNumber')) !== -1 && mw.config.get('wgCurRevisionId')) {
 		Twinkle.tag.mode = 'article';
@@ -29,7 +29,7 @@ Twinkle.tag = function friendlytag() {
 			// Disabled on latest diff because the diff slider could be used to slide
 			// away from the latest diff without causing the script to reload
 			!mw.config.get('wgDiffNewId');
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.tag.callback, 'Tag', 'friendly-tag', 'Add or remove article maintenance tags');
 	}
 };
 

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -17,7 +17,7 @@ Twinkle.talkback = function() {
 	if (!mw.config.exists('wgRelevantUserName') || Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		return;
 	}
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
 };
 
 Twinkle.talkback.callback = function() {

--- a/modules/friendlytalkback.js
+++ b/modules/friendlytalkback.js
@@ -17,7 +17,7 @@ Twinkle.talkback = function() {
 	if (!mw.config.exists('wgRelevantUserName') || Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
 		return;
 	}
-	Twinkle.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.talkback.callback, 'TB', 'friendly-talkback', 'Easy talkback');
 };
 
 Twinkle.talkback.callback = function() {

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -90,7 +90,7 @@ Twinkle.welcome.normal = function() {
 	}
 	// Users and IPs but not IP ranges
 	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
-		Twinkle.addPortletLink(function() {
+		Twinkle.HTMLGenerator.addPortletLink(function() {
 			Twinkle.welcome.callback(mw.config.get('wgRelevantUserName'));
 		}, 'Wel', 'friendly-welcome', 'Welcome user');
 	}

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -90,7 +90,7 @@ Twinkle.welcome.normal = function() {
 	}
 	// Users and IPs but not IP ranges
 	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
-		Twinkle.HTMLGenerator.addPortletLink(function() {
+		Twinkle.MenuBuilder.addPortletLink(function() {
 			Twinkle.welcome.callback(mw.config.get('wgRelevantUserName'));
 		}, 'Wel', 'friendly-welcome', 'Welcome user');
 	}

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -25,7 +25,7 @@ Twinkle.arv = function twinklearv() {
 	}
 	var userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
-	Twinkle.HTMLGenerator.addPortletLink(function() {
+	Twinkle.MenuBuilder.addPortletLink(function() {
 		Twinkle.arv.callback(username, isIP);
 	}, 'ARV', 'tw-arv', 'Report ' + userType + ' to administrators');
 };

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -25,7 +25,7 @@ Twinkle.arv = function twinklearv() {
 	}
 	var userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
-	Twinkle.addPortletLink(function() {
+	Twinkle.HTMLGenerator.addPortletLink(function() {
 		Twinkle.arv.callback(username, isIP);
 	}, 'ARV', 'tw-arv', 'Report ' + userType + ' to administrators');
 };

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -19,7 +19,7 @@ Twinkle.batchdelete = function twinklebatchdelete() {
 			mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex'
 		)
 	) {
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
 	}
 };
 

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -19,7 +19,7 @@ Twinkle.batchdelete = function twinklebatchdelete() {
 			mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex'
 		)
 	) {
-		Twinkle.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchdelete.callback, 'D-batch', 'tw-batch', 'Delete pages found in this category/on this page');
 	}
 };
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -18,7 +18,7 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 	if (Morebits.userIsSysop && ((mw.config.get('wgArticleId') > 0 && (mw.config.get('wgNamespaceNumber') === 2 ||
 		mw.config.get('wgNamespaceNumber') === 4)) || mw.config.get('wgNamespaceNumber') === 14 ||
 		mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex')) {
-		Twinkle.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
 	}
 };
 

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -18,7 +18,7 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 	if (Morebits.userIsSysop && ((mw.config.get('wgArticleId') > 0 && (mw.config.get('wgNamespaceNumber') === 2 ||
 		mw.config.get('wgNamespaceNumber') === 4)) || mw.config.get('wgNamespaceNumber') === 14 ||
 		mw.config.get('wgCanonicalSpecialPageName') === 'Prefixindex')) {
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.batchprotect.callback, 'P-batch', 'tw-pbatch', 'Protect pages linked from this page');
 	}
 };
 

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -19,7 +19,7 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 		mw.config.get('wgNamespaceNumber') !== mw.config.get('wgNamespaceIds').project)) {
 		return;
 	}
-	Twinkle.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
 };
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -19,7 +19,7 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 		mw.config.get('wgNamespaceNumber') !== mw.config.get('wgNamespaceIds').project)) {
 		return;
 	}
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.batchundelete.callback, 'Und-batch', 'tw-batch-undel', "Undelete 'em all");
 };
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -20,7 +20,7 @@ Twinkle.block = function twinkleblock() {
 	// should show on Contributions or Block pages, anywhere there's a relevant user
 	// Ignore ranges wider than the CIDR limit
 	if (Morebits.userIsSysop && relevantUserName && (!Morebits.ip.isRange(relevantUserName) || Morebits.ip.validCIDR(relevantUserName))) {
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
 

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -20,7 +20,7 @@ Twinkle.block = function twinkleblock() {
 	// should show on Contributions or Block pages, anywhere there's a relevant user
 	// Ignore ranges wider than the CIDR limit
 	if (Morebits.userIsSysop && relevantUserName && (!Morebits.ip.isRange(relevantUserName) || Morebits.ip.validCIDR(relevantUserName))) {
-		Twinkle.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.block.callback, 'Block', 'tw-block', 'Block relevant user');
 	}
 };
 

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -931,27 +931,6 @@ Twinkle.config.sections = [
 		title: 'Hidden',
 		hidden: true,
 		preferences: [
-			// twinkle.js: portlet setup
-			{
-				name: 'portletArea',
-				type: 'string'
-			},
-			{
-				name: 'portletId',
-				type: 'string'
-			},
-			{
-				name: 'portletName',
-				type: 'string'
-			},
-			{
-				name: 'portletType',
-				type: 'string'
-			},
-			{
-				name: 'portletNext',
-				type: 'string'
-			},
 			// twinklefluff.js: defines how many revision to query maximum, maximum possible is 50, default is 50
 			{
 				name: 'revertMaxRevisions',

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -20,7 +20,7 @@ Twinkle.deprod = function() {
 	) {
 		return;
 	}
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
 
 var concerns = {};

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -20,7 +20,7 @@ Twinkle.deprod = function() {
 	) {
 		return;
 	}
-	Twinkle.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
 
 var concerns = {};

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -16,18 +16,18 @@ Twinkle.diff = function twinklediff() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId')) {
 		return;
 	}
-	Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
+	Twinkle.MenuBuilder.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
 
 	// Show additional tabs only on diff pages
 	if (mw.config.get('wgDiffNewId')) {
-		Twinkle.HTMLGenerator.addPortletLink(function() {
+		Twinkle.MenuBuilder.addPortletLink(function() {
 			Twinkle.diff.evaluate(false);
 		}, 'Since', 'tw-since', 'Show difference between last diff and the revision made by previous user');
-		Twinkle.HTMLGenerator.addPortletLink(function() {
+		Twinkle.MenuBuilder.addPortletLink(function() {
 			Twinkle.diff.evaluate(true);
 		}, 'Since mine', 'tw-sincemine', 'Show difference between last diff and my last revision');
 
-		Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: mw.config.get('wgDiffNewId')}), 'Current', 'tw-curdiff', 'Show difference to current revision');
+		Twinkle.MenuBuilder.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: mw.config.get('wgDiffNewId')}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
 

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -16,18 +16,18 @@ Twinkle.diff = function twinklediff() {
 	if (mw.config.get('wgNamespaceNumber') < 0 || !mw.config.get('wgArticleId')) {
 		return;
 	}
-	Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
+	Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: 'prev'}), 'Last', 'tw-lastdiff', 'Show most recent diff');
 
 	// Show additional tabs only on diff pages
 	if (mw.config.get('wgDiffNewId')) {
-		Twinkle.addPortletLink(function() {
+		Twinkle.HTMLGenerator.addPortletLink(function() {
 			Twinkle.diff.evaluate(false);
 		}, 'Since', 'tw-since', 'Show difference between last diff and the revision made by previous user');
-		Twinkle.addPortletLink(function() {
+		Twinkle.HTMLGenerator.addPortletLink(function() {
 			Twinkle.diff.evaluate(true);
 		}, 'Since mine', 'tw-sincemine', 'Show difference between last diff and my last revision');
 
-		Twinkle.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: mw.config.get('wgDiffNewId')}), 'Current', 'tw-curdiff', 'Show difference to current revision');
+		Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl(mw.config.get('wgPageName'), {diff: 'cur', oldid: mw.config.get('wgDiffNewId')}), 'Current', 'tw-curdiff', 'Show difference to current revision');
 	}
 };
 

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -14,7 +14,7 @@
 
 Twinkle.image = function twinkleimage() {
 	if (mw.config.get('wgNamespaceNumber') === 6 && mw.config.get('wgArticleId') && !document.getElementById('mw-sharedupload') && !Morebits.isPageRedirect()) {
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
 	}
 };
 

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -14,7 +14,7 @@
 
 Twinkle.image = function twinkleimage() {
 	if (mw.config.get('wgNamespaceNumber') === 6 && mw.config.get('wgArticleId') && !document.getElementById('mw-sharedupload') && !Morebits.isPageRedirect()) {
-		Twinkle.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.image.callback, 'DI', 'tw-di', 'Nominate file for delayed speedy deletion');
 	}
 };
 

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -19,7 +19,7 @@ Twinkle.prod = function twinkleprod() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
 };
 
 // Used in edit summaries, for comparisons, etc.

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -19,7 +19,7 @@ Twinkle.prod = function twinkleprod() {
 		return;
 	}
 
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.prod.callback, 'PROD', 'tw-prod', 'Propose deletion via WP:PROD');
 };
 
 // Used in edit summaries, for comparisons, etc.

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -19,7 +19,7 @@ Twinkle.protect = function twinkleprotect() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
 		Morebits.userIsSysop ? 'Protect page' : 'Request page protection');
 };
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -19,7 +19,7 @@ Twinkle.protect = function twinkleprotect() {
 		return;
 	}
 
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.protect.callback, Morebits.userIsSysop ? 'PP' : 'RPP', 'tw-rpp',
 		Morebits.userIsSysop ? 'Protect page' : 'Request page protection');
 };
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -26,7 +26,7 @@ Twinkle.speedy = function twinklespeedy() {
 		return;
 	}
 
-	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
 
 // This function is run when the CSD tab/header link is clicked

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -26,7 +26,7 @@ Twinkle.speedy = function twinklespeedy() {
 		return;
 	}
 
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
 
 // This function is run when the CSD tab/header link is clicked

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -18,7 +18,7 @@ Twinkle.unlink = function twinkleunlink() {
 		(!Morebits.userIsInGroup('extendedconfirmed') && !Morebits.userIsSysop)) {
 		return;
 	}
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
 };
 
 // the parameter is used when invoking unlink from admin speedy

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -18,7 +18,7 @@ Twinkle.unlink = function twinkleunlink() {
 		(!Morebits.userIsInGroup('extendedconfirmed') && !Morebits.userIsSysop)) {
 		return;
 	}
-	Twinkle.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.unlink.callback, 'Unlink', 'tw-unlink', 'Unlink backlinks');
 };
 
 // the parameter is used when invoking unlink from admin speedy

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -17,7 +17,7 @@ Twinkle.warn = function twinklewarn() {
 
 	// Users and IPs but not IP ranges
 	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
-		Twinkle.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
+		Twinkle.HTMLGenerator.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&
 			mw.config.get('wgNamespaceNumber') === 3 &&
 			Twinkle.getPrefill('vanarticle') &&

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -17,7 +17,7 @@ Twinkle.warn = function twinklewarn() {
 
 	// Users and IPs but not IP ranges
 	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
-		Twinkle.HTMLGenerator.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
+		Twinkle.MenuBuilder.addPortletLink(Twinkle.warn.callback, 'Warn', 'tw-warn', 'Warn/notify user');
 		if (Twinkle.getPref('autoMenuAfterRollback') &&
 			mw.config.get('wgNamespaceNumber') === 3 &&
 			Twinkle.getPrefill('vanarticle') &&

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -46,7 +46,7 @@ Twinkle.xfd = function twinklexfd() {
 				break;
 		}
 	}
-	Twinkle.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', tooltip);
+	Twinkle.HTMLGenerator.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', tooltip);
 };
 
 

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -46,7 +46,7 @@ Twinkle.xfd = function twinklexfd() {
 				break;
 		}
 	}
-	Twinkle.HTMLGenerator.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', tooltip);
+	Twinkle.MenuBuilder.addPortletLink(Twinkle.xfd.callback, 'XFD', 'tw-xfd', tooltip);
 };
 
 

--- a/scripts/morebits-test.js
+++ b/scripts/morebits-test.js
@@ -171,7 +171,7 @@ mw.loader.using('jquery.ui', function() {
 
 Twinkle.morebitsTestInit = function () {
 	if (mw.config.get('wgAction') === 'view' && mw.config.get('skin') === 'vector' && mw.config.get('wgNamespaceNumber') >= 0) {
-		Twinkle.HTMLGenerator.addPortlet('javascript:Twinkle.morebitsTest.launchDialog(Twinkle.morebitsTest.$runTests)', 'Test', 'tw-test', 'Test morebits.js', '');
+		Twinkle.MenuBuilder.addPortlet('javascript:Twinkle.morebitsTest.launchDialog(Twinkle.morebitsTest.$runTests)', 'Test', 'tw-test', 'Test morebits.js', '');
 	}
 };
 

--- a/scripts/morebits-test.js
+++ b/scripts/morebits-test.js
@@ -171,7 +171,7 @@ mw.loader.using('jquery.ui', function() {
 
 Twinkle.morebitsTestInit = function () {
 	if (mw.config.get('wgAction') === 'view' && mw.config.get('skin') === 'vector' && mw.config.get('wgNamespaceNumber') >= 0) {
-		Twinkle.addPortlet('javascript:Twinkle.morebitsTest.launchDialog(Twinkle.morebitsTest.$runTests)', 'Test', 'tw-test', 'Test morebits.js', '');
+		Twinkle.HTMLGenerator.addPortlet('javascript:Twinkle.morebitsTest.launchDialog(Twinkle.morebitsTest.$runTests)', 'Test', 'tw-test', 'Test morebits.js', '');
 	}
 };
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -196,19 +196,19 @@ class TwinkleHTMLGenerator {
 	constructor(skin) {
 		this.skin = skin;
 
-		/** @param {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
+		/** @type {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
 		this.navigation = '';
 
-		/** @param {String} id id of the portlet menu to create, preferably start with "p-". */
+		/** @type {String} id id of the portlet menu to create, preferably start with "p-". */
 		this.id = '';
 
-		/** @param {String} text name of the portlet menu to create. Visibility depends on the class used. */
+		/** @type {String} text name of the portlet menu to create. Visibility depends on the class used. */
 		this.text = '';
 
-		/** @param {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
+		/** @type {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
 		this.type = '';
 
-		/** @param {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
+		/** @type {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
 		this.nextnodeid = {};
 
 		switch (this.skin) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -192,7 +192,7 @@ Twinkle.getPref = function twinkleGetPref(name) {
 	return Twinkle.defaultConfig[name];
 };
 
-class TwinkleHTMLGenerator {
+class TwinkleMenuBuilder {
 	/**
 	 * @param {String} skin MediaWiki skin name, e.g. vector, vector-2022, monobook, etc.
 	 * @param {Object} document DOM
@@ -437,7 +437,7 @@ class TwinkleHTMLGenerator {
 	}
 }
 
-Twinkle.HTMLGenerator = new TwinkleHTMLGenerator(mw.config.get('skin'), document, $, $.collapsibleTabs);
+Twinkle.MenuBuilder = new TwinkleMenuBuilder(mw.config.get('skin'), document, $, $.collapsibleTabs);
 
 /**
  * **************** General initialization code ****************
@@ -540,7 +540,7 @@ Twinkle.load = function () {
 	// If using a skin with space for lots of modules, display a link to Twinkle Preferences
 	var usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
 	if (usingSkinWithDropDownMenu) {
-		Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
+		Twinkle.MenuBuilder.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
 	}
 };
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -193,8 +193,24 @@ Twinkle.getPref = function twinkleGetPref(name) {
 };
 
 class TwinkleHTMLGenerator {
-	constructor(skin) {
+	/**
+	 * @param {String} skin MediaWiki skin name, e.g. vector, vector-2022, monobook, etc.
+	 * @param {Object} document DOM
+	 * @param {function} $ JQuery
+	 * @param {Object} collapsibleTabs A global related to something in the Vector Legacy skin
+	 */
+	constructor(skin, document, $, collapsibleTabs) {
+		/** @type {String} MediaWiki skin name, e.g. vector, vector-2022, monobook, etc. */
 		this.skin = skin;
+
+		/** @type {Object} DOM */
+		this.document = document;
+
+		/** @type {function} JQuery */
+		this.$ = $;
+
+		/** @type {Object} collapsibleTabs A global related to something in the Vector Legacy skin */
+		this.collapsibleTabs = collapsibleTabs;
 
 		/** @type {String} id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
 		this.navigation = '';
@@ -263,12 +279,12 @@ class TwinkleHTMLGenerator {
 		}
 
 		// sanity checks, and get required DOM nodes
-		var root = document.getElementById(this.navigation) || document.querySelector(this.navigation);
+		var root = this.document.getElementById(this.navigation) || this.document.querySelector(this.navigation);
 		if (!root) {
 			return null;
 		}
 
-		var item = document.getElementById(this.id);
+		var item = this.document.getElementById(this.id);
 		if (item) {
 			if (item.parentNode && item.parentNode === root) {
 				return item;
@@ -278,7 +294,7 @@ class TwinkleHTMLGenerator {
 
 		var nextnode;
 		if (this.nextnodeid) {
-			nextnode = document.getElementById(this.nextnodeid);
+			nextnode = this.document.getElementById(this.nextnodeid);
 		}
 
 		// verify/normalize input
@@ -326,11 +342,11 @@ class TwinkleHTMLGenerator {
 		// Build the DOM elements.
 		var outerNav, heading;
 		if (this.skin === 'vector-2022') {
-			outerNav = document.createElement('div');
-			heading = document.createElement('label');
+			outerNav = this.document.createElement('div');
+			heading = this.document.createElement('label');
 		} else {
-			outerNav = document.createElement('nav');
-			heading = document.createElement('h3');
+			outerNav = this.document.createElement('nav');
+			heading = this.document.createElement('h3');
 		}
 
 		outerNav.setAttribute('aria-labelledby', this.id + '-label');
@@ -343,7 +359,7 @@ class TwinkleHTMLGenerator {
 		}
 
 		heading.id = this.id + '-label';
-		var ul = document.createElement('ul');
+		var ul = this.document.createElement('ul');
 
 		if (this.skin === 'vector' || this.skin === 'vector-2022') {
 			heading.setAttribute('for', this.id + '-dropdown-checkbox');
@@ -353,7 +369,7 @@ class TwinkleHTMLGenerator {
 			// add invisible checkbox to keep menu open when clicked
 			// similar to the p-cactions ("More") menu
 			if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
-				var chkbox = document.createElement('input');
+				var chkbox = this.document.createElement('input');
 				chkbox.id = this.id + '-dropdown-checkbox';
 				chkbox.className = 'vector-menu-checkbox vector-dropdown-checkbox';
 				chkbox.setAttribute('type', 'checkbox');
@@ -362,14 +378,14 @@ class TwinkleHTMLGenerator {
 
 				// Vector gets its title in a span; all others except
 				// timeless have no title, and it has no span
-				var span = document.createElement('span');
-				span.appendChild(document.createTextNode(this.text));
+				var span = this.document.createElement('span');
+				span.appendChild(this.document.createTextNode(this.text));
 				heading.appendChild(span);
 
-				var a = document.createElement('a');
+				var a = this.document.createElement('a');
 				a.href = '#';
 
-				$(a).click(function(e) {
+				this.$(a).click(function(e) {
 					e.preventDefault();
 				});
 
@@ -377,13 +393,13 @@ class TwinkleHTMLGenerator {
 			}
 		} else {
 			// Basically just Timeless
-			heading.appendChild(document.createTextNode(this.text));
+			heading.appendChild(this.document.createTextNode(this.text));
 		}
 
 		outerNav.appendChild(heading);
 
 		if (innerDivClass) {
-			var innerDiv = document.createElement('div');
+			var innerDiv = this.document.createElement('div');
 			innerDiv.className = innerDivClass;
 			innerDiv.appendChild(ul);
 			outerNav.appendChild(innerDiv);
@@ -407,21 +423,21 @@ class TwinkleHTMLGenerator {
 			id,
 			tooltip
 		);
-		$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+		this.$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
 		if (typeof task === 'function') {
-			$(link).click(function (ev) {
+			this.$(link).click(function (ev) {
 				task();
 				ev.preventDefault();
 			});
 		}
-		if ($.collapsibleTabs) {
-			$.collapsibleTabs.handleResize();
+		if (this.collapsibleTabs) {
+			this.collapsibleTabs.handleResize();
 		}
 		return link;
 	}
 }
 
-Twinkle.HTMLGenerator = new TwinkleHTMLGenerator(mw.config.get('skin'));
+Twinkle.HTMLGenerator = new TwinkleHTMLGenerator(mw.config.get('skin'), document, $, $.collapsibleTabs);
 
 /**
  * **************** General initialization code ****************

--- a/twinkle.js
+++ b/twinkle.js
@@ -198,8 +198,9 @@ class TwinkleMenuBuilder {
 	 * @param {Object} document DOM
 	 * @param {function} $ JQuery
 	 * @param {Object} collapsibleTabs A global related to something in the Vector Legacy skin
+	 * @param {Object} mwUtil The mw.util global
 	 */
-	constructor(skin, document, $, collapsibleTabs) {
+	constructor(skin, document, $, collapsibleTabs, mwUtil) {
 		/** @type {String} MediaWiki skin name, e.g. vector, vector-2022, monobook, etc. */
 		this.skin = skin;
 
@@ -211,6 +212,9 @@ class TwinkleMenuBuilder {
 
 		/** @type {Object} collapsibleTabs A global related to something in the Vector Legacy skin */
 		this.collapsibleTabs = collapsibleTabs;
+
+		/** @type {Object} The mw.util global */
+		this.mwUtil = mwUtil;
 
 		/** @type {String} id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
 		this.navigation = '';
@@ -416,7 +420,7 @@ class TwinkleMenuBuilder {
 	*/
 	addPortletLink(task, text, id, tooltip) {
 		this.addPortlet(mw.config.get('skin'));
-		var link = mw.util.addPortletLink(
+		var link = this.mwUtil.addPortletLink(
 			this.id,
 			typeof task === 'string' ? task : '#',
 			text,
@@ -437,7 +441,7 @@ class TwinkleMenuBuilder {
 	}
 }
 
-Twinkle.MenuBuilder = new TwinkleMenuBuilder(mw.config.get('skin'), document, $, $.collapsibleTabs);
+Twinkle.MenuBuilder = new TwinkleMenuBuilder(mw.config.get('skin'), document, $, $.collapsibleTabs, mw.util);
 
 /**
  * **************** General initialization code ****************

--- a/twinkle.js
+++ b/twinkle.js
@@ -192,231 +192,236 @@ Twinkle.getPref = function twinkleGetPref(name) {
 	return Twinkle.defaultConfig[name];
 };
 
-/**
- * **************** Twinkle.addPortlet() ****************
- *
- * Adds a portlet menu to one of the navigation areas on the page.
- * This is necessarily quite a hack since skins, navigation areas, and
- * portlet menu types all work slightly different.
- *
- * Available navigation areas depend on the skin used.
- * Vector:
- *  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
- *  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
- *  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
- *  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
- *  Special layout of p-personal portlet (part of "head") through specialized styles.
- * Monobook:
- *  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *  Special layout of p-cactions and p-personal through specialized styles.
- * Modern:
- *  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
- *  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
- *
- * @return Node -- the DOM node of the new item (a DIV element) or null
- */
-Twinkle.addPortlet = function(skin) {
-	/** @param {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
-	var navigation = '';
+class TwinkleHTMLGenerator {
+	constructor(skin) {
+		this.skin = skin;
 
-	/** @param {String} id id of the portlet menu to create, preferably start with "p-". */
-	var id = '';
+		/** @param {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
+		this.navigation = '';
 
-	/** @param {String} text name of the portlet menu to create. Visibility depends on the class used. */
-	var text = '';
+		/** @param {String} id id of the portlet menu to create, preferably start with "p-". */
+		this.id = '';
 
-	/** @param {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
-	var type = '';
+		/** @param {String} text name of the portlet menu to create. Visibility depends on the class used. */
+		this.text = '';
 
-	/** @param {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
-	var nextnodeid = {};
+		/** @param {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
+		this.type = '';
 
-	switch (skin) {
-		case 'vector':
-		case 'vector-2022':
-			navigation = 'right-navigation';
-			id = 'p-twinkle';
-			text = 'TW';
-			type = 'menu';
-			nextnodeid = 'p-search';
-			break;
-		case 'timeless':
-			navigation = '#page-tools .sidebar-inner';
-			id = 'p-twinkle';
-			text = 'Twinkle';
-			type = null;
-			nextnodeid = 'p-userpagetools';
-			break;
-		default:
-			navigation = null;
-			id = 'p-cactions';
-			text = null;
-			type = null;
-			nextnodeid = null;
-	}
+		/** @param {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
+		this.nextnodeid = {};
 
-	if (navigation === null) {
-		return;
-	}
-
-	// sanity checks, and get required DOM nodes
-	var root = document.getElementById(navigation) || document.querySelector(navigation);
-	if (!root) {
-		return null;
-	}
-
-	var item = document.getElementById(id);
-	if (item) {
-		if (item.parentNode && item.parentNode === root) {
-			return item;
+		switch (this.skin) {
+			case 'vector':
+			case 'vector-2022':
+				this.navigation = 'right-navigation';
+				this.id = 'p-twinkle';
+				this.text = 'TW';
+				this.type = 'menu';
+				this.nextnodeid = 'p-search';
+				break;
+			case 'timeless':
+				this.navigation = '#page-tools .sidebar-inner';
+				this.id = 'p-twinkle';
+				this.text = 'Twinkle';
+				this.type = null;
+				this.nextnodeid = 'p-userpagetools';
+				break;
+			default:
+				this.navigation = null;
+				this.id = 'p-cactions';
+				this.text = null;
+				this.type = null;
+				this.nextnodeid = null;
 		}
-		return null;
 	}
 
-	var nextnode;
-	if (nextnodeid) {
-		nextnode = document.getElementById(nextnodeid);
-	}
+	/**
+	* Adds a portlet menu to one of the navigation areas on the page.
+	* This is necessarily quite a hack since skins, navigation areas, and
+	* portlet menu types all work slightly different.
+	*
+	* Available navigation areas depend on the skin used.
+	* Vector:
+	*  For each option, the outer nav class contains "vector-menu", the inner div class is "vector-menu-content", and the ul is "vector-menu-content-list"
+	*  "mw-panel", outer nav class contains "vector-menu-portal". Existing portlets/elements: "p-logo", "p-navigation", "p-interaction", "p-tb", "p-coll-print_export"
+	*  "left-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-namespaces", "p-variants" (menu)
+	*  "right-navigation", outer nav class contains "vector-menu-tabs" or "vector-menu-dropdown". Existing portlets: "p-views", "p-cactions" (menu), "p-search"
+	*  Special layout of p-personal portlet (part of "head") through specialized styles.
+	* Monobook:
+	*  "column-one", outer nav class "portlet", inner div class "pBody". Existing portlets: "p-cactions", "p-personal", "p-logo", "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	*  Special layout of p-cactions and p-personal through specialized styles.
+	* Modern:
+	*  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
+	*  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
+	*
+	* @return Node -- the DOM node of the new item (a DIV element) or null
+	*/
+	addPortlet() {
+		if (this.navigation === null) {
+			return;
+		}
 
-	// verify/normalize input
-	if ((skin !== 'vector' && skin !== 'vector-2022') || (navigation !== 'left-navigation' && navigation !== 'right-navigation')) {
-		type = null; // menu supported only in vector's #left-navigation & #right-navigation
-	}
-	var outerNavClass, innerDivClass;
-	switch (skin) {
-		case 'vector':
-		case 'vector-2022':
-			// XXX: portal doesn't work
-			if (navigation !== 'portal' && navigation !== 'left-navigation' && navigation !== 'right-navigation') {
-				navigation = 'mw-panel';
+		// sanity checks, and get required DOM nodes
+		var root = document.getElementById(this.navigation) || document.querySelector(this.navigation);
+		if (!root) {
+			return null;
+		}
+
+		var item = document.getElementById(this.id);
+		if (item) {
+			if (item.parentNode && item.parentNode === root) {
+				return item;
 			}
+			return null;
+		}
 
-			outerNavClass = 'mw-portlet vector-menu';
-			if (navigation === 'mw-panel') {
-				outerNavClass += ' vector-menu-portal';
-			} else if (type === 'menu') {
-				outerNavClass += ' vector-menu-dropdown vector-dropdown vector-menu-dropdown-noicon';
-			} else {
-				outerNavClass += ' vector-menu-tabs';
+		var nextnode;
+		if (this.nextnodeid) {
+			nextnode = document.getElementById(this.nextnodeid);
+		}
+
+		// verify/normalize input
+		if ((this.skin !== 'vector' && this.skin !== 'vector-2022') || (this.navigation !== 'left-navigation' && this.navigation !== 'right-navigation')) {
+			this.type = null; // menu supported only in vector's #left-navigation & #right-navigation
+		}
+		var outerNavClass, innerDivClass;
+		switch (this.skin) {
+			case 'vector':
+			case 'vector-2022':
+				var panel = false;
+
+				// XXX: portal doesn't work
+				if (
+					this.navigation !== 'portal' &&
+					this.navigation !== 'left-navigation' &&
+					this.navigation !== 'right-navigation'
+				) {
+					panel = true;
+				}
+
+				outerNavClass = 'mw-portlet vector-menu';
+				if (panel) {
+					outerNavClass += ' vector-menu-portal';
+				} else if (this.type === 'menu') {
+					outerNavClass += ' vector-menu-dropdown vector-dropdown vector-menu-dropdown-noicon';
+				} else {
+					outerNavClass += ' vector-menu-tabs';
+				}
+
+				innerDivClass = 'vector-menu-content vector-dropdown-content';
+				break;
+			case 'modern':
+				outerNavClass = 'portlet';
+				break;
+			case 'timeless':
+				outerNavClass = 'mw-portlet';
+				innerDivClass = 'mw-portlet-body';
+				break;
+			default:
+				outerNavClass = 'portlet';
+				break;
+		}
+
+		// Build the DOM elements.
+		var outerNav, heading;
+		if (this.skin === 'vector-2022') {
+			outerNav = document.createElement('div');
+			heading = document.createElement('label');
+		} else {
+			outerNav = document.createElement('nav');
+			heading = document.createElement('h3');
+		}
+
+		outerNav.setAttribute('aria-labelledby', this.id + '-label');
+		outerNav.className = outerNavClass + ' emptyPortlet';
+		outerNav.id = this.id;
+		if (nextnode && nextnode.parentNode === root) {
+			root.insertBefore(outerNav, nextnode);
+		} else {
+			root.appendChild(outerNav);
+		}
+
+		heading.id = this.id + '-label';
+		var ul = document.createElement('ul');
+
+		if (this.skin === 'vector' || this.skin === 'vector-2022') {
+			heading.setAttribute('for', this.id + '-dropdown-checkbox');
+			ul.className = 'vector-menu-content-list';
+			heading.className = 'vector-menu-heading vector-dropdown-label';
+
+			// add invisible checkbox to keep menu open when clicked
+			// similar to the p-cactions ("More") menu
+			if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
+				var chkbox = document.createElement('input');
+				chkbox.id = this.id + '-dropdown-checkbox';
+				chkbox.className = 'vector-menu-checkbox vector-dropdown-checkbox';
+				chkbox.setAttribute('type', 'checkbox');
+				chkbox.setAttribute('aria-labelledby', this.id + '-label');
+				outerNav.appendChild(chkbox);
+
+				// Vector gets its title in a span; all others except
+				// timeless have no title, and it has no span
+				var span = document.createElement('span');
+				span.appendChild(document.createTextNode(this.text));
+				heading.appendChild(span);
+
+				var a = document.createElement('a');
+				a.href = '#';
+
+				$(a).click(function(e) {
+					e.preventDefault();
+				});
+
+				heading.appendChild(a);
 			}
+		} else {
+			// Basically just Timeless
+			heading.appendChild(document.createTextNode(this.text));
+		}
 
-			innerDivClass = 'vector-menu-content vector-dropdown-content';
-			break;
-		case 'modern':
-			if (navigation !== 'mw_portlets' && navigation !== 'mw_contentwrapper') {
-				navigation = 'mw_portlets';
-			}
-			outerNavClass = 'portlet';
-			break;
-		case 'timeless':
-			outerNavClass = 'mw-portlet';
-			innerDivClass = 'mw-portlet-body';
-			break;
-		default:
-			navigation = 'column-one';
-			outerNavClass = 'portlet';
-			break;
+		outerNav.appendChild(heading);
+
+		if (innerDivClass) {
+			var innerDiv = document.createElement('div');
+			innerDiv.className = innerDivClass;
+			innerDiv.appendChild(ul);
+			outerNav.appendChild(innerDiv);
+		} else {
+			outerNav.appendChild(ul);
+		}
+
+		return outerNav;
 	}
 
-	// Build the DOM elements.
-	var outerNav, heading;
-	if (skin === 'vector-2022') {
-		outerNav = document.createElement('div');
-		heading = document.createElement('label');
-	} else {
-		outerNav = document.createElement('nav');
-		heading = document.createElement('h3');
-	}
-
-	outerNav.setAttribute('aria-labelledby', id + '-label');
-	outerNav.className = outerNavClass + ' emptyPortlet';
-	outerNav.id = id;
-	if (nextnode && nextnode.parentNode === root) {
-		root.insertBefore(outerNav, nextnode);
-	} else {
-		root.appendChild(outerNav);
-	}
-
-	heading.id = id + '-label';
-	var ul = document.createElement('ul');
-
-	if (skin === 'vector' || skin === 'vector-2022') {
-		heading.setAttribute('for', id + '-dropdown-checkbox');
-		ul.className = 'vector-menu-content-list';
-		heading.className = 'vector-menu-heading vector-dropdown-label';
-
-		// add invisible checkbox to keep menu open when clicked
-		// similar to the p-cactions ("More") menu
-		if (outerNavClass.indexOf('vector-menu-dropdown') !== -1) {
-			var chkbox = document.createElement('input');
-			chkbox.id = id + '-dropdown-checkbox';
-			chkbox.className = 'vector-menu-checkbox vector-dropdown-checkbox';
-			chkbox.setAttribute('type', 'checkbox');
-			chkbox.setAttribute('aria-labelledby', id + '-label');
-			outerNav.appendChild(chkbox);
-
-			// Vector gets its title in a span; all others except
-			// timeless have no title, and it has no span
-			var span = document.createElement('span');
-			span.appendChild(document.createTextNode(text));
-			heading.appendChild(span);
-
-			var a = document.createElement('a');
-			a.href = '#';
-
-			$(a).click(function(e) {
-				e.preventDefault();
+	/**
+	* Builds a portlet menu if it doesn't exist yet, and add the portlet link.
+	* @param task: Either a URL for the portlet link or a function to execute.
+	*/
+	addPortletLink(task, text, id, tooltip) {
+		this.addPortlet(mw.config.get('skin'));
+		var link = mw.util.addPortletLink(
+			this.id,
+			typeof task === 'string' ? task : '#',
+			text,
+			id,
+			tooltip
+		);
+		$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
+		if (typeof task === 'function') {
+			$(link).click(function (ev) {
+				task();
+				ev.preventDefault();
 			});
-
-			heading.appendChild(a);
 		}
-	} else {
-		// Basically just Timeless
-		heading.appendChild(document.createTextNode(text));
+		if ($.collapsibleTabs) {
+			$.collapsibleTabs.handleResize();
+		}
+		return link;
 	}
+}
 
-	outerNav.appendChild(heading);
-
-	if (innerDivClass) {
-		var innerDiv = document.createElement('div');
-		innerDiv.className = innerDivClass;
-		innerDiv.appendChild(ul);
-		outerNav.appendChild(innerDiv);
-	} else {
-		outerNav.appendChild(ul);
-	}
-
-	return outerNav;
-};
-
-/**
- * **************** Twinkle.addPortletLink() ****************
- * Builds a portlet menu if it doesn't exist yet, and add the portlet link.
- * @param task: Either a URL for the portlet link or a function to execute.
- */
-Twinkle.addPortletLink = function(task, text, id, tooltip) {
-	Twinkle.addPortlet(mw.config.get('skin'));
-	var link = mw.util.addPortletLink(
-		// TODO: broken because of this, going to change my approach, see branch addPortlet-refactor-2
-		Twinkle.getPref('portletId'),
-		typeof task === 'string' ? task : '#',
-		text,
-		id,
-		tooltip
-	);
-	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
-	if (typeof task === 'function') {
-		$(link).click(function (ev) {
-			task();
-			ev.preventDefault();
-		});
-	}
-	if ($.collapsibleTabs) {
-		$.collapsibleTabs.handleResize();
-	}
-	return link;
-};
-
+Twinkle.HTMLGenerator = new TwinkleHTMLGenerator(mw.config.get('skin'));
 
 /**
  * **************** General initialization code ****************
@@ -519,7 +524,7 @@ Twinkle.load = function () {
 	// If using a skin with space for lots of modules, display a link to Twinkle Preferences
 	var usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
 	if (usingSkinWithDropDownMenu) {
-		Twinkle.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
+		Twinkle.HTMLGenerator.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
 	}
 };
 

--- a/twinkle.js
+++ b/twinkle.js
@@ -196,19 +196,19 @@ class TwinkleHTMLGenerator {
 	constructor(skin) {
 		this.skin = skin;
 
-		/** @type {String} navigation id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
+		/** @type {String} id of the target navigation area (skin dependant, on vector either of "left-navigation", "right-navigation", or "mw-panel") */
 		this.navigation = '';
 
-		/** @type {String} id id of the portlet menu to create, preferably start with "p-". */
+		/** @type {String} id of the portlet menu to create, preferably start with "p-". */
 		this.id = '';
 
-		/** @type {String} text name of the portlet menu to create. Visibility depends on the class used. */
+		/** @type {String} name of the portlet menu to create. Visibility depends on the class used. */
 		this.text = '';
 
-		/** @type {String} type type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
+		/** @type {String} type of portlet. Currently only used for the vector non-sidebar portlets, pass "menu" to make this portlet a drop down menu. */
 		this.type = '';
 
-		/** @type {Node} nextnodeid the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
+		/** @type {Node} the id of the node before which the new item should be added, should be another item in the same list, or undefined to place it at the end. */
 		this.nextnodeid = {};
 
 		switch (this.skin) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -255,7 +255,7 @@ class TwinkleHTMLGenerator {
 	*  "mw_contentwrapper" (top nav), outer nav class "portlet", inner div class "pBody". Existing portlets or elements: "p-cactions", "mw_content"
 	*  "mw_portlets" (sidebar), outer nav class "portlet", inner div class "pBody". Existing portlets: "p-navigation", "p-search", "p-interaction", "p-tb", "p-coll-print_export"
 	*
-	* @return Node -- the DOM node of the new item (a DIV element) or null
+	* @return {Node} -- the DOM node of the new item (a DIV element) or null
 	*/
 	addPortlet() {
 		if (this.navigation === null) {


### PR DESCRIPTION
Moved away from storing skin variables in the preferences system, which is confusing, makes them seem like they're configurable at Twinkle/Preferences, but they are not.

Also renamed a variable, and deleted some variables that weren't used.

Later, will refactor that class a bit more so that we can add some unit tests. For example, `document` should probably be passed in through the constructor so it can be mocked.

What is `$.collapsibleTabs`? Can that be deleted? Doesn't look like it's ever set.