### PR TITLE
Remove IE 11 compatibility code

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ Things to watch out for:
 
 - Items and processes laid out in [CONTRIBUTING.md](./CONTRIBUTING.md) are followed.
 - Twinkle is meant to run on the latest weekly version of MediaWiki as rolled out every Thursday on the English Wikipedia. Backwards compatibility is not guaranteed.
-- The goal is for Twinkle and Morebits to support the same [browsers for which MediaWiki provides Grade A support](https://www.mediawiki.org/wiki/Browser_compatibility), except IE 11. The Twinkle gadget on enwiki is configured so that we can use up to JavaScript version ES6. However, due to the MediaWiki minifier, we must not use keywords from ES2016 or later, such as async/await and RegEx /s flag. New functions from ES2016 or later, such as Array.includes() should be okay since these will not break the minifier.
+- The goal is for Twinkle and Morebits to support the same [browsers for which MediaWiki provides Grade A support](https://www.mediawiki.org/wiki/Browser_compatibility). The Twinkle gadget on enwiki is configured so that we can use up to JavaScript version ES6. However, due to the MediaWiki minifier, we must not use keywords from ES2016 or later, such as async/await and RegEx /s flag. New functions from ES2016 or later, such as Array.includes() should be okay since these will not break the minifier.
 - Certain positional jQuery selectors like `:first`, `:last`, and `:eq` were [deprecated in jQuery version 3.4.0](https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/) and should probably not be reintroduced. Instead, use methods like `.first()`, `.last()`, or `.eq()`.
 
 ## Updating scripts on Wikipedia

--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -125,18 +125,11 @@ Twinkle.tag.callback = function friendlytagCallback() {
 		case 'article':
 			Window.setTitle('Article maintenance tagging');
 
-			// Object.values is unavailable in IE 11
-			var obj_values = Object.values || function (obj) {
-				return Object.keys(obj).map(function (key) {
-					return obj[key];
-				});
-			};
-
 			// Build sorting and lookup object flatObject, which is always
 			// needed but also used to generate the alphabetical list
 			Twinkle.tag.article.flatObject = {};
-			obj_values(Twinkle.tag.article.tagList).forEach(function (group) {
-				obj_values(group).forEach(function (subgroup) {
+			Object.values(Twinkle.tag.article.tagList).forEach(function (group) {
+				Object.values(group).forEach(function (subgroup) {
 					if (Array.isArray(subgroup)) {
 						subgroup.forEach(function (item) {
 							Twinkle.tag.article.flatObject[item.tag] = item;

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -219,7 +219,7 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 
 	var firstRadio = e.target.form.template[0];
 	firstRadio.checked = true;
-	var vals = sets[Object.keys(sets)[0]];
+	var vals = Object.values(sets)[0];
 	e.target.form.article.disabled = vals[firstRadio.value] ? !vals[firstRadio.value].linkedArticle : true;
 };
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -348,7 +348,6 @@ Twinkle.fluff.addLinks = {
 };
 
 Twinkle.fluff.disableLinks = function disablelinks(parentNode) {
-	// Array.from not available in IE11 :(
 	$(parentNode).children().each(function(_ix, node) {
 		node.innerHTML = node.textContent; // Feels like cheating
 		$(node).css('font-weight', 'normal').css('color', 'darkgray');

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1309,8 +1309,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 
 	var selected = false;
 	// worker function to create the combo box entries
-	var createEntries = function(contents, container, wrapInOptgroup, val) {
-		val = typeof val !== 'undefined' ? val : value; // IE doesn't support default parameters
+	var createEntries = function(contents, container, wrapInOptgroup, val = value) {
 		// level2->2, singlewarn->''; also used to distinguish the
 		// scaled levels from singlenotice, singlewarn, and custom
 		var level = val.replace(/^\D+/g, '');
@@ -1773,10 +1772,7 @@ Twinkle.warn.callbacks = {
 		var params = pageobj.getCallbackParameters();
 		var messageData = params.messageData;
 
-		// JS somehow didn't get destructured assignment until ES6 so of course IE doesn't support it
-		var warningHistory = Twinkle.warn.callbacks.dateProcessing(text);
-		var latest = warningHistory[0];
-		var history = warningHistory[1];
+		var [latest, history] = Twinkle.warn.callbacks.dateProcessing(text);
 
 		var now = new Morebits.date(pageobj.getLoadTime());
 

--- a/morebits.js
+++ b/morebits.js
@@ -2124,7 +2124,7 @@ Morebits.date.prototype = {
 		level = parseInt(level, 10);
 		level = isNaN(level) ? 2 : level;
 
-		var header = Array(level + 1).join('='); // String.prototype.repeat not supported in IE 11
+		var header = '='.repeat(level);
 		var text = this.getUTCMonthName() + ' ' + this.getUTCFullYear();
 
 		if (header.length) { // wikitext-formatted header
@@ -3755,9 +3755,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 * "edit" or "delete". In practice, only "edit" or "notedit" matters.
 	 * @returns {boolean}
 	 */
-	var fnCanUseMwUserToken = function(action) {
-		action = typeof action !== 'undefined' ? action : 'edit'; // IE doesn't support default parameters
-
+	var fnCanUseMwUserToken = function(action = 'edit') {
 		// If a watchlist expiry is set, we must always load the page
 		// to avoid overwriting indefinite protection.  Of course, not
 		// needed if setting indefinite watching!
@@ -5741,7 +5739,6 @@ Morebits.taskManager = function(context) {
 	this.taskDependencyMap = new Map();
 	this.failureCallbackMap = new Map();
 	this.deferreds = new Map();
-	this.allDeferreds = []; // Hack: IE doesn't support Map.prototype.values
 	this.context = context || window;
 
 	/**
@@ -5760,7 +5757,6 @@ Morebits.taskManager = function(context) {
 		this.failureCallbackMap.set(func, onFailure || function() {});
 		var deferred = $.Deferred();
 		this.deferreds.set(func, deferred);
-		this.allDeferreds.push(deferred);
 	};
 
 	/**
@@ -5791,7 +5787,7 @@ Morebits.taskManager = function(context) {
 				self.failureCallbackMap.get(task).apply(self.context, arguments);
 			});
 		});
-		return $.when.apply(null, this.allDeferreds); // resolved when everything is done!
+		return $.when.apply(null, [...this.deferreds.values()]); // resolved when everything is done!
 	};
 
 };


### PR DESCRIPTION
IE 11 is no longer supported, by Twinkle or by MediaWiki, for a while now.