### PR TITLE
Fix RMTR bug

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2205,7 +2205,6 @@ Twinkle.xfd.callback.evaluate = function(e) {
 			wikipedia_page.setCallbackParameters(params);
 
 			if (params.rmtr) {
-				wikipedia_page.setPageSection(2);
 				wikipedia_page.load(Twinkle.xfd.callbacks.rm.listAtRMTR);
 			} else {
 				// listAtTalk uses .append(), so no need to load the page


### PR DESCRIPTION
Reported by QuietHere at https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#RM%2FTR_error

Hotfix already deployed: https://en.wikipedia.org/w/index.php?title=MediaWiki:Gadget-twinklexfd.js&diff=prev&oldid=1170247859