### PR TITLE
Performance optimizations in dev-server

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -46,8 +46,8 @@ server.listen(port, hostname, async () => {
 	console.log(`Server running at http://${hostname}:${port}/`);
 	console.log(`Please add "mw.loader.load('http://${hostname}:${port}');" to your on-wiki common.js file to begin testing.`);
 
-	if (!process.env.MW_USERNAME || !process.env.MW_PASSWORD) {
-		return console.log("Ensure the Twinkle gadget version is disabled. If you provide your MW_USERNAME and MW_PASSWORD as environment variables, we'll try to automatically disable the gadget for you and re-enable it when you're done testing.");
+	if (!process.env.MW_OAUTH2_TOKEN && (!process.env.MW_USERNAME || !process.env.MW_PASSWORD)) {
+		return console.log("Ensure the Twinkle gadget version is disabled. If you provide your credentials as environment variables (either the BotPassword credentials as MW_USERNAME and MW_PASSWORD, or an owner-only OAuth2 consumer token as MW_OAUTH2_TOKEN), we'll try to automatically disable the gadget for you and re-enable it when you're done testing.");
 	}
 	let mwn, user;
 	try {
@@ -60,6 +60,7 @@ server.listen(port, hostname, async () => {
 			"apiUrl": "https://en.wikipedia.org/w/api.php",
 			"username": process.env.MW_USERNAME,
 			"password": process.env.MW_PASSWORD,
+			"oauth2Token": process.env.MW_OAUTH2_TOKEN,
 			"silent": true
 		});
 	} catch (e) {


### PR DESCRIPTION
- Allow using OAuth 2 token for enabling/disabling onwiki gadget
  - Speeds up the process of disabling onwiki gadget as OAuth2 doesn't require login. Closes #1883
- Mitigate token errors while re-enabling onwiki gadget
  - By preemptively fetching a new CSRF token if more than 15 minutes passed from the user starting the server.
- Parallelize filesystem read calls
  - Earlier, each file was being read sequentially from disk. Parallelizing the calls is seen to reduce load times by 25%. 