### PR TITLE
arv: preview arv reports

### DIFF
--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -1073,7 +1073,7 @@ Twinkle.arv.callback.getAn3ReportData = function(input) {
 			confirmations: data.confirmations
 		};
 	}).catch((errorData) => {
-		if (typeof errorData !== 'object' || Object.prototype.hasOwnProperty.call(errorData, 'message')) {
+		if (typeof errorData !== 'object' || !Object.prototype.hasOwnProperty.call(errorData, 'message')) {
 			return Promise.reject({ message: 'Unknown error: ' + errorData });
 		}
 

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -661,8 +661,6 @@ Twinkle.arv.callback.evaluate = function(e) {
 Twinkle.arv.callback.preview = function(form) {
 	var input = Morebits.quickForm.getInputData(form);
 
-	console.log(input); // eslint-disable-line no-console
-
 	var reportText = '';
 	switch (input.category) {
 		case 'aiv':

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -975,7 +975,7 @@ Twinkle.arv.callback.getAn3ReportData = function(input) {
 				return '(comment hidden)';
 			}
 			// swap curly braces for HTML entities to avoid templates being rendered if they were included in an edit summary
-			return '"' + rev.comment.replace('{', '&#123;').replace('}', '&#125;') + '"';
+			return '"' + rev.comment.replace(/\{/g, '&#123;').replace(/\}/g, '&#125;') + '"';
 
 		};
 

--- a/morebits.js
+++ b/morebits.js
@@ -4770,8 +4770,6 @@ Morebits.wiki.preview = function(previewbox) {
 	this.previewbox = previewbox;
 	$(previewbox).addClass('morebits-previewbox').hide();
 
-	this.shown = false;
-
 	/**
 	 * Displays the preview box, and populates it with a loading indicator. This should be used only when the creation of the wikitext that
 	 * will be displayed in the preview box is done asynchronously or will take a significant amount of time.
@@ -4839,7 +4837,6 @@ Morebits.wiki.preview = function(previewbox) {
 	/** Hides the preview box and clears it. */
 	this.closePreview = function() {
 		$(previewbox).empty().hide();
-		this.shown = false;
 	};
 };
 


### PR DESCRIPTION
Resolves #671.

Sorry that this diff is hard to read, this change includes a fairly substantial refactor so that the creation of the report wikitext is done on its own rather than coupled with report posting logic. Aside from the obvious, I don't think there are any changes to functionality, other than that curly braces in edit summaries will now be escaped to prevent templates from getting rendered in AN3 reports given that they don't render in edit summaries.

Because of that refactor, it's highly possible this has broken something somewhere (especially considering there's now promise chains involved, which I can only barely wrap my head around): I've done quite a lot of testing to make sure that didn't happen but would appreciate someone double-checking my work, especially with AN3 reporting.

One thing that did come up is that in AN3 reports, the logic for filling the |orig= parameter in the report template seems to be broken (both before my change and after, I think) - I would have fixed it but frankly I don't really understand what should go into that parameter in the first place. The API call is not parsed properly (the following is from the current version):

https://github.com/wikimedia-gadgets/twinkle/blob/34259325a9043b246b7d8cd5ae338d09ee244415/modules/twinklearv.js#L854-L894

Seems like the `data` parameter of the callback is trying to be read as an array, but the API call always returns an object. Adding `data = data.query.pages[data.query.pageids[0]].revisions;` at the start of that callback would convert the object to the array it thinks it is, but I don't know enough about what the |orig= parameter is even for to be able to decide whether that actually fixes the problem. I can't even really create a new ticket because I don't know what the expected behavior is, but if someone is able to explain I can probably fix it pretty easily.