### PR TITLE
twinkle: fix vector-2022 TW menu bug

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -274,10 +274,11 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 	if (mw.config.get('skin') === 'vector') {
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		$('#p-twinkle-dropdown').insertAfter('#right-navigation > .vector-page-tools-landmark');
+		var $landmark = $('#right-navigation > .vector-page-tools-landmark');
+		$('#p-twinkle-dropdown').insertAfter($landmark);
 
 		// .vector-page-tools-landmark is unstable and could change. If so, log it to console, to hopefully get someone's attention.
-		if (!document.querySelector('.vector-page-tools-landmark')) {
+		if (!$landmark) {
 			mw.log.warn('Unexpected change in DOM');
 		}
 	}

--- a/twinkle.js
+++ b/twinkle.js
@@ -270,11 +270,11 @@ Twinkle.addPortlet = function(navigation, id, text, type, nextnodeid) {
 
 	var portlet = mw.util.addPortlet(id, text, '#' + nextnodeid);
 
-	// The Twinkle dropdown menu has been added to the left of p-cactions. Move it to the right.
+	// The Twinkle dropdown menu has been added to the left of p-cactions, since that is the only spot that will create a dropdown menu. But we want it on the right. Move it to the right.
 	if (mw.config.get('skin') === 'vector') {
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		$('#p-twinkle-dropdown').appendTo('.vector-page-tools-landmark');
+		$('#p-twinkle-dropdown').insertAfter('#right-navigation > .vector-page-tools-landmark');
 
 		// .vector-page-tools-landmark is unstable and could change. If so, log it to console, to hopefully get someone's attention.
 		if (!document.querySelector('.vector-page-tools-landmark')) {


### PR DESCRIPTION
Fixes #1895 TW menu becomes unusable in vector-2022 if you dock the tools menu to the right side