### PR TITLE
feat(modules/friendlytag): add {{No significant coverage}}

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -835,6 +835,7 @@ Twinkle.tag.article.tagList = {
 			{ tag: 'BLP sources', description: 'BLP that needs additional sources for verification' },
 			{ tag: 'BLP unsourced', description: 'BLP that has no sources at all (use BLP PROD instead for new articles)' },
 			{ tag: 'More citations needed', description: 'needs additional references or sources for verification' },
+			{ tag: 'No significant coverage', description: 'does not cite any sources containing significant coverage' },
 			{ tag: 'One source', description: 'relies largely or entirely on a single source' },
 			{ tag: 'Original research', description: 'contains original research' },
 			{ tag: 'Primary sources', description: 'relies too much on references to primary sources, and needs secondary sources' },


### PR DESCRIPTION
From a request by `@thebiguglyalien` on the Wikipedia Discord, this PR adds {{[No significant coverage](https://en.wikipedia.org/wiki/Template:No_significant_coverage)}} to the friendlytag module.