### PR TITLE
Fix PR labeler CI

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,7 +6,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@main
+    - uses: actions/labeler@v4
       with:
         configuration-path: ".github/labels.yml"
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fix #1907

I can't easily figure out how to upgrade the syntax of https://github.com/wikimedia-gadgets/twinkle/blob/master/.github/labels.yml from v4 to v5. As a band aid fix to get our CI working, force the PR labeler to use v4.