### PR TITLE
welcome: add some {{Welcomeen-XX}} templates

### DIFF
--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -598,6 +598,46 @@ Twinkle.welcome.templates = {
 			'welcomeen-uk': {
 				description: 'welcome for users whose first language appears to be Ukrainian',
 				syntax: '{{subst:welcomeen-uk}}'
+			},
+			'welcomeen-fa': {
+				description: 'welcome for users whose first language appears to be Persian',
+				syntax: '{{subst:welcomeen-fa}}'
+			},
+			'welcomeen-ha': {
+				description: 'welcome for users whose first language appears to be Hausa',
+				syntax: '{{subst:welcomeen-ha}}'
+			},
+			'welcomeen-ms': {
+				description: 'welcome for users whose first language appears to be Malay',
+				syntax: '{{subst:welcomeen-ms}}'
+			},
+			'welcomeen-no': {
+				description: 'welcome for users whose first language appears to be Norwegian',
+				syntax: '{{subst:welcomeen-no}}'
+			},
+			'welcomeen-pl': {
+				description: 'welcome for users whose first language appears to be Polish',
+				syntax: '{{subst:welcomeen-pl}}'
+			},
+			'welcomeen-th': {
+				description: 'welcome for users whose first language appears to be Thai',
+				syntax: '{{subst:welcomeen-th}}'
+			},
+			'welcomeen-tl': {
+				description: 'welcome for users whose first language appears to be Tagalog',
+				syntax: '{{subst:welcomeen-tl}}'
+			},
+			'welcomeen-tr': {
+				description: 'welcome for users whose first language appears to be Turkish',
+				syntax: '{{subst:welcomeen-tr}}'
+			},
+			'welcomeen-ur': {
+				description: 'welcome for users whose first language appears to be Urdu',
+				syntax: '{{subst:welcomeen-ur}}'
+			},
+			'welcomeen-vi': {
+				description: 'welcome for users whose first language appears to be Vietnamese',
+				syntax: '{{subst:welcomeen-vi}}'
 			}
 		}
 	}

--- a/modules/friendlywelcome.js
+++ b/modules/friendlywelcome.js
@@ -539,6 +539,10 @@ Twinkle.welcome.templates = {
 				description: 'welcome for users whose first language appears to be German',
 				syntax: '{{subst:welcomeen-de}}'
 			},
+			'welcomeen-ha': {
+				description: 'welcome for users whose first language appears to be Hausa',
+				syntax: '{{subst:welcomeen-ha}}'
+			},
 			'welcomeen-he': {
 				description: 'welcome for users whose first language appears to be Hebrew',
 				syntax: '{{subst:welcomeen-he}}'
@@ -563,6 +567,10 @@ Twinkle.welcome.templates = {
 				description: 'welcome for users whose first language appears to be Korean',
 				syntax: '{{subst:welcomeen-ko}}'
 			},
+			'welcomeen-ms': {
+				description: 'welcome for users whose first language appears to be Malay',
+				syntax: '{{subst:welcomeen-ms}}'
+			},
 			'welcomeen-ml': {
 				description: 'welcome for users whose first language appears to be Malayalam',
 				syntax: '{{subst:welcomeen-ml}}'
@@ -571,9 +579,21 @@ Twinkle.welcome.templates = {
 				description: 'welcome for users whose first language appears to be Marathi',
 				syntax: '{{subst:welcomeen-mr}}'
 			},
+			'welcomeen-no': {
+				description: 'welcome for users whose first language appears to be Norwegian',
+				syntax: '{{subst:welcomeen-no}}'
+			},
 			'welcomeen-or': {
 				description: 'welcome for users whose first language appears to be Oriya (Odia)',
 				syntax: '{{subst:welcomeen-or}}'
+			},
+			'welcomeen-fa': {
+				description: 'welcome for users whose first language appears to be Persian',
+				syntax: '{{subst:welcomeen-fa}}'
+			},
+			'welcomeen-pl': {
+				description: 'welcome for users whose first language appears to be Polish',
+				syntax: '{{subst:welcomeen-pl}}'
 			},
 			'welcomeen-pt': {
 				description: 'welcome for users whose first language appears to be Portuguese',
@@ -595,30 +615,6 @@ Twinkle.welcome.templates = {
 				description: 'welcome for users whose first language appears to be Swedish',
 				syntax: '{{subst:welcomeen-sv}}'
 			},
-			'welcomeen-uk': {
-				description: 'welcome for users whose first language appears to be Ukrainian',
-				syntax: '{{subst:welcomeen-uk}}'
-			},
-			'welcomeen-fa': {
-				description: 'welcome for users whose first language appears to be Persian',
-				syntax: '{{subst:welcomeen-fa}}'
-			},
-			'welcomeen-ha': {
-				description: 'welcome for users whose first language appears to be Hausa',
-				syntax: '{{subst:welcomeen-ha}}'
-			},
-			'welcomeen-ms': {
-				description: 'welcome for users whose first language appears to be Malay',
-				syntax: '{{subst:welcomeen-ms}}'
-			},
-			'welcomeen-no': {
-				description: 'welcome for users whose first language appears to be Norwegian',
-				syntax: '{{subst:welcomeen-no}}'
-			},
-			'welcomeen-pl': {
-				description: 'welcome for users whose first language appears to be Polish',
-				syntax: '{{subst:welcomeen-pl}}'
-			},
 			'welcomeen-th': {
 				description: 'welcome for users whose first language appears to be Thai',
 				syntax: '{{subst:welcomeen-th}}'
@@ -630,6 +626,10 @@ Twinkle.welcome.templates = {
 			'welcomeen-tr': {
 				description: 'welcome for users whose first language appears to be Turkish',
 				syntax: '{{subst:welcomeen-tr}}'
+			},
+			'welcomeen-uk': {
+				description: 'welcome for users whose first language appears to be Ukrainian',
+				syntax: '{{subst:welcomeen-uk}}'
 			},
 			'welcomeen-ur': {
 				description: 'welcome for users whose first language appears to be Urdu',


### PR DESCRIPTION
Fixes #2038

Full list of languages added:
{{subst:Welcomeen-fa}} (Persian)
{{subst:Welcomeen-ha}} (Hausa)
{{subst:Welcomeen-ms}} (Malay)
{{subst:Welcomeen-no}} (Norwegian)
{{subst:Welcomeen-pl}} (Polish)
{{subst:Welcomeen-th}} (Thai)
{{subst:Welcomeen-tl}} (Tagalog)
{{subst:welcomeen-tr}} (Turkish)
{{subst:Welcomeen-ur}} (Urdu)
{{subst:Welcomeen-vi}} (Vietnamese)