### PR TITLE
twinkle: Put TW menu back on the right side of the More menu

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -271,6 +271,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	var portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
 
 	if (mw.config.get('skin') === 'vector') {
+		// The Twinkle dropdown menu has been added to the left of p-cactions. Move it to the right.
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
 		$('#p-twinkle-dropdown').insertAfter('.vector-page-tools-landmark');

--- a/twinkle.js
+++ b/twinkle.js
@@ -274,10 +274,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 		// The Twinkle dropdown menu has been added to the left of p-cactions. Move it to the right.
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		$('#p-twinkle-dropdown').insertAfter('.vector-page-tools-landmark');
-		// this creates two #p-twinkle-dropdowns for some reason, in different spots on the DOM. maybe some JS in vector 2022? delete the bad one:
-		$('.vector-column-end > #p-twinkle-dropdown').remove();
-		portlet = $('#p-twinkle-dropdown');
+		return $('#p-twinkle-dropdown').detach().insertAfter('.vector-page-tools-landmark');
 	}
 
 	return portlet;

--- a/twinkle.js
+++ b/twinkle.js
@@ -268,7 +268,7 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 		nextnodeid = 'p-cactions';
 	}
 
-	let portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
+	var portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
 
 	if (mw.config.get('skin') === 'vector') {
 		$('#p-twinkle').insertAfter('#p-cactions');

--- a/twinkle.js
+++ b/twinkle.js
@@ -262,11 +262,24 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 		}
 		return null;
 	}
+
 	if (type === 'menu') {
 		// In order to get mw.util.addPortlet to generate a dropdown menu in vector and vector-2022, the nextnodeid must be p-cactions. Any other nextnodeid will generate a non-dropdown portlet instead.
 		nextnodeid = 'p-cactions';
 	}
-	return mw.util.addPortlet(id, text, '#' + nextnodeid);
+
+	let portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
+
+	if (mw.config.get('skin') === 'vector') {
+		$('#p-twinkle').insertAfter('#p-cactions');
+	} else if (mw.config.get('skin') === 'vector-2022') {
+		$('#p-twinkle-dropdown').insertAfter('.vector-page-tools-landmark');
+		// this creates two #p-twinkle-dropdowns for some reason, in different spots on the DOM. maybe some JS in vector 2022? delete the bad one:
+		$('.vector-column-end > #p-twinkle-dropdown').remove();
+		portlet = $('#p-twinkle-dropdown');
+	}
+
+	return portlet;
 };
 
 /**

--- a/twinkle.js
+++ b/twinkle.js
@@ -270,11 +270,16 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 
 	var portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
 
+	// The Twinkle dropdown menu has been added to the left of p-cactions. Move it to the right.
 	if (mw.config.get('skin') === 'vector') {
-		// The Twinkle dropdown menu has been added to the left of p-cactions. Move it to the right.
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		return $('#p-twinkle-dropdown').detach().insertAfter('.vector-page-tools-landmark');
+		$('#p-twinkle-dropdown').appendTo('.vector-page-tools-landmark');
+
+		// .vector-page-tools-landmark is unstable and could change. If so, log it to console, to hopefully get someone's attention.
+		if (!document.querySelector('.vector-page-tools-landmark')) {
+			mw.log.warn('Unexpected change in DOM');
+		}
 	}
 
 	return portlet;


### PR DESCRIPTION
Fixes #1886
Related #1881

Menus are jumping around too much during page load with TW menu on the left. Need to move it back to its spot on the right.

The spot on the right is reserved for it in https://en.wikipedia.org/wiki/MediaWiki:Gadget-Twinkle.css