### PR TITLE
hideReason=true for Uw-blar and Uw-articletodraft

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -208,8 +208,8 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 //   label (required): A short description displayed in the dialog
 //   summary (required): The edit summary used. If an article name is entered, the summary is postfixed with "on [[article]]", and it is always postfixed with "."
 //   suppressArticleInSummary (optional): Set to true to suppress showing the article name in the edit summary. Useful if the warning relates to attack pages, or some such.
-//   hideLinkedPage (optional): Set to true to hide the "Linked article" text box. Some warning templates do not have a linked article parameter.
-//   hideReason (optional): Set to true to hide the "Reason" text box. Some warning templates do not have a reason parameter.
+//   hideLinkedPage (optional): Set to true to hide the "Linked page" text box. Some warning templates do not have a linked article parameter.
+//   hideReason (optional): Set to true to hide the "Optional message" text box. Some warning templates do not have a reason parameter.
 Twinkle.warn.messages = {
 	levels: {
 		'Common warnings': {
@@ -945,7 +945,8 @@ Twinkle.warn.messages = {
 		},
 		'uw-articletodraft': {
 			label: 'Article moved to draftspace',
-			summary: 'Notice: Article moved to draftspace'
+			summary: 'Notice: Article moved to draftspace',
+			hideReason: true
 		},
 		'uw-autobiography': {
 			label: 'Creating autobiographies',
@@ -966,7 +967,8 @@ Twinkle.warn.messages = {
 		},
 		'uw-blar': {
 			label: 'Article blanked and redirected',
-			summary: 'Notice: Article blanked and redirected'
+			summary: 'Notice: Article blanked and redirected',
+			hideReason: true
 		},
 		'uw-coi': {
 			label: 'Conflict of interest',


### PR DESCRIPTION
I just merged #1797, but I realized it needs `hideReason: true` because the {{{2}}} parameter is not a reason. This patch fixes that.

Related #1797
Related #1753