### PR TITLE
xfd: in daily log pages, add a line break to the end of some entries

### DIFF
--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -806,6 +806,10 @@ Twinkle.xfd.callbacks = {
 
 		text += '}}';
 
+		if (venue === 'rfd' || venue === 'tfd' || venue === 'cfd') {
+			text += '\n';
+		}
+
 		// Don't delsort if delsortCats is undefined (TFD, FFD, etc.)
 		// Don't delsort if delsortCats is an empty array (AFD where user chose no categories)
 		if (Array.isArray(params.delsortCats) && params.delsortCats.length) {


### PR DESCRIPTION
RFD, CFD, and TFD entries added to daily log pages by Twinkle currently have no line break between the entry being added and the next entry. They touch each other.

This patch fixes that. After this patch, there will be a line break between each entry.

Before: https://test.wikipedia.org/w/index.php?title=Wikipedia:Categories_for_discussion/Log/2023_December_4&diff=prev&oldid=584083

After: https://test.wikipedia.org/w/index.php?title=Wikipedia:Categories_for_discussion/Log/2023_December_4&diff=prev&oldid=584085