### PR TITLE
tag: Fix removing tags for maintenance templates where |name= points to a redirect

### DIFF
--- a/modules/friendlytag.js
+++ b/modules/friendlytag.js
@@ -1545,7 +1545,7 @@ Twinkle.tag.callbacks = {
 				});
 				pages.forEach(function(page) {
 					var removed = false;
-					page.linkshere.forEach(function(el) {
+					page.linkshere.concat({title: page.title}).forEach(function(el) {
 						var tag = el.title.slice(9);
 						var tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
 						if (tag_re.test(pageText)) {


### PR DESCRIPTION
For #1863/#1618

If a maintenance template had been moved but its `|name=` wasn't updated, the code would pick up every version of that template *except* for the current name (since obviously that won't appear in a linkshere for itself and it tries to use the `|name=` for its current name). This fixes that by ensuring that whatever page linkshere resolves to is also included in the templates it attempts to remove

Credit to #1618 for the solution, I just tested it to make sure it worked

(Testing) Fixes #1618