### PR TITLE
prevent placing of protection, XFD, or CSD tags on TimedText pages 

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -67,7 +67,7 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 				label: 'Tag page with protection template',
 				value: 'tag',
 				tooltip: 'If the protecting admin forgot to apply a protection template, or you have just protected the page without tagging, you can use this to apply the appropriate protection tag.',
-				disabled: mw.config.get('wgArticleId') === 0 || mw.config.get('wgPageContentModel') === 'Scribunto' || mw.config.get('wgNamespaceNumber') === 710
+				disabled: mw.config.get('wgArticleId') === 0 || mw.config.get('wgPageContentModel') === 'Scribunto' || mw.config.get('wgNamespaceNumber') === 710 // TimedText
 			}
 		]
 	});
@@ -1112,7 +1112,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 	var input = Morebits.quickForm.getInputData(form);
 
 	var tagparams;
-	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710)) {
+	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */)) {
 		tagparams = {
 			tag: input.tagtype,
 			reason: false,

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -67,7 +67,7 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 				label: 'Tag page with protection template',
 				value: 'tag',
 				tooltip: 'If the protecting admin forgot to apply a protection template, or you have just protected the page without tagging, you can use this to apply the appropriate protection tag.',
-				disabled: mw.config.get('wgArticleId') === 0 || mw.config.get('wgPageContentModel') === 'Scribunto'
+				disabled: mw.config.get('wgArticleId') === 0 || mw.config.get('wgPageContentModel') === 'Scribunto' || mw.config.get('wgNamespaceNumber') === 710
 			}
 		]
 	});
@@ -502,7 +502,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 				value: '',
 				tooltip: 'Optional revision ID of the RfPP page where protection was requested.'
 			});
-			if (!mw.config.get('wgArticleId') || mw.config.get('wgPageContentModel') === 'Scribunto') {  // tagging isn't relevant for non-existing or module pages
+			if (!mw.config.get('wgArticleId') || mw.config.get('wgPageContentModel') === 'Scribunto' || mw.config.get('wgNamespaceNumber') === 710) {  // tagging isn't relevant for non-existing, module, or TimedText pages
 				break;
 			}
 			/* falls through */
@@ -1075,8 +1075,8 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 		// Add any annotations
 		Twinkle.protect.callback.annotateProtectReason(e);
 
-		// sort out tagging options, disabled if nonexistent or lua
-		if (mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto') {
+		// sort out tagging options, disabled if nonexistent, lua, or TimedText
+		if (mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710) {
 			if (form.category.value === 'unprotect') {
 				form.tagtype.value = 'none';
 			} else {
@@ -1112,7 +1112,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 	var input = Morebits.quickForm.getInputData(form);
 
 	var tagparams;
-	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto')) {
+	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710)) {
 		tagparams = {
 			tag: input.tagtype,
 			reason: false,

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1380,7 +1380,7 @@ Twinkle.speedy.callbacks = {
 			}
 
 			// Tag if possible, post on talk if not
-			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1) {
+			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1 && mw.config.get('wgNamespaceNumber') !== 710) {
 				var text = pageobj.getPageText();
 
 				statelem.status('Checking for tags on the page...');
@@ -1483,7 +1483,7 @@ Twinkle.speedy.callbacks = {
 					talk_page.setCallbackParameters(params);
 					talk_page.newSection(Twinkle.speedy.callbacks.user.tagComplete);
 				} else {
-					pageobj.getStatusElement().error('Page protected and nowhere to add an edit request, aborting');
+					pageobj.getStatusElement().error('Page cannot be edited and no other location to place a speedy deletion request, aborting');
 				}
 			}
 		},

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1380,7 +1380,7 @@ Twinkle.speedy.callbacks = {
 			}
 
 			// Tag if possible, post on talk if not
-			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1 && mw.config.get('wgNamespaceNumber') !== 710) {
+			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1 && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */) {
 				var text = pageobj.getPageText();
 
 				statelem.status('Checking for tags on the page...');

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -499,17 +499,19 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Miscellany for deletion',
 				name: 'work_area'
 			});
-			work_area.append({
-				type: 'checkbox',
-				list: [
-					{
-						label: 'Wrap deletion tag with &lt;noinclude&gt;',
-						value: 'noinclude',
-						name: 'noinclude',
-						tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t transclude. Select this option for userboxes.'
-					}
-				]
-			});
+			if (mw.config.get('wgNamespaceNumber') !== 710) { // TimedText cannot be tagged, so asking whether to noinclude the tag is pointless
+				work_area.append({
+					type: 'checkbox',
+					list: [
+						{
+							label: 'Wrap deletion tag with &lt;noinclude&gt;',
+							value: 'noinclude',
+							name: 'noinclude',
+							tooltip: 'Will wrap the deletion tag in &lt;noinclude&gt; tags, so that it won\'t transclude. Select this option for userboxes.'
+						}
+					]
+				});
+			}
 			if ((mw.config.get('wgNamespaceNumber') === 2 /* User: */ || mw.config.get('wgNamespaceNumber') === 3 /* User talk: */) && mw.config.exists('wgRelevantUserName')) {
 				work_area.append({
 					type: 'checkbox',
@@ -1500,10 +1502,12 @@ Twinkle.xfd.callbacks = {
 			apiobj.statelem.info('next in order is [[' + apiobj.params.discussionpage + ']]');
 
 			// Tagging page
-			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page with deletion tag');
-			wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the page is moved, we would want to follow the redirect
-			wikipedia_page.setCallbackParameters(apiobj.params);
-			wikipedia_page.load(Twinkle.xfd.callbacks.mfd.taggingPage);
+			if (mw.config.get('wgNamespaceNumber') !== 710) { // cannot tag TimedText pages
+				var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page with deletion tag');
+				wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the page is moved, we would want to follow the redirect
+				wikipedia_page.setCallbackParameters(apiobj.params);
+				wikipedia_page.load(Twinkle.xfd.callbacks.mfd.taggingPage);
+			}
 
 			// Updating data for the action completed event
 			Morebits.wiki.actionCompleted.redirect = apiobj.params.discussionpage;

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1501,9 +1501,11 @@ Twinkle.xfd.callbacks = {
 
 			apiobj.statelem.info('next in order is [[' + apiobj.params.discussionpage + ']]');
 
+			var wikipedia_page;
+
 			// Tagging page
 			if (mw.config.get('wgNamespaceNumber') !== 710) { // cannot tag TimedText pages
-				var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page with deletion tag');
+				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page with deletion tag');
 				wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the page is moved, we would want to follow the redirect
 				wikipedia_page.setCallbackParameters(apiobj.params);
 				wikipedia_page.load(Twinkle.xfd.callbacks.mfd.taggingPage);


### PR DESCRIPTION
Fixes #2018. TimedText pages can't display templates, but still use the wikitext content model for some reason, so they weren't caught by that check.

I am not an admin so could not fully test the protection changes – if someone who is could protect a TimedText page and verify that no tag is automatically placed that would be appreciated.