### PR TITLE
eslint: apply autofixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+scripts/
+tests/
+lib/

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,7 +71,6 @@
 		"no-useless-concat": "warn",
 		"no-var": "warn",
 		"operator-linebreak": "warn",
-		"prefer-arrow-callback": "warn",
 		"prefer-const": "warn",
 		"quote-props": "warn"
 	}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,6 @@
 		"mw": "readonly",
 		"Map": "readonly"
 	},
-	"ignorePatterns": ["scripts/", "tests/", "lib/"],
 	"rules": {
 		"array-bracket-spacing": "off",
 		"camelcase": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -38,7 +38,6 @@
 			}
 		],
 
-		"arrow-parens": "warn",
 		"dot-location": "warn",
 		"es-x/no-array-prototype-includes": "warn",
 		"es-x/no-object-values": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,7 +73,6 @@
 		"operator-linebreak": "warn",
 		"prefer-arrow-callback": "warn",
 		"prefer-const": "warn",
-		"quote-props": "warn",
-		"wrap-iife": "off"
+		"quote-props": "warn"
 	}
 }

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -25,7 +25,7 @@ Twinkle.arv = function twinklearv() {
 	}
 	const userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
-	Twinkle.addPortletLink(function() {
+	Twinkle.addPortletLink(() => {
 		Twinkle.arv.callback(username, isIP);
 	}, 'ARV', 'tw-arv', 'Report ' + userType + ' to administrators');
 };
@@ -110,7 +110,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 	} else {
 		query.bkusers = uid;
 	}
-	new Morebits.wiki.api("Checking the user's block status", query, function(apiobj) {
+	new Morebits.wiki.api("Checking the user's block status", query, ((apiobj) => {
 		const blocklist = apiobj.getResponse().query.blocks;
 		if (blocklist.length) {
 			// If an IP is blocked *and* rangeblocked, only use whichever is more recent
@@ -123,7 +123,7 @@ Twinkle.arv.callback = function (uid, isIP) {
 			}
 			$('#twinkle-arv-blockwarning').text(message);
 		}
-	}).post();
+	})).post();
 
 
 	// We must init the
@@ -368,7 +368,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							rvuser: rvuser,
 							indexpageids: true,
 							titles: titles
-						}).done(function(data) {
+						}).done((data) => {
 							const pageid = data.query.pageids[0];
 							const page = data.query.pages[pageid];
 							if (!page.revisions) {
@@ -414,7 +414,7 @@ Twinkle.arv.callback.changeCategory = function (e) {
 								});
 								$free_entry.append($free_label).append($free_input).appendTo($field);
 							}
-						}).fail(function() {
+						}).fail(() => {
 							$('<span class="entry">API failure, reload page and try again</span>').appendTo($field);
 						});
 					};
@@ -492,7 +492,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 				return;
 			}
 
-			types = types.map(function(v) {
+			types = types.map((v) => {
 				switch (v) {
 					case 'final':
 						return 'vandalism after final warning';
@@ -549,7 +549,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			aivPage.setPageSection(1);
 			aivPage.setFollowRedirect(true);
 
-			aivPage.load(function() {
+			aivPage.load(() => {
 				const text = aivPage.getPageText();
 				const $aivLink = '<a target="_blank" href="/wiki/WP:AIV">WP:AIV</a>';
 
@@ -562,7 +562,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 
 				// then check for any bot reports
 				const tb2Page = new Morebits.wiki.page('Wikipedia:Administrator intervention against vandalism/TB2', 'Checking bot reports');
-				tb2Page.load(function() {
+				tb2Page.load(() => {
 					const tb2Text = tb2Page.getPageText();
 					const tb2statelem = tb2Page.getStatusElement();
 
@@ -630,7 +630,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			var uaaPage = new Morebits.wiki.page('Wikipedia:Usernames for administrator attention', 'Processing UAA request');
 			uaaPage.setFollowRedirect(true);
 
-			uaaPage.load(function() {
+			uaaPage.load(() => {
 				const text = uaaPage.getPageText();
 
 				// check if user has already been reported
@@ -669,7 +669,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 
 			sockParameters.uid = puppetReport ? form.sockmaster.value.trim() : uid;
-			sockParameters.sockpuppets = puppetReport ? [uid] : Morebits.array.uniq($.map($('input:text[name=sockpuppet]', form), function(o) {
+			sockParameters.sockpuppets = puppetReport ? [uid] : Morebits.array.uniq($.map($('input:text[name=sockpuppet]', form), (o) => {
 				return $(o).val() || null;
 			}));
 
@@ -679,7 +679,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			break;
 
 		case 'an3':
-			var diffs = $.map($('input:checkbox[name=s_diffs]:checked', form), function(o) {
+			var diffs = $.map($('input:checkbox[name=s_diffs]:checked', form), (o) => {
 				return $(o).data('revinfo');
 			});
 
@@ -687,7 +687,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 				return;
 			}
 
-			var warnings = $.map($('input:checkbox[name=s_warnings]:checked', form), function(o) {
+			var warnings = $.map($('input:checkbox[name=s_warnings]:checked', form), (o) => {
 				return $(o).data('revinfo');
 			});
 
@@ -695,7 +695,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 				return;
 			}
 
-			var resolves = $.map($('input:checkbox[name=s_resolves]:checked', form), function(o) {
+			var resolves = $.map($('input:checkbox[name=s_resolves]:checked', form), (o) => {
 				return $(o).data('revinfo');
 			});
 			var free_resolves = $('input[name=s_resolves_free]').val();
@@ -791,7 +791,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					}
 				}
 
-				new mw.Api().get(query).done(function(data) {
+				new mw.Api().get(query).done((data) => {
 					let page;
 					if (data.compare && data.compare.fromtitle === data.compare.totitle) {
 						page = data;
@@ -802,7 +802,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 						return;
 					}
 					an3_next(page);
-				}).fail(function(data) {
+				}).fail((data) => {
 					console.log('API failed :(', data); // eslint-disable-line no-console
 				});
 			} else {
@@ -817,7 +817,7 @@ Twinkle.arv.processSock = function(params) {
 
 	// prepare the SPI report
 	let text = '\n{{subst:SPI report|' +
-		params.sockpuppets.map(function(sock, index) {
+		params.sockpuppets.map((sock, index) => {
 			return (index + 1) + '=' + sock;
 		}).join('|') + '\n|evidence=' + params.evidence + ' \n';
 
@@ -861,7 +861,7 @@ Twinkle.arv.processAN3 = function(params) {
 		rvexcludeuser: params.uid,
 		indexpageids: true,
 		titles: params.page
-	}).done(function(data) {
+	}).done((data) => {
 		Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 		// In case an edit summary was revdel'd
@@ -906,7 +906,7 @@ Twinkle.arv.processAN3 = function(params) {
 			grouped_diffs[lastid].push(cur);
 		}
 
-		const difftext = $.map(grouped_diffs, function(sub) {
+		const difftext = $.map(grouped_diffs, (sub) => {
 			let ret = '';
 			if (sub.length >= 2) {
 				const last = sub[0];
@@ -914,15 +914,15 @@ Twinkle.arv.processAN3 = function(params) {
 				const label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
-			ret += sub.reverse().map(function(v) {
+			ret += sub.reverse().map((v) => {
 				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 			}).join('\n');
 			return ret;
 		}).reverse().join('\n');
-		const warningtext = params.warnings.reverse().map(function(v) {
+		const warningtext = params.warnings.reverse().map((v) => {
 			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 		}).join('\n');
-		let resolvetext = params.resolves.reverse().map(function(v) {
+		let resolvetext = params.resolves.reverse().map((v) => {
 			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 		}).join('\n');
 
@@ -976,7 +976,7 @@ Twinkle.arv.processAN3 = function(params) {
 		talkPage.setAppendText(notifyText);
 		talkPage.append();
 		Morebits.wiki.removeCheckpoint();  // all page updates have been started
-	}).fail(function(data) {
+	}).fail((data) => {
 		console.log('API failed :(', data); // eslint-disable-line no-console
 	});
 };

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -13,17 +13,17 @@
  */
 
 Twinkle.arv = function twinklearv() {
-	var username = mw.config.get('wgRelevantUserName');
+	let username = mw.config.get('wgRelevantUserName');
 	if (!username || username === mw.config.get('wgUserName')) {
 		return;
 	}
 
-	var isIP = mw.util.isIPAddress(username, true);
+	let isIP = mw.util.isIPAddress(username, true);
 	// Ignore ranges wider than the CIDR limit
 	if (Morebits.ip.isRange(username) && !Morebits.ip.validCIDR(username)) {
 		return;
 	}
-	var userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
+	let userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
 	Twinkle.addPortletLink(function() {
 		Twinkle.arv.callback(username, isIP);
@@ -31,7 +31,7 @@ Twinkle.arv = function twinklearv() {
 };
 
 Twinkle.arv.callback = function (uid, isIP) {
-	var Window = new Morebits.simpleWindow(600, 500);
+	let Window = new Morebits.simpleWindow(600, 500);
 	Window.setTitle('Advance Reporting and Vetting'); // Backronym
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('AIV guide', 'WP:GAIV');
@@ -41,8 +41,8 @@ Twinkle.arv.callback = function (uid, isIP) {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#arv');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.arv.callback.evaluate);
-	var categories = form.append({
+	let form = new Morebits.quickForm(Twinkle.arv.callback.evaluate);
+	let categories = form.append({
 		type: 'select',
 		name: 'category',
 		label: 'Select report type:',
@@ -94,12 +94,12 @@ Twinkle.arv.callback = function (uid, isIP) {
 		value: uid
 	});
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// Check if the user is blocked, update notice
-	var query = {
+	let query = {
 		action: 'query',
 		list: 'blocks',
 		bkprop: 'range|flags',
@@ -111,11 +111,11 @@ Twinkle.arv.callback = function (uid, isIP) {
 		query.bkusers = uid;
 	}
 	new Morebits.wiki.api("Checking the user's block status", query, function(apiobj) {
-		var blocklist = apiobj.getResponse().query.blocks;
+		let blocklist = apiobj.getResponse().query.blocks;
 		if (blocklist.length) {
 			// If an IP is blocked *and* rangeblocked, only use whichever is more recent
-			var block = blocklist[0];
-			var message = (isIP ? 'This IP ' + (Morebits.ip.isRange(uid) ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
+			let block = blocklist[0];
+			let message = (isIP ? 'This IP ' + (Morebits.ip.isRange(uid) ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
 			// Start and end differ, range blocked
 			message += block.rangestart !== block.rangeend ? ' as part of a rangeblock.' : '.';
 			if (block.partial) {
@@ -127,16 +127,16 @@ Twinkle.arv.callback = function (uid, isIP) {
 
 
 	// We must init the
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.category.dispatchEvent(evt);
 };
 
 Twinkle.arv.callback.changeCategory = function (e) {
-	var value = e.target.value;
-	var root = e.target.form;
-	var old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
-	var work_area = null;
+	let value = e.target.value;
+	let root = e.target.form;
+	let old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
+	let work_area = null;
 
 	switch (value) {
 		case 'aiv':
@@ -154,8 +154,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				tooltip: 'Leave blank to not link to the page in the report',
 				value: Twinkle.getPrefill('vanarticle') || '',
 				event: function(e) {
-					var value = e.target.value;
-					var root = e.target.form;
+					let value = e.target.value;
+					let root = e.target.form;
 					if (value === '') {
 						root.badid.disabled = root.goodid.disabled = true;
 					} else {
@@ -172,8 +172,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				value: Twinkle.getPrefill('vanarticlerevid') || '',
 				disabled: !Twinkle.getPrefill('vanarticle'),
 				event: function(e) {
-					var value = e.target.value;
-					var root = e.target.form;
+					let value = e.target.value;
+					let root = e.target.form;
 					root.goodid.disabled = value === '';
 				}
 			});
@@ -349,13 +349,13 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				name: 'load',
 				label: 'Load',
 				event: function(e) {
-					var root = e.target.form;
+					let root = e.target.form;
 
-					var date = new Morebits.date().subtract(48, 'hours'); // all since 48 hours
+					let date = new Morebits.date().subtract(48, 'hours'); // all since 48 hours
 
 					// Run for each AN3 field
-					var getAN3Entries = function(field, rvuser, titles) {
-						var $field = $(root).find('[name=' + field + ']');
+					let getAN3Entries = function(field, rvuser, titles) {
+						let $field = $(root).find('[name=' + field + ']');
 						$field.find('.entry').remove();
 
 						new mw.Api().get({
@@ -369,24 +369,24 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							indexpageids: true,
 							titles: titles
 						}).done(function(data) {
-							var pageid = data.query.pageids[0];
-							var page = data.query.pages[pageid];
+							let pageid = data.query.pageids[0];
+							let page = data.query.pages[pageid];
 							if (!page.revisions) {
 								$('<span class="entry">None found</span>').appendTo($field);
 							} else {
-								for (var i = 0; i < page.revisions.length; ++i) {
-									var rev = page.revisions[i];
-									var $entry = $('<div/>', {
+								for (let i = 0; i < page.revisions.length; ++i) {
+									let rev = page.revisions[i];
+									let $entry = $('<div/>', {
 										class: 'entry'
 									});
-									var $input = $('<input/>', {
+									let $input = $('<input/>', {
 										type: 'checkbox',
 										name: 's_' + field,
 										value: rev.revid
 									});
 									$input.data('revinfo', rev);
 									$input.appendTo($entry);
-									var comment = '<span>';
+									let comment = '<span>';
 									// revdel/os
 									if (typeof rev.commenthidden === 'string') {
 										comment += '(comment hidden)';
@@ -400,15 +400,15 @@ Twinkle.arv.callback.changeCategory = function (e) {
 
 							// add free form input for resolves
 							if (field === 'resolves') {
-								var $free_entry = $('<div/>', {
+								let $free_entry = $('<div/>', {
 									class: 'entry'
 								});
-								var $free_input = $('<input/>', {
+								let $free_input = $('<input/>', {
 									type: 'text',
 									name: 's_resolves_free'
 								});
 
-								var $free_label = $('<label/>', {
+								let $free_label = $('<label/>', {
 									for: 's_resolves_free',
 									html: 'URL link of diff with additional discussions: '
 								});
@@ -420,18 +420,18 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					};
 
 					// warnings
-					var uid = root.uid.value;
+					let uid = root.uid.value;
 					getAN3Entries('warnings', mw.config.get('wgUserName'), 'User talk:' + uid);
 
 					// diffs and resolves require a valid page
-					var page = root.page.value;
+					let page = root.page.value;
 					if (page) {
 						// diffs
 						getAN3Entries('diffs', uid, page);
 
 						// resolutions
-						var t = new mw.Title(page);
-						var talk_page = t.getTalkPage().getPrefixedText();
+						let t = new mw.Title(page);
+						let talk_page = t.getTalkPage().getPrefixedText();
 						getAN3Entries('resolves', mw.config.get('wgUserName'), talk_page);
 					} else {
 						$(root).find('[name=diffs]').find('.entry').remove();
@@ -471,15 +471,15 @@ Twinkle.arv.callback.changeCategory = function (e) {
 };
 
 Twinkle.arv.callback.evaluate = function(e) {
-	var form = e.target;
-	var reason = '';
-	var comment = '';
+	let form = e.target;
+	let reason = '';
+	let comment = '';
 	if (form.reason) {
 		comment = form.reason.value;
 	}
-	var uid = form.uid.value;
+	let uid = form.uid.value;
 
-	var types;
+	let types;
 	switch (form.category.value) {
 
 		// Report user for vandalism
@@ -523,9 +523,9 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 
 			if (comment !== '') {
-				var reasonEndsInPunctuationOrBlank = /([.?!;:]|^)$/.test(reason);
+				let reasonEndsInPunctuationOrBlank = /([.?!;:]|^)$/.test(reason);
 				reason += reasonEndsInPunctuationOrBlank ? '' : '.';
-				var reasonIsBlank = reason === '';
+				let reasonIsBlank = reason === '';
 				reason += reasonIsBlank ? '' : ' ';
 				reason += comment;
 			}
@@ -550,8 +550,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 			aivPage.setFollowRedirect(true);
 
 			aivPage.load(function() {
-				var text = aivPage.getPageText();
-				var $aivLink = '<a target="_blank" href="/wiki/WP:AIV">WP:AIV</a>';
+				let text = aivPage.getPageText();
+				let $aivLink = '<a target="_blank" href="/wiki/WP:AIV">WP:AIV</a>';
 
 				// check if user has already been reported
 				if (new RegExp('\\{\\{\\s*(?:(?:[Ii][Pp])?[Vv]andal|[Uu]serlinks)\\s*\\|\\s*(?:1=)?\\s*' + Morebits.string.escapeRegExp(uid) + '\\s*\\}\\}').test(text)) {
@@ -561,10 +561,10 @@ Twinkle.arv.callback.evaluate = function(e) {
 				}
 
 				// then check for any bot reports
-				var tb2Page = new Morebits.wiki.page('Wikipedia:Administrator intervention against vandalism/TB2', 'Checking bot reports');
+				let tb2Page = new Morebits.wiki.page('Wikipedia:Administrator intervention against vandalism/TB2', 'Checking bot reports');
 				tb2Page.load(function() {
-					var tb2Text = tb2Page.getPageText();
-					var tb2statelem = tb2Page.getStatusElement();
+					let tb2Text = tb2Page.getPageText();
+					let tb2statelem = tb2Page.getStatusElement();
 
 					if (new RegExp('\\{\\{\\s*(?:(?:[Ii][Pp])?[Vv]andal|[Uu]serlinks)\\s*\\|\\s*(?:1=)?\\s*' + Morebits.string.escapeRegExp(uid) + '\\s*\\}\\}').test(tb2Text)) {
 						if (confirm('The user ' + uid + ' has already been reported by a bot. Do you wish to make the report anyway?')) {
@@ -612,7 +612,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 			if (comment !== '') {
 				reason += Morebits.string.toUpperCaseFirstChar(comment);
-				var endsInPeriod = /\.$/.test(comment);
+				let endsInPeriod = /\.$/.test(comment);
 				if (!endsInPeriod) {
 					reason += '.';
 				}
@@ -631,12 +631,12 @@ Twinkle.arv.callback.evaluate = function(e) {
 			uaaPage.setFollowRedirect(true);
 
 			uaaPage.load(function() {
-				var text = uaaPage.getPageText();
+				let text = uaaPage.getPageText();
 
 				// check if user has already been reported
 				if (new RegExp('\\{\\{\\s*user-uaa\\s*\\|\\s*(1\\s*=\\s*)?' + Morebits.string.escapeRegExp(uid) + '\\s*(\\||\\})').test(text)) {
 					uaaPage.getStatusElement().error('User is already listed.');
-					var $uaaLink = '<a target="_blank" href="/wiki/WP:UAA">WP:UAA</a>';
+					let $uaaLink = '<a target="_blank" href="/wiki/WP:UAA">WP:UAA</a>';
 					Morebits.status.printUserText(reason, 'The comments you typed are provided below, in case you wish to manually post them under the existing report for this user at ' + $uaaLink + ':');
 					return;
 				}
@@ -705,7 +705,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					return;
 				}
 
-				var an3Parameters = {
+				let an3Parameters = {
 					uid: uid,
 					page: form.page.value.trim(),
 					comment: form.comment.value.trim(),
@@ -721,9 +721,9 @@ Twinkle.arv.callback.evaluate = function(e) {
 			};
 
 			if (free_resolves) {
-				var query;
-				var diff, oldid;
-				var specialDiff = /Special:Diff\/(\d+)(?:\/(\S+))?/i.exec(free_resolves);
+				let query;
+				let diff, oldid;
+				let specialDiff = /Special:Diff\/(\d+)(?:\/(\S+))?/i.exec(free_resolves);
 				if (specialDiff) {
 					if (specialDiff[2]) {
 						oldid = specialDiff[1];
@@ -735,8 +735,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 					diff = mw.util.getParamValue('diff', free_resolves);
 					oldid = mw.util.getParamValue('oldid', free_resolves);
 				}
-				var title = mw.util.getParamValue('title', free_resolves);
-				var diffNum = /^\d+$/.test(diff); // used repeatedly
+				let title = mw.util.getParamValue('title', free_resolves);
+				let diffNum = /^\d+$/.test(diff); // used repeatedly
 
 				// rvdiffto in prop=revisions is deprecated, but action=compare doesn't return
 				// timestamps ([[phab:T247686]]) so we can't rely on it unless necessary.
@@ -792,11 +792,11 @@ Twinkle.arv.callback.evaluate = function(e) {
 				}
 
 				new mw.Api().get(query).done(function(data) {
-					var page;
+					let page;
 					if (data.compare && data.compare.fromtitle === data.compare.totitle) {
 						page = data;
 					} else if (data.query) {
-						var pageid = data.query.pageids[0];
+						let pageid = data.query.pageids[0];
 						page = data.query.pages[pageid];
 					} else {
 						return;
@@ -816,7 +816,7 @@ Twinkle.arv.processSock = function(params) {
 	Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 	// prepare the SPI report
-	var text = '\n{{subst:SPI report|' +
+	let text = '\n{{subst:SPI report|' +
 		params.sockpuppets.map(function(sock, index) {
 			return (index + 1) + '=' + sock;
 		}).join('|') + '\n|evidence=' + params.evidence + ' \n';
@@ -826,12 +826,12 @@ Twinkle.arv.processSock = function(params) {
 	}
 	text += '}}';
 
-	var reportpage = 'Wikipedia:Sockpuppet investigations/' + params.uid;
+	let reportpage = 'Wikipedia:Sockpuppet investigations/' + params.uid;
 
 	Morebits.wiki.actionCompleted.redirect = reportpage;
 	Morebits.wiki.actionCompleted.notice = 'Reporting complete';
 
-	var spiPage = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
+	let spiPage = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 	spiPage.setFollowRedirect(true);
 	spiPage.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
 	spiPage.setChangeTags(Twinkle.changeTags);
@@ -844,8 +844,8 @@ Twinkle.arv.processSock = function(params) {
 
 Twinkle.arv.processAN3 = function(params) {
 	// prepare the AN3 report
-	var minid;
-	for (var i = 0; i < params.diffs.length; ++i) {
+	let minid;
+	for (let i = 0; i < params.diffs.length; ++i) {
 		if (params.diffs[i].parentid && (!minid || params.diffs[i].parentid < minid)) {
 			minid = params.diffs[i].parentid;
 		}
@@ -865,7 +865,7 @@ Twinkle.arv.processAN3 = function(params) {
 		Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 		// In case an edit summary was revdel'd
-		var hasHiddenComment = function(rev) {
+		let hasHiddenComment = function(rev) {
 			if (!rev.comment && typeof rev.commenthidden === 'string') {
 				return '(comment hidden)';
 			}
@@ -873,10 +873,10 @@ Twinkle.arv.processAN3 = function(params) {
 
 		};
 
-		var orig;
+		let orig;
 		if (data.length) {
-			var sha1 = data[0].sha1;
-			for (var i = 1; i < data.length; ++i) {
+			let sha1 = data[0].sha1;
+			for (let i = 1; i < data.length; ++i) {
 				if (data[i].sha1 === sha1) {
 					orig = data[i];
 					break;
@@ -888,16 +888,16 @@ Twinkle.arv.processAN3 = function(params) {
 			}
 		}
 
-		var origtext = '';
+		let origtext = '';
 		if (orig) {
 			origtext = '{{diff2|' + orig.revid + '|' + orig.timestamp + '}} ' + hasHiddenComment(orig);
 		}
 
-		var grouped_diffs = {};
+		let grouped_diffs = {};
 
-		var parentid, lastid;
-		for (var j = 0; j < params.diffs.length; ++j) {
-			var cur = params.diffs[j];
+		let parentid, lastid;
+		for (let j = 0; j < params.diffs.length; ++j) {
+			let cur = params.diffs[j];
 			if ((cur.revid && cur.revid !== parentid) || lastid === null) {
 				lastid = cur.revid;
 				grouped_diffs[lastid] = [];
@@ -906,12 +906,12 @@ Twinkle.arv.processAN3 = function(params) {
 			grouped_diffs[lastid].push(cur);
 		}
 
-		var difftext = $.map(grouped_diffs, function(sub) {
-			var ret = '';
+		let difftext = $.map(grouped_diffs, function(sub) {
+			let ret = '';
 			if (sub.length >= 2) {
-				var last = sub[0];
-				var first = sub.slice(-1)[0];
-				var label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
+				let last = sub[0];
+				let first = sub.slice(-1)[0];
+				let label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
 			ret += sub.reverse().map(function(v) {
@@ -919,46 +919,46 @@ Twinkle.arv.processAN3 = function(params) {
 			}).join('\n');
 			return ret;
 		}).reverse().join('\n');
-		var warningtext = params.warnings.reverse().map(function(v) {
+		let warningtext = params.warnings.reverse().map(function(v) {
 			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 		}).join('\n');
-		var resolvetext = params.resolves.reverse().map(function(v) {
+		let resolvetext = params.resolves.reverse().map(function(v) {
 			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 		}).join('\n');
 
 		if (params.free_resolves) {
-			var page = params.free_resolves;
+			let page = params.free_resolves;
 			if (page.compare) {
 				resolvetext += '\n# ' + ' {{diff|oldid=' + page.compare.fromrevid + '|diff=' + page.compare.torevid + '|label=Consecutive edits on ' + page.compare.totitle + '}}';
 			} else if (page.revisions) {
-				var revCount = page.revisions.length;
-				var rev;
+				let revCount = page.revisions.length;
+				let rev;
 				if (revCount < 3) { // diff=prev or next
 					rev = revCount === 1 ? page.revisions[0] : page.revisions[1];
 					resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title + '}} ' + hasHiddenComment(rev);
 				} else { // diff and oldid are nonconsecutive
 					rev = page.revisions[0];
-					var revLatest = page.revisions[revCount - 1];
-					var label = 'Consecutive edits made from ' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(revLatest.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title;
+					let revLatest = page.revisions[revCount - 1];
+					let label = 'Consecutive edits made from ' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(revLatest.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title;
 					resolvetext += '\n# {{diff|oldid=' + rev.revid + '|diff=' + revLatest.revid + '|label=' + label + '}}\n';
 				}
 			}
 		}
 
-		var comment = params.comment.replace(/~*$/g, '').trim();
+		let comment = params.comment.replace(/~*$/g, '').trim();
 
 		if (comment) {
 			comment += ' ~~~~';
 		}
 
-		var text = '\n\n' + '{{subst:AN3 report|diffs=' + difftext + '|warnings=' + warningtext + '|resolves=' + resolvetext + '|pagename=' + params.page + '|orig=' + origtext + '|comment=' + comment + '|uid=' + params.uid + '}}';
+		let text = '\n\n' + '{{subst:AN3 report|diffs=' + difftext + '|warnings=' + warningtext + '|resolves=' + resolvetext + '|pagename=' + params.page + '|orig=' + origtext + '|comment=' + comment + '|uid=' + params.uid + '}}';
 
-		var reportpage = 'Wikipedia:Administrators\' noticeboard/Edit warring';
+		let reportpage = 'Wikipedia:Administrators\' noticeboard/Edit warring';
 
 		Morebits.wiki.actionCompleted.redirect = reportpage;
 		Morebits.wiki.actionCompleted.notice = 'Reporting complete';
 
-		var an3Page = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
+		let an3Page = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 		an3Page.setFollowRedirect(true);
 		an3Page.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
 		an3Page.setChangeTags(Twinkle.changeTags);
@@ -967,9 +967,9 @@ Twinkle.arv.processAN3 = function(params) {
 
 		// notify user
 
-		var notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
+		let notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
 
-		var talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
+		let talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
 		talkPage.setFollowRedirect(true);
 		talkPage.setEditSummary('Notifying about edit warring noticeboard discussion.');
 		talkPage.setChangeTags(Twinkle.changeTags);

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -669,9 +669,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 
 			sockParameters.uid = puppetReport ? form.sockmaster.value.trim() : uid;
-			sockParameters.sockpuppets = puppetReport ? [uid] : Morebits.array.uniq($.map($('input:text[name=sockpuppet]', form), (o) => {
-				return $(o).val() || null;
-			}));
+			sockParameters.sockpuppets = puppetReport ? [uid] : Morebits.array.uniq($.map($('input:text[name=sockpuppet]', form), (o) => $(o).val() || null));
 
 			Morebits.simpleWindow.setButtonsEnabled(false);
 			Morebits.status.init(form);
@@ -679,25 +677,19 @@ Twinkle.arv.callback.evaluate = function(e) {
 			break;
 
 		case 'an3':
-			var diffs = $.map($('input:checkbox[name=s_diffs]:checked', form), (o) => {
-				return $(o).data('revinfo');
-			});
+			var diffs = $.map($('input:checkbox[name=s_diffs]:checked', form), (o) => $(o).data('revinfo'));
 
 			if (diffs.length < 3 && !confirm('You have selected fewer than three offending edits. Do you wish to make the report anyway?')) {
 				return;
 			}
 
-			var warnings = $.map($('input:checkbox[name=s_warnings]:checked', form), (o) => {
-				return $(o).data('revinfo');
-			});
+			var warnings = $.map($('input:checkbox[name=s_warnings]:checked', form), (o) => $(o).data('revinfo'));
 
 			if (!warnings.length && !confirm('You have not selected any edits where you warned the offender. Do you wish to make the report anyway?')) {
 				return;
 			}
 
-			var resolves = $.map($('input:checkbox[name=s_resolves]:checked', form), (o) => {
-				return $(o).data('revinfo');
-			});
+			var resolves = $.map($('input:checkbox[name=s_resolves]:checked', form), (o) => $(o).data('revinfo'));
 			var free_resolves = $('input[name=s_resolves_free]').val();
 
 			var an3_next = function(free_resolves) {
@@ -817,9 +809,7 @@ Twinkle.arv.processSock = function(params) {
 
 	// prepare the SPI report
 	let text = '\n{{subst:SPI report|' +
-		params.sockpuppets.map((sock, index) => {
-			return (index + 1) + '=' + sock;
-		}).join('|') + '\n|evidence=' + params.evidence + ' \n';
+		params.sockpuppets.map((sock, index) => (index + 1) + '=' + sock).join('|') + '\n|evidence=' + params.evidence + ' \n';
 
 	if (params.checkuser) {
 		text += '|checkuser=yes';
@@ -914,17 +904,11 @@ Twinkle.arv.processAN3 = function(params) {
 				const label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
-			ret += sub.reverse().map((v) => {
-				return (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
-			}).join('\n');
+			ret += sub.reverse().map((v) => (sub.length >= 2 ? '#' : '') + '# {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v)).join('\n');
 			return ret;
 		}).reverse().join('\n');
-		const warningtext = params.warnings.reverse().map((v) => {
-			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
-		}).join('\n');
-		let resolvetext = params.resolves.reverse().map((v) => {
-			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
-		}).join('\n');
+		const warningtext = params.warnings.reverse().map((v) => '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v)).join('\n');
+		let resolvetext = params.resolves.reverse().map((v) => '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v)).join('\n');
 
 		if (params.free_resolves) {
 			const page = params.free_resolves;

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -13,17 +13,17 @@
  */
 
 Twinkle.arv = function twinklearv() {
-	let username = mw.config.get('wgRelevantUserName');
+	const username = mw.config.get('wgRelevantUserName');
 	if (!username || username === mw.config.get('wgUserName')) {
 		return;
 	}
 
-	let isIP = mw.util.isIPAddress(username, true);
+	const isIP = mw.util.isIPAddress(username, true);
 	// Ignore ranges wider than the CIDR limit
 	if (Morebits.ip.isRange(username) && !Morebits.ip.validCIDR(username)) {
 		return;
 	}
-	let userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
+	const userType = isIP ? 'IP' + (Morebits.ip.isRange(username) ? ' range' : '') : 'user';
 
 	Twinkle.addPortletLink(function() {
 		Twinkle.arv.callback(username, isIP);
@@ -31,7 +31,7 @@ Twinkle.arv = function twinklearv() {
 };
 
 Twinkle.arv.callback = function (uid, isIP) {
-	let Window = new Morebits.simpleWindow(600, 500);
+	const Window = new Morebits.simpleWindow(600, 500);
 	Window.setTitle('Advance Reporting and Vetting'); // Backronym
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('AIV guide', 'WP:GAIV');
@@ -41,8 +41,8 @@ Twinkle.arv.callback = function (uid, isIP) {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#arv');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.arv.callback.evaluate);
-	let categories = form.append({
+	const form = new Morebits.quickForm(Twinkle.arv.callback.evaluate);
+	const categories = form.append({
 		type: 'select',
 		name: 'category',
 		label: 'Select report type:',
@@ -94,12 +94,12 @@ Twinkle.arv.callback = function (uid, isIP) {
 		value: uid
 	});
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// Check if the user is blocked, update notice
-	let query = {
+	const query = {
 		action: 'query',
 		list: 'blocks',
 		bkprop: 'range|flags',
@@ -111,10 +111,10 @@ Twinkle.arv.callback = function (uid, isIP) {
 		query.bkusers = uid;
 	}
 	new Morebits.wiki.api("Checking the user's block status", query, function(apiobj) {
-		let blocklist = apiobj.getResponse().query.blocks;
+		const blocklist = apiobj.getResponse().query.blocks;
 		if (blocklist.length) {
 			// If an IP is blocked *and* rangeblocked, only use whichever is more recent
-			let block = blocklist[0];
+			const block = blocklist[0];
 			let message = (isIP ? 'This IP ' + (Morebits.ip.isRange(uid) ? 'range' : 'address') : 'This account') + ' is ' + (block.partial ? 'partially' : 'already') + ' blocked';
 			// Start and end differ, range blocked
 			message += block.rangestart !== block.rangeend ? ' as part of a rangeblock.' : '.';
@@ -127,15 +127,15 @@ Twinkle.arv.callback = function (uid, isIP) {
 
 
 	// We must init the
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.category.dispatchEvent(evt);
 };
 
 Twinkle.arv.callback.changeCategory = function (e) {
-	let value = e.target.value;
-	let root = e.target.form;
-	let old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
+	const value = e.target.value;
+	const root = e.target.form;
+	const old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
 	let work_area = null;
 
 	switch (value) {
@@ -154,8 +154,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				tooltip: 'Leave blank to not link to the page in the report',
 				value: Twinkle.getPrefill('vanarticle') || '',
 				event: function(e) {
-					let value = e.target.value;
-					let root = e.target.form;
+					const value = e.target.value;
+					const root = e.target.form;
 					if (value === '') {
 						root.badid.disabled = root.goodid.disabled = true;
 					} else {
@@ -172,8 +172,8 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				value: Twinkle.getPrefill('vanarticlerevid') || '',
 				disabled: !Twinkle.getPrefill('vanarticle'),
 				event: function(e) {
-					let value = e.target.value;
-					let root = e.target.form;
+					const value = e.target.value;
+					const root = e.target.form;
 					root.goodid.disabled = value === '';
 				}
 			});
@@ -349,13 +349,13 @@ Twinkle.arv.callback.changeCategory = function (e) {
 				name: 'load',
 				label: 'Load',
 				event: function(e) {
-					let root = e.target.form;
+					const root = e.target.form;
 
-					let date = new Morebits.date().subtract(48, 'hours'); // all since 48 hours
+					const date = new Morebits.date().subtract(48, 'hours'); // all since 48 hours
 
 					// Run for each AN3 field
-					let getAN3Entries = function(field, rvuser, titles) {
-						let $field = $(root).find('[name=' + field + ']');
+					const getAN3Entries = function(field, rvuser, titles) {
+						const $field = $(root).find('[name=' + field + ']');
 						$field.find('.entry').remove();
 
 						new mw.Api().get({
@@ -369,17 +369,17 @@ Twinkle.arv.callback.changeCategory = function (e) {
 							indexpageids: true,
 							titles: titles
 						}).done(function(data) {
-							let pageid = data.query.pageids[0];
-							let page = data.query.pages[pageid];
+							const pageid = data.query.pageids[0];
+							const page = data.query.pages[pageid];
 							if (!page.revisions) {
 								$('<span class="entry">None found</span>').appendTo($field);
 							} else {
 								for (let i = 0; i < page.revisions.length; ++i) {
-									let rev = page.revisions[i];
-									let $entry = $('<div/>', {
+									const rev = page.revisions[i];
+									const $entry = $('<div/>', {
 										class: 'entry'
 									});
-									let $input = $('<input/>', {
+									const $input = $('<input/>', {
 										type: 'checkbox',
 										name: 's_' + field,
 										value: rev.revid
@@ -400,15 +400,15 @@ Twinkle.arv.callback.changeCategory = function (e) {
 
 							// add free form input for resolves
 							if (field === 'resolves') {
-								let $free_entry = $('<div/>', {
+								const $free_entry = $('<div/>', {
 									class: 'entry'
 								});
-								let $free_input = $('<input/>', {
+								const $free_input = $('<input/>', {
 									type: 'text',
 									name: 's_resolves_free'
 								});
 
-								let $free_label = $('<label/>', {
+								const $free_label = $('<label/>', {
 									for: 's_resolves_free',
 									html: 'URL link of diff with additional discussions: '
 								});
@@ -420,18 +420,18 @@ Twinkle.arv.callback.changeCategory = function (e) {
 					};
 
 					// warnings
-					let uid = root.uid.value;
+					const uid = root.uid.value;
 					getAN3Entries('warnings', mw.config.get('wgUserName'), 'User talk:' + uid);
 
 					// diffs and resolves require a valid page
-					let page = root.page.value;
+					const page = root.page.value;
 					if (page) {
 						// diffs
 						getAN3Entries('diffs', uid, page);
 
 						// resolutions
-						let t = new mw.Title(page);
-						let talk_page = t.getTalkPage().getPrefixedText();
+						const t = new mw.Title(page);
+						const talk_page = t.getTalkPage().getPrefixedText();
 						getAN3Entries('resolves', mw.config.get('wgUserName'), talk_page);
 					} else {
 						$(root).find('[name=diffs]').find('.entry').remove();
@@ -471,13 +471,13 @@ Twinkle.arv.callback.changeCategory = function (e) {
 };
 
 Twinkle.arv.callback.evaluate = function(e) {
-	let form = e.target;
+	const form = e.target;
 	let reason = '';
 	let comment = '';
 	if (form.reason) {
 		comment = form.reason.value;
 	}
-	let uid = form.uid.value;
+	const uid = form.uid.value;
 
 	let types;
 	switch (form.category.value) {
@@ -523,9 +523,9 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 
 			if (comment !== '') {
-				let reasonEndsInPunctuationOrBlank = /([.?!;:]|^)$/.test(reason);
+				const reasonEndsInPunctuationOrBlank = /([.?!;:]|^)$/.test(reason);
 				reason += reasonEndsInPunctuationOrBlank ? '' : '.';
-				let reasonIsBlank = reason === '';
+				const reasonIsBlank = reason === '';
 				reason += reasonIsBlank ? '' : ' ';
 				reason += comment;
 			}
@@ -550,8 +550,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 			aivPage.setFollowRedirect(true);
 
 			aivPage.load(function() {
-				let text = aivPage.getPageText();
-				let $aivLink = '<a target="_blank" href="/wiki/WP:AIV">WP:AIV</a>';
+				const text = aivPage.getPageText();
+				const $aivLink = '<a target="_blank" href="/wiki/WP:AIV">WP:AIV</a>';
 
 				// check if user has already been reported
 				if (new RegExp('\\{\\{\\s*(?:(?:[Ii][Pp])?[Vv]andal|[Uu]serlinks)\\s*\\|\\s*(?:1=)?\\s*' + Morebits.string.escapeRegExp(uid) + '\\s*\\}\\}').test(text)) {
@@ -561,10 +561,10 @@ Twinkle.arv.callback.evaluate = function(e) {
 				}
 
 				// then check for any bot reports
-				let tb2Page = new Morebits.wiki.page('Wikipedia:Administrator intervention against vandalism/TB2', 'Checking bot reports');
+				const tb2Page = new Morebits.wiki.page('Wikipedia:Administrator intervention against vandalism/TB2', 'Checking bot reports');
 				tb2Page.load(function() {
-					let tb2Text = tb2Page.getPageText();
-					let tb2statelem = tb2Page.getStatusElement();
+					const tb2Text = tb2Page.getPageText();
+					const tb2statelem = tb2Page.getStatusElement();
 
 					if (new RegExp('\\{\\{\\s*(?:(?:[Ii][Pp])?[Vv]andal|[Uu]serlinks)\\s*\\|\\s*(?:1=)?\\s*' + Morebits.string.escapeRegExp(uid) + '\\s*\\}\\}').test(tb2Text)) {
 						if (confirm('The user ' + uid + ' has already been reported by a bot. Do you wish to make the report anyway?')) {
@@ -612,7 +612,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			}
 			if (comment !== '') {
 				reason += Morebits.string.toUpperCaseFirstChar(comment);
-				let endsInPeriod = /\.$/.test(comment);
+				const endsInPeriod = /\.$/.test(comment);
 				if (!endsInPeriod) {
 					reason += '.';
 				}
@@ -631,12 +631,12 @@ Twinkle.arv.callback.evaluate = function(e) {
 			uaaPage.setFollowRedirect(true);
 
 			uaaPage.load(function() {
-				let text = uaaPage.getPageText();
+				const text = uaaPage.getPageText();
 
 				// check if user has already been reported
 				if (new RegExp('\\{\\{\\s*user-uaa\\s*\\|\\s*(1\\s*=\\s*)?' + Morebits.string.escapeRegExp(uid) + '\\s*(\\||\\})').test(text)) {
 					uaaPage.getStatusElement().error('User is already listed.');
-					let $uaaLink = '<a target="_blank" href="/wiki/WP:UAA">WP:UAA</a>';
+					const $uaaLink = '<a target="_blank" href="/wiki/WP:UAA">WP:UAA</a>';
 					Morebits.status.printUserText(reason, 'The comments you typed are provided below, in case you wish to manually post them under the existing report for this user at ' + $uaaLink + ':');
 					return;
 				}
@@ -705,7 +705,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					return;
 				}
 
-				let an3Parameters = {
+				const an3Parameters = {
 					uid: uid,
 					page: form.page.value.trim(),
 					comment: form.comment.value.trim(),
@@ -723,7 +723,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 			if (free_resolves) {
 				let query;
 				let diff, oldid;
-				let specialDiff = /Special:Diff\/(\d+)(?:\/(\S+))?/i.exec(free_resolves);
+				const specialDiff = /Special:Diff\/(\d+)(?:\/(\S+))?/i.exec(free_resolves);
 				if (specialDiff) {
 					if (specialDiff[2]) {
 						oldid = specialDiff[1];
@@ -735,8 +735,8 @@ Twinkle.arv.callback.evaluate = function(e) {
 					diff = mw.util.getParamValue('diff', free_resolves);
 					oldid = mw.util.getParamValue('oldid', free_resolves);
 				}
-				let title = mw.util.getParamValue('title', free_resolves);
-				let diffNum = /^\d+$/.test(diff); // used repeatedly
+				const title = mw.util.getParamValue('title', free_resolves);
+				const diffNum = /^\d+$/.test(diff); // used repeatedly
 
 				// rvdiffto in prop=revisions is deprecated, but action=compare doesn't return
 				// timestamps ([[phab:T247686]]) so we can't rely on it unless necessary.
@@ -796,7 +796,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 					if (data.compare && data.compare.fromtitle === data.compare.totitle) {
 						page = data;
 					} else if (data.query) {
-						let pageid = data.query.pageids[0];
+						const pageid = data.query.pageids[0];
 						page = data.query.pages[pageid];
 					} else {
 						return;
@@ -826,12 +826,12 @@ Twinkle.arv.processSock = function(params) {
 	}
 	text += '}}';
 
-	let reportpage = 'Wikipedia:Sockpuppet investigations/' + params.uid;
+	const reportpage = 'Wikipedia:Sockpuppet investigations/' + params.uid;
 
 	Morebits.wiki.actionCompleted.redirect = reportpage;
 	Morebits.wiki.actionCompleted.notice = 'Reporting complete';
 
-	let spiPage = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
+	const spiPage = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 	spiPage.setFollowRedirect(true);
 	spiPage.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
 	spiPage.setChangeTags(Twinkle.changeTags);
@@ -865,7 +865,7 @@ Twinkle.arv.processAN3 = function(params) {
 		Morebits.wiki.addCheckpoint(); // prevent notification events from causing an erronous "action completed"
 
 		// In case an edit summary was revdel'd
-		let hasHiddenComment = function(rev) {
+		const hasHiddenComment = function(rev) {
 			if (!rev.comment && typeof rev.commenthidden === 'string') {
 				return '(comment hidden)';
 			}
@@ -875,7 +875,7 @@ Twinkle.arv.processAN3 = function(params) {
 
 		let orig;
 		if (data.length) {
-			let sha1 = data[0].sha1;
+			const sha1 = data[0].sha1;
 			for (let i = 1; i < data.length; ++i) {
 				if (data[i].sha1 === sha1) {
 					orig = data[i];
@@ -893,11 +893,11 @@ Twinkle.arv.processAN3 = function(params) {
 			origtext = '{{diff2|' + orig.revid + '|' + orig.timestamp + '}} ' + hasHiddenComment(orig);
 		}
 
-		let grouped_diffs = {};
+		const grouped_diffs = {};
 
 		let parentid, lastid;
 		for (let j = 0; j < params.diffs.length; ++j) {
-			let cur = params.diffs[j];
+			const cur = params.diffs[j];
 			if ((cur.revid && cur.revid !== parentid) || lastid === null) {
 				lastid = cur.revid;
 				grouped_diffs[lastid] = [];
@@ -906,12 +906,12 @@ Twinkle.arv.processAN3 = function(params) {
 			grouped_diffs[lastid].push(cur);
 		}
 
-		let difftext = $.map(grouped_diffs, function(sub) {
+		const difftext = $.map(grouped_diffs, function(sub) {
 			let ret = '';
 			if (sub.length >= 2) {
-				let last = sub[0];
-				let first = sub.slice(-1)[0];
-				let label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
+				const last = sub[0];
+				const first = sub.slice(-1)[0];
+				const label = 'Consecutive edits made from ' + new Morebits.date(first.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(last.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)';
 				ret = '# {{diff|oldid=' + first.parentid + '|diff=' + last.revid + '|label=' + label + '}}\n';
 			}
 			ret += sub.reverse().map(function(v) {
@@ -919,7 +919,7 @@ Twinkle.arv.processAN3 = function(params) {
 			}).join('\n');
 			return ret;
 		}).reverse().join('\n');
-		let warningtext = params.warnings.reverse().map(function(v) {
+		const warningtext = params.warnings.reverse().map(function(v) {
 			return '# ' + ' {{diff2|' + v.revid + '|' + new Morebits.date(v.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC)}} ' + hasHiddenComment(v);
 		}).join('\n');
 		let resolvetext = params.resolves.reverse().map(function(v) {
@@ -927,19 +927,19 @@ Twinkle.arv.processAN3 = function(params) {
 		}).join('\n');
 
 		if (params.free_resolves) {
-			let page = params.free_resolves;
+			const page = params.free_resolves;
 			if (page.compare) {
 				resolvetext += '\n# ' + ' {{diff|oldid=' + page.compare.fromrevid + '|diff=' + page.compare.torevid + '|label=Consecutive edits on ' + page.compare.totitle + '}}';
 			} else if (page.revisions) {
-				let revCount = page.revisions.length;
+				const revCount = page.revisions.length;
 				let rev;
 				if (revCount < 3) { // diff=prev or next
 					rev = revCount === 1 ? page.revisions[0] : page.revisions[1];
 					resolvetext += '\n# ' + ' {{diff2|' + rev.revid + '|' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title + '}} ' + hasHiddenComment(rev);
 				} else { // diff and oldid are nonconsecutive
 					rev = page.revisions[0];
-					let revLatest = page.revisions[revCount - 1];
-					let label = 'Consecutive edits made from ' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(revLatest.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title;
+					const revLatest = page.revisions[revCount - 1];
+					const label = 'Consecutive edits made from ' + new Morebits.date(rev.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) to ' + new Morebits.date(revLatest.timestamp).format('HH:mm, D MMMM YYYY', 'utc') + ' (UTC) on ' + page.title;
 					resolvetext += '\n# {{diff|oldid=' + rev.revid + '|diff=' + revLatest.revid + '|label=' + label + '}}\n';
 				}
 			}
@@ -951,14 +951,14 @@ Twinkle.arv.processAN3 = function(params) {
 			comment += ' ~~~~';
 		}
 
-		let text = '\n\n' + '{{subst:AN3 report|diffs=' + difftext + '|warnings=' + warningtext + '|resolves=' + resolvetext + '|pagename=' + params.page + '|orig=' + origtext + '|comment=' + comment + '|uid=' + params.uid + '}}';
+		const text = '\n\n' + '{{subst:AN3 report|diffs=' + difftext + '|warnings=' + warningtext + '|resolves=' + resolvetext + '|pagename=' + params.page + '|orig=' + origtext + '|comment=' + comment + '|uid=' + params.uid + '}}';
 
-		let reportpage = 'Wikipedia:Administrators\' noticeboard/Edit warring';
+		const reportpage = 'Wikipedia:Administrators\' noticeboard/Edit warring';
 
 		Morebits.wiki.actionCompleted.redirect = reportpage;
 		Morebits.wiki.actionCompleted.notice = 'Reporting complete';
 
-		let an3Page = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
+		const an3Page = new Morebits.wiki.page(reportpage, 'Retrieving discussion page');
 		an3Page.setFollowRedirect(true);
 		an3Page.setEditSummary('Adding new report for [[Special:Contributions/' + params.uid + '|' + params.uid + ']].');
 		an3Page.setChangeTags(Twinkle.changeTags);
@@ -967,9 +967,9 @@ Twinkle.arv.processAN3 = function(params) {
 
 		// notify user
 
-		let notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
+		const notifyText = '\n\n{{subst:an3-notice|1=' + mw.util.wikiUrlencode(params.uid) + '|auto=1}} ~~~~';
 
-		let talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
+		const talkPage = new Morebits.wiki.page('User talk:' + params.uid, 'Notifying edit warrior');
 		talkPage.setFollowRedirect(true);
 		talkPage.setEditSummary('Notifying about edit warring noticeboard discussion.');
 		talkPage.setChangeTags(Twinkle.changeTags);

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -982,7 +982,7 @@ Twinkle.arv.processAN3 = function(params) {
 };
 
 Twinkle.addInitCallback(Twinkle.arv, 'arv');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -26,17 +26,17 @@ Twinkle.batchdelete = function twinklebatchdelete() {
 Twinkle.batchdelete.unlinkCache = {};
 
 // Has the subpages list been loaded?
-var subpagesLoaded;
+let subpagesLoaded;
 
 Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	subpagesLoaded = false;
-	var Window = new Morebits.simpleWindow(600, 400);
+	let Window = new Morebits.simpleWindow(600, 400);
 	Window.setTitle('Batch deletion');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#batchdelete');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.batchdelete.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.batchdelete.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -111,7 +111,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		size: 60
 	});
 
-	var query = {
+	let query = {
 		action: 'query',
 		prop: 'revisions|info|imageinfo',
 		inprop: 'protection',
@@ -134,11 +134,11 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			query.gapnamespace = mw.util.getParamValue('namespace');
 			query.gapprefix = mw.util.getParamValue('prefix');
 		} else {
-			var pathSplit = decodeURIComponent(location.pathname).split('/');
+			let pathSplit = decodeURIComponent(location.pathname).split('/');
 			if (pathSplit.length < 3 || pathSplit[2] !== 'Special:PrefixIndex') {
 				return;
 			}
-			var titleSplit = pathSplit[3].split(':');
+			let titleSplit = pathSplit[3].split(':');
 			query.gapnamespace = mw.config.get('wgNamespaceIds')[titleSplit[0].toLowerCase()];
 			if (titleSplit.length < 2 || typeof query.gapnamespace === 'undefined') {
 				query.gapnamespace = 0;  // article namespace
@@ -157,7 +157,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
-	var statusdiv = document.createElement('div');
+	let statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
@@ -165,21 +165,21 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 
 	Twinkle.batchdelete.pages = {};
 
-	var statelem = new Morebits.status('Grabbing list of pages');
-	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = (response.query && response.query.pages) || [];
+	let statelem = new Morebits.status('Grabbing list of pages');
+	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		let response = apiobj.getResponse();
+		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter(function(page) {
 			return !page.missing && page.imagerepository !== 'shared';
 		});
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			var metadata = [];
+			let metadata = [];
 			if (page.redirect) {
 				metadata.push('redirect');
 			}
 
-			var editProt = page.protection.filter(function(pr) {
+			let editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -194,7 +194,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 				metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 			}
 
-			var title = page.title;
+			let title = page.title;
 			Twinkle.batchdelete.pages[title] = {
 				label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''),
 				value: title,
@@ -203,7 +203,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			};
 		});
 
-		var form = apiobj.params.form;
+		let form = apiobj.params.form;
 		form.append({ type: 'header', label: 'Pages to delete' });
 		form.append({
 			type: 'button',
@@ -251,9 +251,9 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 Twinkle.batchdelete.generateNewPageList = function(form) {
 
 	// Update the list of checked pages in Twinkle.batchdelete.pages object
-	var elements = form.elements.pages;
+	let elements = form.elements.pages;
 	if (elements instanceof NodeList) { // if there are multiple pages
-		for (var i = 0; i < elements.length; ++i) {
+		for (let i = 0; i < elements.length; ++i) {
 			Twinkle.batchdelete.pages[elements[i].value].checked = elements[i].checked;
 		}
 	} else if (elements instanceof HTMLInputElement) { // if there is just one page
@@ -273,8 +273,8 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 
 Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e) {
 
-	var form = e.target.form;
-	var newPageList;
+	let form = e.target.form;
+	let newPageList;
 
 	if (e.target.checked) {
 
@@ -303,18 +303,18 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		}
 
 		// Proceed with API calls to get list of subpages
-		var loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
+		let loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
 		$(e.target).after(loadingText);
 
-		var pages = $(form.pages).map(function(i, el) {
+		let pages = $(form.pages).map(function(i, el) {
 			return el.value;
 		}).get();
 
-		var subpageLister = new Morebits.batchOperation();
+		let subpageLister = new Morebits.batchOperation();
 		subpageLister.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		subpageLister.setPageList(pages);
 		subpageLister.run(function worker (pageName) {
-			var pageTitle = mw.Title.newFromText(pageName);
+			let pageTitle = mw.Title.newFromText(pageName);
 
 			// No need to look for subpages in main/file/mediawiki space
 			if ([0, 6, 8].indexOf(pageTitle.namespace) > -1) {
@@ -322,7 +322,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				return;
 			}
 
-			var wikipedia_api = new Morebits.wiki.api('Getting list of subpages of ' + pageName, {
+			let wikipedia_api = new Morebits.wiki.api('Getting list of subpages of ' + pageName, {
 				action: 'query',
 				prop: 'revisions|info|imageinfo',
 				generator: 'allpages',
@@ -333,17 +333,17 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				gaplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function onSuccess(apiobj) {
-				var response = apiobj.getResponse();
-				var pages = (response.query && response.query.pages) || [];
-				var subpageList = [];
+				let response = apiobj.getResponse();
+				let pages = (response.query && response.query.pages) || [];
+				let subpageList = [];
 				pages.sort(Twinkle.sortByNamespace);
 				pages.forEach(function(page) {
-					var metadata = [];
+					let metadata = [];
 					if (page.redirect) {
 						metadata.push('redirect');
 					}
 
-					var editProt = page.protection.filter(function(pr) {
+					let editProt = page.protection.filter(function(pr) {
 						return pr.type === 'edit' && pr.level === 'sysop';
 					}).pop();
 					if (editProt) {
@@ -357,7 +357,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 						metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 					}
 
-					var title = page.title;
+					let title = page.title;
 					subpageList.push({
 						label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''),
 						value: title,
@@ -366,7 +366,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 					});
 				});
 				if (subpageList.length) {
-					var pageName = apiobj.params.pageNameFull;
+					let pageName = apiobj.params.pageNameFull;
 					Twinkle.batchdelete.pages[pageName].subgroup = {
 						type: 'checkbox',
 						name: 'subpages',
@@ -420,16 +420,16 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch deletion is now complete';
 
-	var form = event.target;
+	let form = event.target;
 
-	var numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	let numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to delete ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}
 
-	var input = Morebits.quickForm.getInputData(form);
+	let input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert('You need to give a reason, you cabal crony!');
@@ -442,13 +442,13 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		return;
 	}
 
-	var pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
+	let pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
 	pageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	// we only need the initial status lines if we're deleting the pages in the pages array
 	pageDeleter.setOption('preserveIndividualStatusLines', input.delete_page);
 	pageDeleter.setPageList(input.pages);
 	pageDeleter.run(function worker(pageName) {
-		var params = {
+		let params = {
 			page: pageName,
 			delete_page: input.delete_page,
 			delete_talk: input.delete_talk,
@@ -459,7 +459,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 			pageDeleter: pageDeleter
 		};
 
-		var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
+		let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
 		if (input.delete_page) {
 			wikipedia_page.setEditSummary(input.reason);
@@ -471,12 +471,12 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		}
 	}, function postFinish() {
 		if (input.delete_subpages && input.subpages) {
-			var subpageDeleter = new Morebits.batchOperation('Deleting subpages');
+			let subpageDeleter = new Morebits.batchOperation('Deleting subpages');
 			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 			subpageDeleter.setOption('preserveIndividualStatusLines', true);
 			subpageDeleter.setPageList(input.subpages);
 			subpageDeleter.run(function(pageName) {
-				var params = {
+				let params = {
 					page: pageName,
 					delete_page: true,
 					delete_talk: input.delete_subpage_talks,
@@ -487,7 +487,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 					pageDeleter: subpageDeleter
 				};
 
-				var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
+				let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
 				wikipedia_page.setCallbackParameters(params);
 				wikipedia_page.setEditSummary(input.reason);
 				wikipedia_page.setChangeTags(Twinkle.changeTags);
@@ -502,13 +502,13 @@ Twinkle.batchdelete.callbacks = {
 	// this stupid parameter name is a temporary thing until I implement an overhaul
 	// of Morebits.wiki.* callback parameters
 	doExtras: function(thingWithParameters) {
-		var params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
+		let params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
 			thingWithParameters.getCallbackParameters();
 		// the initial batch operation's job is to delete the page, and that has
 		// succeeded by now
 		params.pageDeleter.workerSuccess(thingWithParameters);
 
-		var query, wikipedia_api;
+		let query, wikipedia_api;
 
 		if (params.unlink_page) {
 			Twinkle.batchdelete.unlinkCache = {};
@@ -553,7 +553,7 @@ Twinkle.batchdelete.callbacks = {
 				wikipedia_api.post();
 			}
 			if (params.delete_talk) {
-				var pageTitle = mw.Title.newFromText(params.page);
+				let pageTitle = mw.Title.newFromText(params.page);
 				if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 					pageTitle.namespace++;  // now pageTitle is the talk page title!
 					query = {
@@ -570,8 +570,8 @@ Twinkle.batchdelete.callbacks = {
 		}
 	},
 	deleteRedirectsMain: function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = response.query.pages[0].redirects || [];
+		let response = apiobj.getResponse();
+		let pages = response.query.pages[0].redirects || [];
 		pages = pages.map(function(redirect) {
 			return redirect.title;
 		});
@@ -579,32 +579,32 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		var redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
+		let redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
 		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		redirectDeleter.setPageList(pages);
 		redirectDeleter.run(function(pageName) {
-			var wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
+			let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
 			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
 			wikipedia_page.setChangeTags(Twinkle.changeTags);
 			wikipedia_page.deletePage(redirectDeleter.workerSuccess, redirectDeleter.workerFailure);
 		});
 	},
 	deleteTalk: function(apiobj) {
-		var response = apiobj.getResponse();
+		let response = apiobj.getResponse();
 
 		// no talk page; forget about it
 		if (response.query.pages[0].missing) {
 			return;
 		}
 
-		var page = new Morebits.wiki.page(apiobj.params.talkPage, 'Deleting talk page of page ' + apiobj.params.page);
+		let page = new Morebits.wiki.page(apiobj.params.talkPage, 'Deleting talk page of page ' + apiobj.params.page);
 		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
 		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	unlinkBacklinksMain: function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = response.query.backlinks || [];
+		let response = apiobj.getResponse();
+		let pages = response.query.backlinks || [];
 		pages = pages.map(function(page) {
 			return page.title;
 		});
@@ -612,12 +612,12 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		var unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
+		let unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
-			var wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
-			var params = $.extend({}, apiobj.params);
+			let wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
+			let params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
 			wikipedia_page.setCallbackParameters(params);
@@ -625,21 +625,21 @@ Twinkle.batchdelete.callbacks = {
 		});
 	},
 	unlinkBacklinks: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
+		let params = pageobj.getCallbackParameters();
 		if (!pageobj.exists()) {
 			// we probably just deleted it, as a recursive backlink
 			params.unlinker.workerSuccess(pageobj);
 			return;
 		}
 
-		var text;
+		let text;
 		if (params.title in Twinkle.batchdelete.unlinkCache) {
 			text = Twinkle.batchdelete.unlinkCache[params.title];
 		} else {
 			text = pageobj.getPageText();
 		}
-		var old_text = text;
-		var wikiPage = new Morebits.wikitext.page(text);
+		let old_text = text;
+		let wikiPage = new Morebits.wikitext.page(text);
 		text = wikiPage.removeLink(params.page).getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
@@ -656,8 +656,8 @@ Twinkle.batchdelete.callbacks = {
 		pageobj.save(params.unlinker.workerSuccess, params.unlinker.workerFailure);
 	},
 	unlinkImageInstancesMain: function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = response.query.imageusage || [];
+		let response = apiobj.getResponse();
+		let pages = response.query.imageusage || [];
 		pages = pages.map(function(page) {
 			return page.title;
 		});
@@ -665,12 +665,12 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		var unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
+		let unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
-			var wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);
-			var params = $.extend({}, apiobj.params);
+			let wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);
+			let params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
 			wikipedia_page.setCallbackParameters(params);
@@ -678,22 +678,22 @@ Twinkle.batchdelete.callbacks = {
 		});
 	},
 	unlinkImageInstances: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
+		let params = pageobj.getCallbackParameters();
 		if (!pageobj.exists()) {
 			// we probably just deleted it, as a recursive backlink
 			params.unlinker.workerSuccess(pageobj);
 			return;
 		}
 
-		var image = params.page.replace(new RegExp('^' + Morebits.namespaceRegex(6) + ':'), '');
-		var text;
+		let image = params.page.replace(new RegExp('^' + Morebits.namespaceRegex(6) + ':'), '');
+		let text;
 		if (params.title in Twinkle.batchdelete.unlinkCache) {
 			text = Twinkle.batchdelete.unlinkCache[params.title];
 		} else {
 			text = pageobj.getPageText();
 		}
-		var old_text = text;
-		var wikiPage = new Morebits.wikitext.page(text);
+		let old_text = text;
+		let wikiPage = new Morebits.wikitext.page(text);
 		text = wikiPage.commentOutImage(image, 'Commented out because image was deleted').getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -166,20 +166,20 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	Twinkle.batchdelete.pages = {};
 
 	const statelem = new Morebits.status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
-		pages = pages.filter(function(page) {
+		pages = pages.filter((page) => {
 			return !page.missing && page.imagerepository !== 'shared';
 		});
 		pages.sort(Twinkle.sortByNamespace);
-		pages.forEach(function(page) {
+		pages.forEach((page) => {
 			const metadata = [];
 			if (page.redirect) {
 				metadata.push('redirect');
 			}
 
-			const editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter((pr) => {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -209,7 +209,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			type: 'button',
 			label: 'Select All',
 			event: function dBatchSelectAll() {
-				$(result).find('input[name=pages]:not(:checked)').each(function(_, e) {
+				$(result).find('input[name=pages]:not(:checked)').each((_, e) => {
 					e.click(); // check it, and invoke click event so that subgroup can be shown
 				});
 
@@ -221,7 +221,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			type: 'button',
 			label: 'Deselect All',
 			event: function dBatchDeselectAll() {
-				$(result).find('input[name=pages]:checked').each(function(_, e) {
+				$(result).find('input[name=pages]:checked').each((_, e) => {
 					e.click(); // uncheck it, and invoke click event so that subgroup can be hidden
 				});
 			}
@@ -231,7 +231,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			name: 'pages',
 			id: 'tw-dbatch-pages',
 			shiftClickSupport: true,
-			list: $.map(Twinkle.batchdelete.pages, function (e) {
+			list: $.map(Twinkle.batchdelete.pages, (e) => {
 				return e;
 			})
 		});
@@ -242,7 +242,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 
 		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
-	}, statelem);
+	}), statelem);
 
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();
@@ -265,7 +265,7 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 		name: 'pages',
 		id: 'tw-dbatch-pages',
 		shiftClickSupport: true,
-		list: $.map(Twinkle.batchdelete.pages, function (e) {
+		list: $.map(Twinkle.batchdelete.pages, (e) => {
 			return e;
 		})
 	}).render();
@@ -286,7 +286,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		// available without use of any API calls
 		if (subpagesLoaded) {
 
-			$.each(Twinkle.batchdelete.pages, function(i, el) {
+			$.each(Twinkle.batchdelete.pages, (i, el) => {
 				// Get back the subgroup from subgroup_, where we saved it
 				if (el.subgroup === null && el.subgroup_) {
 					el.subgroup = el.subgroup_;
@@ -306,14 +306,14 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		const loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
 		$(e.target).after(loadingText);
 
-		const pages = $(form.pages).map(function(i, el) {
+		const pages = $(form.pages).map((i, el) => {
 			return el.value;
 		}).get();
 
 		const subpageLister = new Morebits.batchOperation();
 		subpageLister.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		subpageLister.setPageList(pages);
-		subpageLister.run(function worker (pageName) {
+		subpageLister.run((pageName) => {
 			const pageTitle = mw.Title.newFromText(pageName);
 
 			// No need to look for subpages in main/file/mediawiki space
@@ -332,18 +332,18 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				gapnamespace: pageTitle.namespace,
 				gaplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
-			}, function onSuccess(apiobj) {
+			}, ((apiobj) => {
 				const response = apiobj.getResponse();
 				const pages = (response.query && response.query.pages) || [];
 				const subpageList = [];
 				pages.sort(Twinkle.sortByNamespace);
-				pages.forEach(function(page) {
+				pages.forEach((page) => {
 					const metadata = [];
 					if (page.redirect) {
 						metadata.push('redirect');
 					}
 
-					const editProt = page.protection.filter(function(pr) {
+					const editProt = page.protection.filter((pr) => {
 						return pr.type === 'edit' && pr.level === 'sysop';
 					}).pop();
 					if (editProt) {
@@ -376,13 +376,13 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 					};
 				}
 				subpageLister.workerSuccess();
-			}, null /* statusElement */, function onFailure() {
+			}), null /* statusElement */, (() => {
 				subpageLister.workerFailure();
-			});
+			}));
 			wikipedia_api.params = { pageNameFull: pageName }; // Used in onSuccess()
 			wikipedia_api.post();
 
-		}, function postFinish () {
+		}, () => {
 			// List 'em on the interface
 
 			newPageList = Twinkle.batchdelete.generateNewPageList(form);
@@ -400,7 +400,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 
 	} else if (!e.target.checked) {
 
-		$.each(Twinkle.batchdelete.pages, function(i, el) {
+		$.each(Twinkle.batchdelete.pages, (i, el) => {
 			if (el.subgroup) {
 				// Remove subgroup after saving its contents in subgroup_
 				// so that it can be retrieved easily if user decides to
@@ -422,7 +422,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 
 	const form = event.target;
 
-	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to delete ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
@@ -447,7 +447,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 	// we only need the initial status lines if we're deleting the pages in the pages array
 	pageDeleter.setOption('preserveIndividualStatusLines', input.delete_page);
 	pageDeleter.setPageList(input.pages);
-	pageDeleter.run(function worker(pageName) {
+	pageDeleter.run((pageName) => {
 		const params = {
 			page: pageName,
 			delete_page: input.delete_page,
@@ -469,13 +469,13 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		} else {
 			Twinkle.batchdelete.callbacks.doExtras(wikipedia_page);
 		}
-	}, function postFinish() {
+	}, () => {
 		if (input.delete_subpages && input.subpages) {
 			const subpageDeleter = new Morebits.batchOperation('Deleting subpages');
 			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 			subpageDeleter.setOption('preserveIndividualStatusLines', true);
 			subpageDeleter.setPageList(input.subpages);
-			subpageDeleter.run(function(pageName) {
+			subpageDeleter.run((pageName) => {
 				const params = {
 					page: pageName,
 					delete_page: true,
@@ -572,7 +572,7 @@ Twinkle.batchdelete.callbacks = {
 	deleteRedirectsMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.pages[0].redirects || [];
-		pages = pages.map(function(redirect) {
+		pages = pages.map((redirect) => {
 			return redirect.title;
 		});
 		if (!pages.length) {
@@ -582,7 +582,7 @@ Twinkle.batchdelete.callbacks = {
 		const redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
 		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		redirectDeleter.setPageList(pages);
-		redirectDeleter.run(function(pageName) {
+		redirectDeleter.run((pageName) => {
 			const wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
 			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
 			wikipedia_page.setChangeTags(Twinkle.changeTags);
@@ -605,7 +605,7 @@ Twinkle.batchdelete.callbacks = {
 	unlinkBacklinksMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.backlinks || [];
-		pages = pages.map(function(page) {
+		pages = pages.map((page) => {
 			return page.title;
 		});
 		if (!pages.length) {
@@ -615,7 +615,7 @@ Twinkle.batchdelete.callbacks = {
 		const unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
-		unlinker.run(function(pageName) {
+		unlinker.run((pageName) => {
 			const wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
 			const params = $.extend({}, apiobj.params);
 			params.title = pageName;
@@ -658,7 +658,7 @@ Twinkle.batchdelete.callbacks = {
 	unlinkImageInstancesMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.imageusage || [];
-		pages = pages.map(function(page) {
+		pages = pages.map((page) => {
 			return page.title;
 		});
 		if (!pages.length) {
@@ -668,7 +668,7 @@ Twinkle.batchdelete.callbacks = {
 		const unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
-		unlinker.run(function(pageName) {
+		unlinker.run((pageName) => {
 			const wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);
 			const params = $.extend({}, apiobj.params);
 			params.title = pageName;

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -712,7 +712,7 @@ Twinkle.batchdelete.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.batchdelete, 'batchdelete');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -169,9 +169,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
-		pages = pages.filter((page) => {
-			return !page.missing && page.imagerepository !== 'shared';
-		});
+		pages = pages.filter((page) => !page.missing && page.imagerepository !== 'shared');
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach((page) => {
 			const metadata = [];
@@ -179,9 +177,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 				metadata.push('redirect');
 			}
 
-			const editProt = page.protection.filter((pr) => {
-				return pr.type === 'edit' && pr.level === 'sysop';
-			}).pop();
+			const editProt = page.protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 			if (editProt) {
 				metadata.push('fully protected' +
 				(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)'));
@@ -231,9 +227,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			name: 'pages',
 			id: 'tw-dbatch-pages',
 			shiftClickSupport: true,
-			list: $.map(Twinkle.batchdelete.pages, (e) => {
-				return e;
-			})
+			list: $.map(Twinkle.batchdelete.pages, (e) => e)
 		});
 		form.append({ type: 'submit' });
 
@@ -265,9 +259,7 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 		name: 'pages',
 		id: 'tw-dbatch-pages',
 		shiftClickSupport: true,
-		list: $.map(Twinkle.batchdelete.pages, (e) => {
-			return e;
-		})
+		list: $.map(Twinkle.batchdelete.pages, (e) => e)
 	}).render();
 };
 
@@ -306,9 +298,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		const loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
 		$(e.target).after(loadingText);
 
-		const pages = $(form.pages).map((i, el) => {
-			return el.value;
-		}).get();
+		const pages = $(form.pages).map((i, el) => el.value).get();
 
 		const subpageLister = new Morebits.batchOperation();
 		subpageLister.setOption('chunkSize', Twinkle.getPref('batchChunks'));
@@ -343,9 +333,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 						metadata.push('redirect');
 					}
 
-					const editProt = page.protection.filter((pr) => {
-						return pr.type === 'edit' && pr.level === 'sysop';
-					}).pop();
+					const editProt = page.protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 					if (editProt) {
 						metadata.push('fully protected' +
 						(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)'));
@@ -422,9 +410,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 
 	const form = event.target;
 
-	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => {
-		return element.checked && element.nextElementSibling.style.color === 'red';
-	}).length;
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => element.checked && element.nextElementSibling.style.color === 'red').length;
 	if (numProtected > 0 && !confirm('You are about to delete ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}
@@ -572,9 +558,7 @@ Twinkle.batchdelete.callbacks = {
 	deleteRedirectsMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.pages[0].redirects || [];
-		pages = pages.map((redirect) => {
-			return redirect.title;
-		});
+		pages = pages.map((redirect) => redirect.title);
 		if (!pages.length) {
 			return;
 		}
@@ -605,9 +589,7 @@ Twinkle.batchdelete.callbacks = {
 	unlinkBacklinksMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.backlinks || [];
-		pages = pages.map((page) => {
-			return page.title;
-		});
+		pages = pages.map((page) => page.title);
 		if (!pages.length) {
 			return;
 		}
@@ -658,9 +640,7 @@ Twinkle.batchdelete.callbacks = {
 	unlinkImageInstancesMain: function(apiobj) {
 		const response = apiobj.getResponse();
 		let pages = response.query.imageusage || [];
-		pages = pages.map((page) => {
-			return page.title;
-		});
+		pages = pages.map((page) => page.title);
 		if (!pages.length) {
 			return;
 		}

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -30,13 +30,13 @@ let subpagesLoaded;
 
 Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 	subpagesLoaded = false;
-	let Window = new Morebits.simpleWindow(600, 400);
+	const Window = new Morebits.simpleWindow(600, 400);
 	Window.setTitle('Batch deletion');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#batchdelete');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.batchdelete.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.batchdelete.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -111,7 +111,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		size: 60
 	});
 
-	let query = {
+	const query = {
 		action: 'query',
 		prop: 'revisions|info|imageinfo',
 		inprop: 'protection',
@@ -138,7 +138,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			if (pathSplit.length < 3 || pathSplit[2] !== 'Special:PrefixIndex') {
 				return;
 			}
-			let titleSplit = pathSplit[3].split(':');
+			const titleSplit = pathSplit[3].split(':');
 			query.gapnamespace = mw.config.get('wgNamespaceIds')[titleSplit[0].toLowerCase()];
 			if (titleSplit.length < 2 || typeof query.gapnamespace === 'undefined') {
 				query.gapnamespace = 0;  // article namespace
@@ -157,7 +157,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
-	let statusdiv = document.createElement('div');
+	const statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
@@ -165,21 +165,21 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 
 	Twinkle.batchdelete.pages = {};
 
-	let statelem = new Morebits.status('Grabbing list of pages');
-	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		let response = apiobj.getResponse();
+	const statelem = new Morebits.status('Grabbing list of pages');
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter(function(page) {
 			return !page.missing && page.imagerepository !== 'shared';
 		});
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			let metadata = [];
+			const metadata = [];
 			if (page.redirect) {
 				metadata.push('redirect');
 			}
 
-			let editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -194,7 +194,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 				metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 			}
 
-			let title = page.title;
+			const title = page.title;
 			Twinkle.batchdelete.pages[title] = {
 				label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''),
 				value: title,
@@ -203,7 +203,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 			};
 		});
 
-		let form = apiobj.params.form;
+		const form = apiobj.params.form;
 		form.append({ type: 'header', label: 'Pages to delete' });
 		form.append({
 			type: 'button',
@@ -251,7 +251,7 @@ Twinkle.batchdelete.callback = function twinklebatchdeleteCallback() {
 Twinkle.batchdelete.generateNewPageList = function(form) {
 
 	// Update the list of checked pages in Twinkle.batchdelete.pages object
-	let elements = form.elements.pages;
+	const elements = form.elements.pages;
 	if (elements instanceof NodeList) { // if there are multiple pages
 		for (let i = 0; i < elements.length; ++i) {
 			Twinkle.batchdelete.pages[elements[i].value].checked = elements[i].checked;
@@ -273,7 +273,7 @@ Twinkle.batchdelete.generateNewPageList = function(form) {
 
 Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e) {
 
-	let form = e.target.form;
+	const form = e.target.form;
 	let newPageList;
 
 	if (e.target.checked) {
@@ -303,18 +303,18 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 		}
 
 		// Proceed with API calls to get list of subpages
-		let loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
+		const loadingText = '<strong id="dbatch-subpage-loading">Loading... </strong>';
 		$(e.target).after(loadingText);
 
-		let pages = $(form.pages).map(function(i, el) {
+		const pages = $(form.pages).map(function(i, el) {
 			return el.value;
 		}).get();
 
-		let subpageLister = new Morebits.batchOperation();
+		const subpageLister = new Morebits.batchOperation();
 		subpageLister.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		subpageLister.setPageList(pages);
 		subpageLister.run(function worker (pageName) {
-			let pageTitle = mw.Title.newFromText(pageName);
+			const pageTitle = mw.Title.newFromText(pageName);
 
 			// No need to look for subpages in main/file/mediawiki space
 			if ([0, 6, 8].indexOf(pageTitle.namespace) > -1) {
@@ -322,7 +322,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				return;
 			}
 
-			let wikipedia_api = new Morebits.wiki.api('Getting list of subpages of ' + pageName, {
+			const wikipedia_api = new Morebits.wiki.api('Getting list of subpages of ' + pageName, {
 				action: 'query',
 				prop: 'revisions|info|imageinfo',
 				generator: 'allpages',
@@ -333,17 +333,17 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 				gaplimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function onSuccess(apiobj) {
-				let response = apiobj.getResponse();
-				let pages = (response.query && response.query.pages) || [];
-				let subpageList = [];
+				const response = apiobj.getResponse();
+				const pages = (response.query && response.query.pages) || [];
+				const subpageList = [];
 				pages.sort(Twinkle.sortByNamespace);
 				pages.forEach(function(page) {
-					let metadata = [];
+					const metadata = [];
 					if (page.redirect) {
 						metadata.push('redirect');
 					}
 
-					let editProt = page.protection.filter(function(pr) {
+					const editProt = page.protection.filter(function(pr) {
 						return pr.type === 'edit' && pr.level === 'sysop';
 					}).pop();
 					if (editProt) {
@@ -357,7 +357,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 						metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 					}
 
-					let title = page.title;
+					const title = page.title;
 					subpageList.push({
 						label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''),
 						value: title,
@@ -366,7 +366,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 					});
 				});
 				if (subpageList.length) {
-					let pageName = apiobj.params.pageNameFull;
+					const pageName = apiobj.params.pageNameFull;
 					Twinkle.batchdelete.pages[pageName].subgroup = {
 						type: 'checkbox',
 						name: 'subpages',
@@ -420,16 +420,16 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch deletion is now complete';
 
-	let form = event.target;
+	const form = event.target;
 
-	let numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to delete ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}
 
-	let input = Morebits.quickForm.getInputData(form);
+	const input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert('You need to give a reason, you cabal crony!');
@@ -442,13 +442,13 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		return;
 	}
 
-	let pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
+	const pageDeleter = new Morebits.batchOperation(input.delete_page ? 'Deleting pages' : 'Initiating requested tasks');
 	pageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	// we only need the initial status lines if we're deleting the pages in the pages array
 	pageDeleter.setOption('preserveIndividualStatusLines', input.delete_page);
 	pageDeleter.setPageList(input.pages);
 	pageDeleter.run(function worker(pageName) {
-		let params = {
+		const params = {
 			page: pageName,
 			delete_page: input.delete_page,
 			delete_talk: input.delete_talk,
@@ -459,7 +459,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 			pageDeleter: pageDeleter
 		};
 
-		let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
+		const wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
 		if (input.delete_page) {
 			wikipedia_page.setEditSummary(input.reason);
@@ -471,12 +471,12 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 		}
 	}, function postFinish() {
 		if (input.delete_subpages && input.subpages) {
-			let subpageDeleter = new Morebits.batchOperation('Deleting subpages');
+			const subpageDeleter = new Morebits.batchOperation('Deleting subpages');
 			subpageDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 			subpageDeleter.setOption('preserveIndividualStatusLines', true);
 			subpageDeleter.setPageList(input.subpages);
 			subpageDeleter.run(function(pageName) {
-				let params = {
+				const params = {
 					page: pageName,
 					delete_page: true,
 					delete_talk: input.delete_subpage_talks,
@@ -487,7 +487,7 @@ Twinkle.batchdelete.callback.evaluate = function twinklebatchdeleteCallbackEvalu
 					pageDeleter: subpageDeleter
 				};
 
-				let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
+				const wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting subpage ' + pageName);
 				wikipedia_page.setCallbackParameters(params);
 				wikipedia_page.setEditSummary(input.reason);
 				wikipedia_page.setChangeTags(Twinkle.changeTags);
@@ -502,7 +502,7 @@ Twinkle.batchdelete.callbacks = {
 	// this stupid parameter name is a temporary thing until I implement an overhaul
 	// of Morebits.wiki.* callback parameters
 	doExtras: function(thingWithParameters) {
-		let params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
+		const params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
 			thingWithParameters.getCallbackParameters();
 		// the initial batch operation's job is to delete the page, and that has
 		// succeeded by now
@@ -553,7 +553,7 @@ Twinkle.batchdelete.callbacks = {
 				wikipedia_api.post();
 			}
 			if (params.delete_talk) {
-				let pageTitle = mw.Title.newFromText(params.page);
+				const pageTitle = mw.Title.newFromText(params.page);
 				if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 					pageTitle.namespace++;  // now pageTitle is the talk page title!
 					query = {
@@ -570,7 +570,7 @@ Twinkle.batchdelete.callbacks = {
 		}
 	},
 	deleteRedirectsMain: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 		let pages = response.query.pages[0].redirects || [];
 		pages = pages.map(function(redirect) {
 			return redirect.title;
@@ -579,31 +579,31 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		let redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
+		const redirectDeleter = new Morebits.batchOperation('Deleting redirects to ' + apiobj.params.page);
 		redirectDeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		redirectDeleter.setPageList(pages);
 		redirectDeleter.run(function(pageName) {
-			let wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
+			const wikipedia_page = new Morebits.wiki.page(pageName, 'Deleting ' + pageName);
 			wikipedia_page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
 			wikipedia_page.setChangeTags(Twinkle.changeTags);
 			wikipedia_page.deletePage(redirectDeleter.workerSuccess, redirectDeleter.workerFailure);
 		});
 	},
 	deleteTalk: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 
 		// no talk page; forget about it
 		if (response.query.pages[0].missing) {
 			return;
 		}
 
-		let page = new Morebits.wiki.page(apiobj.params.talkPage, 'Deleting talk page of page ' + apiobj.params.page);
+		const page = new Morebits.wiki.page(apiobj.params.talkPage, 'Deleting talk page of page ' + apiobj.params.page);
 		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
 		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	unlinkBacklinksMain: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 		let pages = response.query.backlinks || [];
 		pages = pages.map(function(page) {
 			return page.title;
@@ -612,12 +612,12 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		let unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
+		const unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
-			let wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
-			let params = $.extend({}, apiobj.params);
+			const wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking on ' + pageName);
+			const params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
 			wikipedia_page.setCallbackParameters(params);
@@ -625,7 +625,7 @@ Twinkle.batchdelete.callbacks = {
 		});
 	},
 	unlinkBacklinks: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 		if (!pageobj.exists()) {
 			// we probably just deleted it, as a recursive backlink
 			params.unlinker.workerSuccess(pageobj);
@@ -638,8 +638,8 @@ Twinkle.batchdelete.callbacks = {
 		} else {
 			text = pageobj.getPageText();
 		}
-		let old_text = text;
-		let wikiPage = new Morebits.wikitext.page(text);
+		const old_text = text;
+		const wikiPage = new Morebits.wikitext.page(text);
 		text = wikiPage.removeLink(params.page).getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;
@@ -656,7 +656,7 @@ Twinkle.batchdelete.callbacks = {
 		pageobj.save(params.unlinker.workerSuccess, params.unlinker.workerFailure);
 	},
 	unlinkImageInstancesMain: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 		let pages = response.query.imageusage || [];
 		pages = pages.map(function(page) {
 			return page.title;
@@ -665,12 +665,12 @@ Twinkle.batchdelete.callbacks = {
 			return;
 		}
 
-		let unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
+		const unlinker = new Morebits.batchOperation('Unlinking backlinks to ' + apiobj.params.page);
 		unlinker.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		unlinker.setPageList(pages);
 		unlinker.run(function(pageName) {
-			let wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);
-			let params = $.extend({}, apiobj.params);
+			const wikipedia_page = new Morebits.wiki.page(pageName, 'Removing file usages on ' + pageName);
+			const params = $.extend({}, apiobj.params);
 			params.title = pageName;
 			params.unlinker = unlinker;
 			wikipedia_page.setCallbackParameters(params);
@@ -678,22 +678,22 @@ Twinkle.batchdelete.callbacks = {
 		});
 	},
 	unlinkImageInstances: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 		if (!pageobj.exists()) {
 			// we probably just deleted it, as a recursive backlink
 			params.unlinker.workerSuccess(pageobj);
 			return;
 		}
 
-		let image = params.page.replace(new RegExp('^' + Morebits.namespaceRegex(6) + ':'), '');
+		const image = params.page.replace(new RegExp('^' + Morebits.namespaceRegex(6) + ':'), '');
 		let text;
 		if (params.title in Twinkle.batchdelete.unlinkCache) {
 			text = Twinkle.batchdelete.unlinkCache[params.title];
 		} else {
 			text = pageobj.getPageText();
 		}
-		let old_text = text;
-		let wikiPage = new Morebits.wikitext.page(text);
+		const old_text = text;
+		const wikiPage = new Morebits.wikitext.page(text);
 		text = wikiPage.commentOutImage(image, 'Commented out because image was deleted').getText();
 
 		Twinkle.batchdelete.unlinkCache[params.title] = text;

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -82,10 +82,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		name: 'movelevel',
 		label: 'Move protection:',
 		event: Twinkle.protect.formevents.movelevel,
-		list: Twinkle.protect.protectionLevels.filter((level) => 
-			// Autoconfirmed is required for a move, redundant
-			 level.value !== 'autoconfirmed'
-		)
+		list: Twinkle.protect.protectionLevels.filter((level) => /* Autoconfirmed is required for a move, redundant */ level.value !== 'autoconfirmed')
 	});
 	form.append({
 		type: 'select',

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -82,10 +82,10 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		name: 'movelevel',
 		label: 'Move protection:',
 		event: Twinkle.protect.formevents.movelevel,
-		list: Twinkle.protect.protectionLevels.filter((level) => {
+		list: Twinkle.protect.protectionLevels.filter((level) => 
 			// Autoconfirmed is required for a move, redundant
-			return level.value !== 'autoconfirmed';
-		})
+			 level.value !== 'autoconfirmed'
+		)
 	});
 	form.append({
 		type: 'select',
@@ -189,9 +189,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 			if (missing) {
 				metadata.push('page does not exist');
-				editProt = page.protection.filter((pr) => {
-					return pr.type === 'create' && pr.level === 'sysop';
-				}).pop();
+				editProt = page.protection.filter((pr) => pr.type === 'create' && pr.level === 'sysop').pop();
 			} else {
 				if (page.redirect) {
 					metadata.push('redirect');
@@ -204,9 +202,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 					metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 				}
 
-				editProt = page.protection.filter((pr) => {
-					return pr.type === 'edit' && pr.level === 'sysop';
-				}).pop();
+				editProt = page.protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 			}
 			if (editProt) {
 				metadata.push('fully' + (missing ? ' create' : '') + ' protected' +
@@ -261,9 +257,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 
 	const form = event.target;
 
-	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => {
-		return element.checked && element.nextElementSibling.style.color === 'red';
-	}).length;
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => element.checked && element.nextElementSibling.style.color === 'red').length;
 	if (numProtected > 0 && !confirm('You are about to act on ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -82,7 +82,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		name: 'movelevel',
 		label: 'Move protection:',
 		event: Twinkle.protect.formevents.movelevel,
-		list: Twinkle.protect.protectionLevels.filter(function(level) {
+		list: Twinkle.protect.protectionLevels.filter((level) => {
 			// Autoconfirmed is required for a move, redundant
 			return level.value !== 'autoconfirmed';
 		})
@@ -178,18 +178,18 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 	const statelem = new Morebits.status('Grabbing list of pages');
 
-	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		const pages = (response.query && response.query.pages) || [];
 		const list = [];
 		pages.sort(Twinkle.sortByNamespace);
-		pages.forEach(function(page) {
+		pages.forEach((page) => {
 			const metadata = [];
 			let missing = !!page.missing, editProt;
 
 			if (missing) {
 				metadata.push('page does not exist');
-				editProt = page.protection.filter(function(pr) {
+				editProt = page.protection.filter((pr) => {
 					return pr.type === 'create' && pr.level === 'sysop';
 				}).pop();
 			} else {
@@ -204,7 +204,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 					metadata.push(mw.language.convertNumber(page.revisions[0].size) + ' bytes');
 				}
 
-				editProt = page.protection.filter(function(pr) {
+				editProt = page.protection.filter((pr) => {
 					return pr.type === 'edit' && pr.level === 'sysop';
 				}).pop();
 			}
@@ -249,7 +249,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 
 		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
-	}, statelem);
+	}), statelem);
 
 	wikipedia_api.post();
 };
@@ -261,7 +261,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 
 	const form = event.target;
 
-	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter((index, element) => {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to act on ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
@@ -287,7 +287,7 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 	batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	batchOperation.setOption('preserveIndividualStatusLines', true);
 	batchOperation.setPageList(input.pages);
-	batchOperation.run(function(pageName) {
+	batchOperation.run((pageName) => {
 		const query = {
 			action: 'query',
 			titles: pageName,

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -24,14 +24,14 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 
 Twinkle.batchprotect.unlinkCache = {};
 Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
-	let Window = new Morebits.simpleWindow(600, 400);
+	const Window = new Morebits.simpleWindow(600, 400);
 	Window.setTitle('Batch protection');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Protection policy', 'WP:PROT');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#protect');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.batchprotect.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.batchprotect.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		event: Twinkle.protect.formevents.editmodify,
@@ -147,7 +147,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		tooltip: 'For the protection log and page history.'
 	});
 
-	let query = {
+	const query = {
 		action: 'query',
 		prop: 'revisions|info|imageinfo',
 		rvprop: 'size|user',
@@ -170,21 +170,21 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
-	let statusdiv = document.createElement('div');
+	const statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	let statelem = new Morebits.status('Grabbing list of pages');
+	const statelem = new Morebits.status('Grabbing list of pages');
 
-	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		let response = apiobj.getResponse();
-		let pages = (response.query && response.query.pages) || [];
-		let list = [];
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		const response = apiobj.getResponse();
+		const pages = (response.query && response.query.pages) || [];
+		const list = [];
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			let metadata = [];
+			const metadata = [];
 			let missing = !!page.missing, editProt;
 
 			if (missing) {
@@ -213,7 +213,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 				(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)'));
 			}
 
-			let title = page.title;
+			const title = page.title;
 			list.push({ label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''), value: title, checked: true, style: editProt ? 'color:red' : '' });
 		});
 		form.append({ type: 'header', label: 'Pages to protect' });
@@ -239,7 +239,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		});
 		form.append({ type: 'submit' });
 
-		let result = form.render();
+		const result = form.render();
 		Window.setContent(result);
 
 		// Set defaults
@@ -259,16 +259,16 @@ Twinkle.batchprotect.currentprotector = 0;
 Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch protection is now complete';
 
-	let form = event.target;
+	const form = event.target;
 
-	let numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	const numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to act on ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}
 
-	let input = Morebits.quickForm.getInputData(form);
+	const input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert("You've got to give a reason, you rouge admin!");
@@ -283,17 +283,17 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 		return;
 	}
 
-	let batchOperation = new Morebits.batchOperation('Applying protection settings');
+	const batchOperation = new Morebits.batchOperation('Applying protection settings');
 	batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	batchOperation.setOption('preserveIndividualStatusLines', true);
 	batchOperation.setPageList(input.pages);
 	batchOperation.run(function(pageName) {
-		let query = {
+		const query = {
 			action: 'query',
 			titles: pageName,
 			format: 'json'
 		};
-		let wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
+		const wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
 			Twinkle.batchprotect.callbacks.main, null, batchOperation.workerFailure);
 		wikipedia_api.params = $.extend({
 			page: pageName,
@@ -305,15 +305,15 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 
 Twinkle.batchprotect.callbacks = {
 	main: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 
 		if (response.query.normalized) {
 			apiobj.params.page = response.query.normalized[0].to;
 		}
 
-		let exists = !response.query.pages[0].missing;
+		const exists = !response.query.pages[0].missing;
 
-		let page = new Morebits.wiki.page(apiobj.params.page, 'Protecting ' + apiobj.params.page);
+		const page = new Morebits.wiki.page(apiobj.params.page, 'Protecting ' + apiobj.params.page);
 		let takenAction = false;
 		if (exists && apiobj.params.editmodify) {
 			page.setEditProtection(apiobj.params.editlevel, apiobj.params.editexpiry);

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -24,14 +24,14 @@ Twinkle.batchprotect = function twinklebatchprotect() {
 
 Twinkle.batchprotect.unlinkCache = {};
 Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
-	var Window = new Morebits.simpleWindow(600, 400);
+	let Window = new Morebits.simpleWindow(600, 400);
 	Window.setTitle('Batch protection');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Protection policy', 'WP:PROT');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#protect');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.batchprotect.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.batchprotect.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		event: Twinkle.protect.formevents.editmodify,
@@ -147,7 +147,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		tooltip: 'For the protection log and page history.'
 	});
 
-	var query = {
+	let query = {
 		action: 'query',
 		prop: 'revisions|info|imageinfo',
 		rvprop: 'size|user',
@@ -170,22 +170,22 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		query.gpllimit = Twinkle.getPref('batchMax');
 	}
 
-	var statusdiv = document.createElement('div');
+	let statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	var statelem = new Morebits.status('Grabbing list of pages');
+	let statelem = new Morebits.status('Grabbing list of pages');
 
-	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = (response.query && response.query.pages) || [];
-		var list = [];
+	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		let response = apiobj.getResponse();
+		let pages = (response.query && response.query.pages) || [];
+		let list = [];
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			var metadata = [];
-			var missing = !!page.missing, editProt;
+			let metadata = [];
+			let missing = !!page.missing, editProt;
 
 			if (missing) {
 				metadata.push('page does not exist');
@@ -213,7 +213,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 				(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)'));
 			}
 
-			var title = page.title;
+			let title = page.title;
 			list.push({ label: title + (metadata.length ? ' (' + metadata.join('; ') + ')' : ''), value: title, checked: true, style: editProt ? 'color:red' : '' });
 		});
 		form.append({ type: 'header', label: 'Pages to protect' });
@@ -239,7 +239,7 @@ Twinkle.batchprotect.callback = function twinklebatchprotectCallback() {
 		});
 		form.append({ type: 'submit' });
 
-		var result = form.render();
+		let result = form.render();
 		Window.setContent(result);
 
 		// Set defaults
@@ -259,16 +259,16 @@ Twinkle.batchprotect.currentprotector = 0;
 Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch protection is now complete';
 
-	var form = event.target;
+	let form = event.target;
 
-	var numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
+	let numProtected = $(Morebits.quickForm.getElements(form, 'pages')).filter(function(index, element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to act on ' + mw.language.convertNumber(numProtected) + ' fully protected page(s). Are you sure?')) {
 		return;
 	}
 
-	var input = Morebits.quickForm.getInputData(form);
+	let input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert("You've got to give a reason, you rouge admin!");
@@ -283,17 +283,17 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 		return;
 	}
 
-	var batchOperation = new Morebits.batchOperation('Applying protection settings');
+	let batchOperation = new Morebits.batchOperation('Applying protection settings');
 	batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	batchOperation.setOption('preserveIndividualStatusLines', true);
 	batchOperation.setPageList(input.pages);
 	batchOperation.run(function(pageName) {
-		var query = {
+		let query = {
 			action: 'query',
 			titles: pageName,
 			format: 'json'
 		};
-		var wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
+		let wikipedia_api = new Morebits.wiki.api('Checking if page ' + pageName + ' exists', query,
 			Twinkle.batchprotect.callbacks.main, null, batchOperation.workerFailure);
 		wikipedia_api.params = $.extend({
 			page: pageName,
@@ -305,16 +305,16 @@ Twinkle.batchprotect.callback.evaluate = function twinklebatchprotectCallbackEva
 
 Twinkle.batchprotect.callbacks = {
 	main: function(apiobj) {
-		var response = apiobj.getResponse();
+		let response = apiobj.getResponse();
 
 		if (response.query.normalized) {
 			apiobj.params.page = response.query.normalized[0].to;
 		}
 
-		var exists = !response.query.pages[0].missing;
+		let exists = !response.query.pages[0].missing;
 
-		var page = new Morebits.wiki.page(apiobj.params.page, 'Protecting ' + apiobj.params.page);
-		var takenAction = false;
+		let page = new Morebits.wiki.page(apiobj.params.page, 'Protecting ' + apiobj.params.page);
+		let takenAction = false;
 		if (exists && apiobj.params.editmodify) {
 			page.setEditProtection(apiobj.params.editlevel, apiobj.params.editexpiry);
 			takenAction = true;

--- a/modules/twinklebatchprotect.js
+++ b/modules/twinklebatchprotect.js
@@ -340,7 +340,7 @@ Twinkle.batchprotect.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.batchprotect, 'batchprotect');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -23,13 +23,13 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 };
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
-	let Window = new Morebits.simpleWindow(600, 400);
+	const Window = new Morebits.simpleWindow(600, 400);
 	Window.setScriptName('Twinkle');
 	Window.setTitle('Batch undelete');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#batchundelete');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.batchundelete.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.batchundelete.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -48,13 +48,13 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		size: 60
 	});
 
-	let statusdiv = document.createElement('div');
+	const statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	let query = {
+	const query = {
 		action: 'query',
 		generator: 'links',
 		prop: 'info',
@@ -63,21 +63,21 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		gpllimit: Twinkle.getPref('batchMax'),
 		format: 'json'
 	};
-	let statelem = new Morebits.status('Grabbing list of pages');
-	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		let response = apiobj.getResponse();
+	const statelem = new Morebits.status('Grabbing list of pages');
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter(function(page) {
 			return page.missing;
 		});
-		let list = [];
+		const list = [];
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			let editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter(function(pr) {
 				return pr.type === 'create' && pr.level === 'sysop';
 			}).pop();
 
-			let title = page.title;
+			const title = page.title;
 			list.push({
 				label: title + (editProt ? ' (fully create protected' +
 					(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)') + ')' : ''),
@@ -109,7 +109,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		});
 		apiobj.params.form.append({ type: 'submit' });
 
-		let result = apiobj.params.form.render();
+		const result = apiobj.params.form.render();
 		apiobj.params.Window.setContent(result);
 
 		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
@@ -122,14 +122,14 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 Twinkle.batchundelete.callback.evaluate = function(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch undeletion is now complete';
 
-	let numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter(function(element) {
+	const numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter(function(element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to undelete ' + numProtected + ' fully create protected page(s). Are you sure?')) {
 		return;
 	}
 
-	let input = Morebits.quickForm.getInputData(event.target);
+	const input = Morebits.quickForm.getInputData(event.target);
 
 	if (!input.reason) {
 		alert('You need to give a reason, you cabal crony!');
@@ -143,19 +143,19 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 		return;
 	}
 
-	let pageUndeleter = new Morebits.batchOperation('Undeleting pages');
+	const pageUndeleter = new Morebits.batchOperation('Undeleting pages');
 	pageUndeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	pageUndeleter.setOption('preserveIndividualStatusLines', true);
 	pageUndeleter.setPageList(input.pages);
 	pageUndeleter.run(function(pageName) {
-		let params = {
+		const params = {
 			page: pageName,
 			undel_talk: input.undel_talk,
 			reason: input.reason,
 			pageUndeleter: pageUndeleter
 		};
 
-		let wikipedia_page = new Morebits.wiki.page(pageName, 'Undeleting page ' + pageName);
+		const wikipedia_page = new Morebits.wiki.page(pageName, 'Undeleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
 		wikipedia_page.setEditSummary(input.reason);
 		wikipedia_page.setChangeTags(Twinkle.changeTags);
@@ -169,7 +169,7 @@ Twinkle.batchundelete.callbacks = {
 	// this stupid parameter name is a temporary thing until I implement an overhaul
 	// of Morebits.wiki.* callback parameters
 	doExtras: function(thingWithParameters) {
-		let params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
+		const params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
 			thingWithParameters.getCallbackParameters();
 		// the initial batch operation's job is to delete the page, and that has
 		// succeeded by now
@@ -178,7 +178,7 @@ Twinkle.batchundelete.callbacks = {
 		let query, wikipedia_api;
 
 		if (params.undel_talk) {
-			let talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
+			const talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
 			if (talkpagename !== params.page) {
 				query = {
 					action: 'query',
@@ -196,16 +196,16 @@ Twinkle.batchundelete.callbacks = {
 		}
 	},
 	undeleteTalk: function(apiobj) {
-		let page = apiobj.getResponse().query.pages[0];
-		let exists = !page.missing;
-		let delrevs = page.deletedrevisions && page.deletedrevisions[0].revid;
+		const page = apiobj.getResponse().query.pages[0];
+		const exists = !page.missing;
+		const delrevs = page.deletedrevisions && page.deletedrevisions[0].revid;
 
 		if (exists || !delrevs) {
 			// page exists or has no deleted revisions; forget about it
 			return;
 		}
 
-		let talkpage = new Morebits.wiki.page(apiobj.params.talkPage, 'Undeleting talk page of ' + apiobj.params.page);
+		const talkpage = new Morebits.wiki.page(apiobj.params.talkPage, 'Undeleting talk page of ' + apiobj.params.page);
 		talkpage.setEditSummary('Undeleting [[Help:Talk page|talk page]] of "' + apiobj.params.page + '"');
 		talkpage.setChangeTags(Twinkle.changeTags);
 		talkpage.undeletePage();

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -23,13 +23,13 @@ Twinkle.batchundelete = function twinklebatchundelete() {
 };
 
 Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
-	var Window = new Morebits.simpleWindow(600, 400);
+	let Window = new Morebits.simpleWindow(600, 400);
 	Window.setScriptName('Twinkle');
 	Window.setTitle('Batch undelete');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#batchundelete');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.batchundelete.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.batchundelete.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -48,13 +48,13 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		size: 60
 	});
 
-	var statusdiv = document.createElement('div');
+	let statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	var query = {
+	let query = {
 		action: 'query',
 		generator: 'links',
 		prop: 'info',
@@ -63,21 +63,21 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		gpllimit: Twinkle.getPref('batchMax'),
 		format: 'json'
 	};
-	var statelem = new Morebits.status('Grabbing list of pages');
-	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = (response.query && response.query.pages) || [];
+	let statelem = new Morebits.status('Grabbing list of pages');
+	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		let response = apiobj.getResponse();
+		let pages = (response.query && response.query.pages) || [];
 		pages = pages.filter(function(page) {
 			return page.missing;
 		});
-		var list = [];
+		let list = [];
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			var editProt = page.protection.filter(function(pr) {
+			let editProt = page.protection.filter(function(pr) {
 				return pr.type === 'create' && pr.level === 'sysop';
 			}).pop();
 
-			var title = page.title;
+			let title = page.title;
 			list.push({
 				label: title + (editProt ? ' (fully create protected' +
 					(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + new Morebits.date(editProt.expiry).calendar('utc') + ' (UTC)') + ')' : ''),
@@ -109,7 +109,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		});
 		apiobj.params.form.append({ type: 'submit' });
 
-		var result = apiobj.params.form.render();
+		let result = apiobj.params.form.render();
 		apiobj.params.Window.setContent(result);
 
 		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
@@ -122,14 +122,14 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 Twinkle.batchundelete.callback.evaluate = function(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch undeletion is now complete';
 
-	var numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter(function(element) {
+	let numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter(function(element) {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to undelete ' + numProtected + ' fully create protected page(s). Are you sure?')) {
 		return;
 	}
 
-	var input = Morebits.quickForm.getInputData(event.target);
+	let input = Morebits.quickForm.getInputData(event.target);
 
 	if (!input.reason) {
 		alert('You need to give a reason, you cabal crony!');
@@ -143,19 +143,19 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 		return;
 	}
 
-	var pageUndeleter = new Morebits.batchOperation('Undeleting pages');
+	let pageUndeleter = new Morebits.batchOperation('Undeleting pages');
 	pageUndeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	pageUndeleter.setOption('preserveIndividualStatusLines', true);
 	pageUndeleter.setPageList(input.pages);
 	pageUndeleter.run(function(pageName) {
-		var params = {
+		let params = {
 			page: pageName,
 			undel_talk: input.undel_talk,
 			reason: input.reason,
 			pageUndeleter: pageUndeleter
 		};
 
-		var wikipedia_page = new Morebits.wiki.page(pageName, 'Undeleting page ' + pageName);
+		let wikipedia_page = new Morebits.wiki.page(pageName, 'Undeleting page ' + pageName);
 		wikipedia_page.setCallbackParameters(params);
 		wikipedia_page.setEditSummary(input.reason);
 		wikipedia_page.setChangeTags(Twinkle.changeTags);
@@ -169,16 +169,16 @@ Twinkle.batchundelete.callbacks = {
 	// this stupid parameter name is a temporary thing until I implement an overhaul
 	// of Morebits.wiki.* callback parameters
 	doExtras: function(thingWithParameters) {
-		var params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
+		let params = thingWithParameters.parent ? thingWithParameters.parent.getCallbackParameters() :
 			thingWithParameters.getCallbackParameters();
 		// the initial batch operation's job is to delete the page, and that has
 		// succeeded by now
 		params.pageUndeleter.workerSuccess(thingWithParameters);
 
-		var query, wikipedia_api;
+		let query, wikipedia_api;
 
 		if (params.undel_talk) {
-			var talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
+			let talkpagename = new mw.Title(params.page).getTalkPage().getPrefixedText();
 			if (talkpagename !== params.page) {
 				query = {
 					action: 'query',
@@ -196,16 +196,16 @@ Twinkle.batchundelete.callbacks = {
 		}
 	},
 	undeleteTalk: function(apiobj) {
-		var page = apiobj.getResponse().query.pages[0];
-		var exists = !page.missing;
-		var delrevs = page.deletedrevisions && page.deletedrevisions[0].revid;
+		let page = apiobj.getResponse().query.pages[0];
+		let exists = !page.missing;
+		let delrevs = page.deletedrevisions && page.deletedrevisions[0].revid;
 
 		if (exists || !delrevs) {
 			// page exists or has no deleted revisions; forget about it
 			return;
 		}
 
-		var talkpage = new Morebits.wiki.page(apiobj.params.talkPage, 'Undeleting talk page of ' + apiobj.params.page);
+		let talkpage = new Morebits.wiki.page(apiobj.params.talkPage, 'Undeleting talk page of ' + apiobj.params.page);
 		talkpage.setEditSummary('Undeleting [[Help:Talk page|talk page]] of "' + apiobj.params.page + '"');
 		talkpage.setChangeTags(Twinkle.changeTags);
 		talkpage.undeletePage();

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -67,15 +67,11 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
-		pages = pages.filter((page) => {
-			return page.missing;
-		});
+		pages = pages.filter((page) => page.missing);
 		const list = [];
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach((page) => {
-			const editProt = page.protection.filter((pr) => {
-				return pr.type === 'create' && pr.level === 'sysop';
-			}).pop();
+			const editProt = page.protection.filter((pr) => pr.type === 'create' && pr.level === 'sysop').pop();
 
 			const title = page.title;
 			list.push({
@@ -122,9 +118,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 Twinkle.batchundelete.callback.evaluate = function(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch undeletion is now complete';
 
-	const numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter((element) => {
-		return element.checked && element.nextElementSibling.style.color === 'red';
-	}).length;
+	const numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter((element) => element.checked && element.nextElementSibling.style.color === 'red').length;
 	if (numProtected > 0 && !confirm('You are about to undelete ' + numProtected + ' fully create protected page(s). Are you sure?')) {
 		return;
 	}

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -213,7 +213,7 @@ Twinkle.batchundelete.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.batchundelete, 'batchundelete');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklebatchundelete.js
+++ b/modules/twinklebatchundelete.js
@@ -64,16 +64,16 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 		format: 'json'
 	};
 	const statelem = new Morebits.status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		let pages = (response.query && response.query.pages) || [];
-		pages = pages.filter(function(page) {
+		pages = pages.filter((page) => {
 			return page.missing;
 		});
 		const list = [];
 		pages.sort(Twinkle.sortByNamespace);
-		pages.forEach(function(page) {
-			const editProt = page.protection.filter(function(pr) {
+		pages.forEach((page) => {
+			const editProt = page.protection.filter((pr) => {
 				return pr.type === 'create' && pr.level === 'sysop';
 			}).pop();
 
@@ -114,7 +114,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 
 		Morebits.quickForm.getElements(result, 'pages').forEach(Twinkle.generateArrowLinks);
 
-	}, statelem);
+	}), statelem);
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();
 };
@@ -122,7 +122,7 @@ Twinkle.batchundelete.callback = function twinklebatchundeleteCallback() {
 Twinkle.batchundelete.callback.evaluate = function(event) {
 	Morebits.wiki.actionCompleted.notice = 'Batch undeletion is now complete';
 
-	const numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter(function(element) {
+	const numProtected = Morebits.quickForm.getElements(event.target, 'pages').filter((element) => {
 		return element.checked && element.nextElementSibling.style.color === 'red';
 	}).length;
 	if (numProtected > 0 && !confirm('You are about to undelete ' + numProtected + ' fully create protected page(s). Are you sure?')) {
@@ -147,7 +147,7 @@ Twinkle.batchundelete.callback.evaluate = function(event) {
 	pageUndeleter.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 	pageUndeleter.setOption('preserveIndividualStatusLines', true);
 	pageUndeleter.setPageList(input.pages);
-	pageUndeleter.run(function(pageName) {
+	pageUndeleter.run((pageName) => {
 		const params = {
 			page: pageName,
 			undel_talk: input.undel_talk,

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -3,8 +3,8 @@
 
 (function($) {
 
-var api = new mw.Api(), relevantUserName, blockedUserName;
-var menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
+let api = new mw.Api(), relevantUserName, blockedUserName;
+let menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
 menuFormattedNamespaces[0] = '(Article)';
 
 /*
@@ -34,7 +34,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
 
-	var Window = new Morebits.simpleWindow(650, 530);
+	let Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Block or issue block template to ' + relevantUserName);
 	Window.setScriptName('Twinkle');
@@ -47,8 +47,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	// Always added, hidden later if actual user not blocked
 	Window.addFooterLink('Unblock this user', 'Special:Unblock/' + relevantUserName, true);
 
-	var form = new Morebits.quickForm(Twinkle.block.callback.evaluate);
-	var actionfield = form.append({
+	let form = new Morebits.quickForm(Twinkle.block.callback.evaluate);
+	let actionfield = form.append({
 		type: 'field',
 		label: 'Type of action'
 	});
@@ -92,9 +92,9 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	  (mis)treated as separate by MediaWiki's logging ([[phab:T146628]]),
 	  using Morebits.ip.get64 provides a modicum of relief in thise case.
 	*/
-	var sixtyFour = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
+	let sixtyFour = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 	if (sixtyFour && sixtyFour !== mw.config.get('wgRelevantUserName')) {
-		var block64field = form.append({
+		let block64field = form.append({
 			type: 'field',
 			label: 'Convert to /64 rangeblock',
 			name: 'field_64'
@@ -124,7 +124,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 
 	form.append({ type: 'submit' });
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 	result.root = result;
@@ -140,7 +140,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		Twinkle.block.transformBlockPresets();
 
 		// init the controls after user and block info have been fetched
-		var evt = document.createEvent('Event');
+		let evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 
 		if (result.block64 && result.block64.checked) {
@@ -157,7 +157,7 @@ Twinkle.block.fetchedData = {};
 // Processes the data from a a query response, separated from
 // Twinkle.block.fetchUserInfo to allow reprocessing of already-fetched data
 Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
-	var blockinfo = data.query.blocks[0],
+	let blockinfo = data.query.blocks[0],
 		userinfo = data.query.users[0];
 	// If an IP is blocked *and* rangeblocked, the above finds
 	// whichever block is more recent, not necessarily correct.
@@ -187,7 +187,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 	blockedUserName = Twinkle.block.currentBlockInfo && Twinkle.block.currentBlockInfo.user;
 
 	// Toggle unblock link if not the user in question; always first
-	var unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
+	let unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
 	if (blockedUserName !== relevantUserName) {
 		unblockLink.hidden = true, unblockLink.nextSibling.hidden = true; // link+trailing bullet
 	} else {
@@ -212,7 +212,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 };
 
 Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
-	var query = {
+	let query = {
 		format: 'json',
 		action: 'query',
 		list: 'blocks|users|logevents',
@@ -250,11 +250,11 @@ Twinkle.block.callback.saveFieldset = function twinkleblockCallbacksaveFieldset(
 };
 
 Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock64(e) {
-	var $form = $(e.target.form), $block64 = $form.find('[name=block64]');
+	let $form = $(e.target.form), $block64 = $form.find('[name=block64]');
 
 	// Show/hide block64 button
 	// Single IPv6, or IPv6 range smaller than a /64
-	var priorName = relevantUserName;
+	let priorName = relevantUserName;
 	if ($block64.is(':checked')) {
 		relevantUserName = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 	} else {
@@ -262,20 +262,20 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 	}
 	// No templates for ranges, but if the original user is a single IP, offer the option
 	// (done separately in Twinkle.block.callback.issue_template)
-	var originalIsRange = Morebits.ip.isRange(mw.config.get('wgRelevantUserName'));
+	let originalIsRange = Morebits.ip.isRange(mw.config.get('wgRelevantUserName'));
 	$form.find('[name=actiontype][value=template]').prop('disabled', originalIsRange).prop('checked', !originalIsRange);
 
 	// Refetch/reprocess user info then regenerate the main content
-	var regenerateForm = function() {
+	let regenerateForm = function() {
 		// Tweak titlebar text.  In theory, we could save the dialog
 		// at initialization and then use `.setTitle` or
 		// `dialog('option', 'title')`, but in practice that swallows
 		// the scriptName and requires `.display`ing, which jumps the
 		// window.  It's just a line of text, so this is fine.
-		var titleBar = document.querySelector('.ui-dialog-title').firstChild.nextSibling;
+		let titleBar = document.querySelector('.ui-dialog-title').firstChild.nextSibling;
 		titleBar.nodeValue = titleBar.nodeValue.replace(priorName, relevantUserName);
 		// Tweak unblock link
-		var unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
+		let unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
 		unblockLink.href = unblockLink.href.replace(priorName, relevantUserName);
 		unblockLink.title = unblockLink.title.replace(priorName, relevantUserName);
 
@@ -297,18 +297,18 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 };
 
 Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction(e) {
-	var field_preset, field_template_options, field_block_options, $form = $(e.target.form);
+	let field_preset, field_template_options, field_block_options, $form = $(e.target.form);
 	// Make ifs shorter
-	var blockBox = $form.find('[name=actiontype][value=block]').is(':checked');
-	var templateBox = $form.find('[name=actiontype][value=template]').is(':checked');
-	var $partial = $form.find('[name=actiontype][value=partial]');
-	var partialBox = $partial.is(':checked');
-	var blockGroup = partialBox ? Twinkle.block.blockGroupsPartial : Twinkle.block.blockGroups;
+	let blockBox = $form.find('[name=actiontype][value=block]').is(':checked');
+	let templateBox = $form.find('[name=actiontype][value=template]').is(':checked');
+	let $partial = $form.find('[name=actiontype][value=partial]');
+	let partialBox = $partial.is(':checked');
+	let blockGroup = partialBox ? Twinkle.block.blockGroupsPartial : Twinkle.block.blockGroups;
 
 	$partial.prop('disabled', !blockBox && !templateBox);
 
 	// Add current block parameters as default preset
-	var prior = { label: 'Prior block' };
+	let prior = { label: 'Prior block' };
 	if (blockedUserName === relevantUserName) {
 		Twinkle.block.blockPresetsInfo.prior = Twinkle.block.currentBlockInfo;
 		// value not a valid template selection, chosen below by setting templateName
@@ -402,7 +402,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				value: '',
 				tooltip: '10 page max.'
 			});
-			var ns = field_block_options.append({
+			let ns = field_block_options.append({
 				type: 'select',
 				multiple: true,
 				name: 'namespacerestrictions',
@@ -418,7 +418,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			});
 		}
 
-		var blockoptions = [
+		let blockoptions = [
 			{
 				checked: Twinkle.block.field_block_options.nocreate,
 				label: 'Block account creation',
@@ -520,8 +520,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	Twinkle.block.dsinfo = Morebits.wiki.getCachedJson('Template:Ds/topics.json');
 
 	Twinkle.block.dsinfo.then(function(dsinfo) {
-		var $select = $('[name="dstopic"]');
-		var $options = $.map(dsinfo, function (value, key) {
+		let $select = $('[name="dstopic"]');
+		let $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
 		});
 		$select.append($options);
@@ -529,7 +529,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	// DS selection visible in either the template field set or preset,
 	// joint settings saved here
-	var dsSelectSettings = {
+	let dsSelectSettings = {
 		type: 'select',
 		name: 'dstopic',
 		label: 'DS topic',
@@ -623,7 +623,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			});
 		}
 
-		var $previewlink = $('<a id="twinkleblock-preview-link">Preview</a>');
+		let $previewlink = $('<a id="twinkleblock-preview-link">Preview</a>');
 		$previewlink.off('click').on('click', function() {
 			Twinkle.block.callback.preview($form[0]);
 		});
@@ -635,7 +635,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		field_preset.append(dsSelectSettings);
 	}
 
-	var oldfield;
+	let oldfield;
 	if (field_preset) {
 		oldfield = $form.find('fieldset[name="field_preset"]')[0];
 		oldfield.parentNode.replaceChild(field_preset.render(), oldfield);
@@ -664,7 +664,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				dataType: 'json',
 				delay: 100,
 				data: function(params) {
-					var title = mw.Title.newFromText(params.term);
+					let title = mw.Title.newFromText(params.term);
 					if (!title) {
 						return;
 					}
@@ -680,7 +680,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				processResults: function(data) {
 					return {
 						results: data.query.allpages.map(function(page) {
-							var title = mw.Title.newFromText(page.title, page.ns).toText();
+							let title = mw.Title.newFromText(page.title, page.ns).toText();
 							return {
 								id: title,
 								text: title
@@ -739,10 +739,10 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	if (Twinkle.block.currentBlockInfo) {
 		// false for an ip covered by a range or a smaller range within a larger range;
 		// true for a user, single ip block, or the exact range for a range block
-		var sameUser = blockedUserName === relevantUserName;
+		let sameUser = blockedUserName === relevantUserName;
 
 		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
-		var statusStr = relevantUserName + ' is ' + (Twinkle.block.currentBlockInfo.partial === '' ? 'partially blocked' : 'blocked sitewide');
+		let statusStr = relevantUserName + ' is ' + (Twinkle.block.currentBlockInfo.partial === '' ? 'partially blocked' : 'blocked sitewide');
 
 		// Range blocked
 		if (Twinkle.block.currentBlockInfo.rangestart !== Twinkle.block.currentBlockInfo.rangeend) {
@@ -751,7 +751,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			} else {
 				statusStr += ' within a' + (Morebits.ip.get64(relevantUserName) === blockedUserName ? ' /64' : '') + ' rangeblock';
 				// Link to the full range
-				var $rangeblockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: blockedUserName, type: 'block'}) + '">' + blockedUserName + '</a>)'));
+				let $rangeblockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: blockedUserName, type: 'block'}) + '">' + blockedUserName + '</a>)'));
 				statusStr += ' (' + $rangeblockloglink.html() + ')';
 			}
 		}
@@ -763,7 +763,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 
 
-		var infoStr = 'This form will';
+		let infoStr = 'This form will';
 		if (sameUser) {
 			infoStr += ' change that block';
 			if (Twinkle.block.currentBlockInfo.partial === undefined && partialBox) {
@@ -786,9 +786,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	// only return the correct block log if wgRelevantUserName is the
 	// exact range, not merely a funtional equivalent
 	if (Twinkle.block.hasBlockLog) {
-		var $blockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: relevantUserName, type: 'block'}) + '">block log</a>)'));
+		let $blockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: relevantUserName, type: 'block'}) + '">block log</a>)'));
 		if (!Twinkle.block.currentBlockInfo) {
-			var lastBlockAction = Twinkle.block.blockLog[0];
+			let lastBlockAction = Twinkle.block.blockLog[0];
 			if (lastBlockAction.action === 'unblock') {
 				$blockloglink.append(' (unblocked ' + new Morebits.date(lastBlockAction.timestamp).calendar('utc') + ')');
 			} else { // block or reblock
@@ -1453,7 +1453,7 @@ Twinkle.block.blockGroupsPartial = [
 
 Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(group, show_template) {
 	return $.map(group, function(blockGroup) {
-		var list = $.map(blockGroup.list, function(blockPreset) {
+		let list = $.map(blockGroup.list, function(blockPreset) {
 			switch (blockPreset.value) {
 				case 'uw-talkrevoked':
 					if (blockedUserName !== relevantUserName) {
@@ -1482,9 +1482,9 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 					break;
 			}
 
-			var blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
+			let blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
 
-			var registrationRestrict;
+			let registrationRestrict;
 			if (blockSettings.forRegisteredOnly) {
 				registrationRestrict = Twinkle.block.isRegistered;
 			} else if (blockSettings.forUnregisteredOnly) {
@@ -1494,7 +1494,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 			}
 
 			if (!(blockSettings.templateName && show_template) && registrationRestrict) {
-				var templateName = blockSettings.templateName || blockPreset.value;
+				let templateName = blockSettings.templateName || blockPreset.value;
 				return {
 					label: (show_template ? '{{' + templateName + '}}: ' : '') + blockPreset.label,
 					value: blockPreset.value,
@@ -1517,7 +1517,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 };
 
 Twinkle.block.callback.change_preset = function twinkleblockCallbackChangePreset(e) {
-	var form = e.target.form, key = form.preset.value;
+	let form = e.target.form, key = form.preset.value;
 	if (!key) {
 		return;
 	}
@@ -1532,7 +1532,7 @@ Twinkle.block.callback.change_preset = function twinkleblockCallbackChangePreset
 };
 
 Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry(e) {
-	var expiry = e.target.form.expiry;
+	let expiry = e.target.form.expiry;
 	if (e.target.value === 'custom') {
 		Morebits.quickForm.setElementVisibility(expiry.parentNode, true);
 	} else {
@@ -1543,7 +1543,7 @@ Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry
 
 Twinkle.block.seeAlsos = [];
 Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSeeAlso() {
-	var reason = this.form.reason.value.replace(
+	let reason = this.form.reason.value.replace(
 		new RegExp('( <!--|;) ' + 'see also ' + Twinkle.block.seeAlsos.join(' and ') + '( -->)?'), ''
 	);
 
@@ -1554,7 +1554,7 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 	if (this.checked) {
 		Twinkle.block.seeAlsos.push(this.value);
 	}
-	var seeAlsoMessage = Twinkle.block.seeAlsos.join(' and ');
+	let seeAlsoMessage = Twinkle.block.seeAlsos.join(' and ');
 
 	if (!Twinkle.block.seeAlsos.length) {
 		this.form.reason.value = reason;
@@ -1567,13 +1567,13 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 
 Twinkle.block.dsReason = '';
 Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSReason() {
-	var reason = this.form.reason.value.replace(
+	let reason = this.form.reason.value.replace(
 		new RegExp(' ?\\(\\[\\[' + Twinkle.block.dsReason + '\\]\\]\\)'), ''
 	);
 
 	Twinkle.block.dsinfo.then(function(dsinfo) {
-		var sanctionCode = this.selectedIndex;
-		var sanctionName = this.options[sanctionCode].label;
+		let sanctionCode = this.selectedIndex;
+		let sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;
 		if (!this.value) {
 			this.form.reason.value = reason;
@@ -1584,7 +1584,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 };
 
 Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {
-	var form = e.target.form, expiry = data.expiry;
+	let form = e.target.form, expiry = data.expiry;
 
 	// don't override original expiry if useInitialOptions is set
 	if (!data.useInitialOptions) {
@@ -1618,7 +1618,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 			return;
 		}
 
-		var check = data[el.name] === '' || !!data[el.name];
+		let check = data[el.name] === '' || !!data[el.name];
 		$(el).prop('checked', check);
 	});
 
@@ -1630,8 +1630,8 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 
 	// Clear and/or set any partial page or namespace restrictions
 	if (form.pagerestrictions) {
-		var $pageSelect = $(form).find('[name=pagerestrictions]');
-		var $namespaceSelect = $(form).find('[name=namespacerestrictions]');
+		let $pageSelect = $(form).find('[name=pagerestrictions]');
+		let $namespaceSelect = $(form).find('[name=namespacerestrictions]');
 
 		// Respect useInitialOptions by clearing data when switching presets
 		// In practice, this will always clear, since no partial presets use it
@@ -1643,14 +1643,14 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		// Add any preset options; in practice, just used for prior block settings
 		if (data.restrictions) {
 			if (data.restrictions.pages && !$pageSelect.val().length) {
-				var pages = data.restrictions.pages.map(function(pr) {
+				let pages = data.restrictions.pages.map(function(pr) {
 					return pr.title;
 				});
 				// since page restrictions use an ajax source, we
 				// short-circuit that and just add a new option
 				pages.forEach(function(page) {
 					if (!$pageSelect.find("option[value='" + $.escapeSelector(page) + "']").length) {
-						var newOption = new Option(page, page, true, true);
+						let newOption = new Option(page, page, true, true);
 						$pageSelect.append(newOption);
 					}
 				});
@@ -1664,11 +1664,11 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 };
 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
-	var form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
+	let form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
 
-	var blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
-	var partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
-	var templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
+	let blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
+	let partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
+	let templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
 
 	// Block form is not present
 	if (!blockBox) {
@@ -1713,7 +1713,7 @@ Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemp
 Twinkle.block.prev_template_expiry = null;
 
 Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
-	var params = {
+	let params = {
 		article: form.article.value,
 		blank_duration: form.blank_duration ? form.blank_duration.checked : false,
 		disabletalk: form.disabletalk.checked || (form.notalk ? form.notalk.checked : false),
@@ -1731,13 +1731,13 @@ Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
 		area: form.area.value
 	};
 
-	var templateText = Twinkle.block.callback.getBlockNoticeWikitext(params);
+	let templateText = Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	form.previewer.beginRender(templateText, 'User_talk:' + relevantUserName); // Force wikitext/correct username
 };
 
 Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
-	var $form = $(e.target),
+	let $form = $(e.target),
 		toBlock = $form.find('[name=actiontype][value=block]').is(':checked'),
 		toWarn = $form.find('[name=actiontype][value=template]').is(':checked'),
 		toPartial = $form.find('[name=actiontype][value=partial]').is(':checked'),
@@ -1795,7 +1795,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 
 		Morebits.simpleWindow.setButtonsEnabled(false);
 		Morebits.status.init(e.target);
-		var statusElement = new Morebits.status('Executing block');
+		let statusElement = new Morebits.status('Executing block');
 		blockoptions.action = 'block';
 
 		blockoptions.user = relevantUserName;
@@ -1830,7 +1830,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		  a block expired (different statuses, confirmation) or the
 		  same block is still active (same status, no confirmation).
 		*/
-		var query = {
+		let query = {
 			format: 'json',
 			action: 'query',
 			list: 'blocks|logevents',
@@ -1845,7 +1845,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			query.bkusers = blockoptions.user;
 		}
 		api.get(query).then(function(data) {
-			var block = data.query.blocks[0];
+			let block = data.query.blocks[0];
 			// As with the initial data fetch, if an IP is blocked
 			// *and* rangeblocked, this would only grab whichever
 			// block is more recent, which would likely mean a
@@ -1855,23 +1855,23 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			if (data.query.blocks.length > 1 && block.user !== relevantUserName) {
 				block = data.query.blocks[1];
 			}
-			var logevents = data.query.logevents[0];
-			var logid = data.query.logevents.length ? logevents.logid : false;
+			let logevents = data.query.logevents[0];
+			let logid = data.query.logevents.length ? logevents.logid : false;
 
 			if (logid !== Twinkle.block.blockLogId || !!block !== !!Twinkle.block.currentBlockInfo) {
-				var message = 'The block status of ' + blockoptions.user + ' has changed. ';
+				let message = 'The block status of ' + blockoptions.user + ' has changed. ';
 				if (block) {
 					message += 'New status: ';
 				} else {
 					message += 'Last entry: ';
 				}
 
-				var logExpiry = '';
+				let logExpiry = '';
 				if (logevents.params.duration) {
 					if (logevents.params.duration === 'infinity') {
 						logExpiry = 'indefinitely';
 					} else {
-						var expiryDate = new Morebits.date(logevents.params.expiry);
+						let expiryDate = new Morebits.date(logevents.params.expiry);
 						logExpiry += (expiryDate.isBefore(new Date()) ? ', expired ' : ' until ') + expiryDate.calendar();
 					}
 				} else { // no duration, action=unblock, just show timestamp
@@ -1890,7 +1890,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			// execute block
 			blockoptions.tags = Twinkle.changeTags;
 			blockoptions.token = mw.user.tokens.get('csrfToken');
-			var mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
+			let mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
 				statusElement.info('Completed');
 				if (toWarn) {
 					Twinkle.block.callback.issue_template(templateoptions);
@@ -1911,9 +1911,9 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTemplate(formData) {
 	// Use wgRelevantUserName to ensure the block template goes to a single IP and not to the
 	// "talk page" of an IP range (which does not exist)
-	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
+	let userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
-	var params = $.extend(formData, {
+	let params = $.extend(formData, {
 		messageData: Twinkle.block.blockPresetsInfo[formData.template],
 		reason: Twinkle.block.field_template_options.block_reason,
 		disabletalk: Twinkle.block.field_template_options.notalk,
@@ -1924,13 +1924,13 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Actions complete, loading user talk page in a few seconds';
 
-	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
 
 Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
-	var text = '{{', settings = Twinkle.block.blockPresetsInfo[params.template];
+	let text = '{{', settings = Twinkle.block.blockPresetsInfo[params.template];
 	if (!settings.nonstandard) {
 		text += 'subst:' + params.template;
 		if (params.article && settings.pageParam) {
@@ -1964,11 +1964,11 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 		// Building the template, however, takes a fair bit of logic
 		if (params.partial) {
 			if (params.pagerestrictions.length || params.namespacerestrictions.length) {
-				var makeSentence = function (array) {
+				let makeSentence = function (array) {
 					if (array.length < 3) {
 						return array.join(' and ');
 					}
-					var last = array.pop();
+					let last = array.pop();
 					return array.join(', ') + ', and ' + last;
 
 				};
@@ -1981,7 +1981,7 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 				}
 				if (params.namespacerestrictions.length) {
 					// 1 => Talk, 2 => User, etc.
-					var namespaceNames = params.namespacerestrictions.map(function(id) {
+					let namespaceNames = params.namespacerestrictions.map(function(id) {
 						return menuFormattedNamespaces[id];
 					});
 					text += '[[Wikipedia:Namespace|namespaces]] (' + makeSentence(namespaceNames) + ')';
@@ -2008,7 +2008,7 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 };
 
 Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
-	var params = pageobj.getCallbackParameters(),
+	let params = pageobj.getCallbackParameters(),
 		date = new Morebits.date(pageobj.getLoadTime()),
 		messageData = params.messageData,
 		text;
@@ -2021,14 +2021,14 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	} else {
 		text = pageobj.getPageText();
 
-		var dateHeaderRegex = date.monthHeaderRegex(), dateHeaderRegexLast, dateHeaderRegexResult;
+		let dateHeaderRegex = date.monthHeaderRegex(), dateHeaderRegexLast, dateHeaderRegexResult;
 		while ((dateHeaderRegexLast = dateHeaderRegex.exec(text)) !== null) {
 			dateHeaderRegexResult = dateHeaderRegexLast;
 		}
 		// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
 		// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
 		// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
-		var lastHeaderIndex = text.lastIndexOf('\n==') + 1;
+		let lastHeaderIndex = text.lastIndexOf('\n==') + 1;
 
 		if (text.length > 0) {
 			text += '\n\n';
@@ -2045,7 +2045,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 	text += Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	// build the edit summary
-	var summary = messageData.summary;
+	let summary = messageData.summary;
 	if (messageData.suppressArticleInSummary !== true && params.article) {
 		summary += ' on [[:' + params.article + ']]';
 	}

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -170,9 +170,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 
 	Twinkle.block.isRegistered = !!userinfo.userid;
 	if (Twinkle.block.isRegistered) {
-		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map((e) => {
-			return e.group;
-		}).indexOf('bot') !== -1;
+		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map((e) => e.group).indexOf('bot') !== -1;
 	} else {
 		Twinkle.block.userIsBot = false;
 	}
@@ -315,9 +313,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		prior.list = [{ label: 'Prior block settings', value: 'prior', selected: true }];
 
 		// Arrays of objects are annoying to check
-		if (!blockGroup.some((bg) => {
-			return bg.label === prior.label;
-		})) {
+		if (!blockGroup.some((bg) => bg.label === prior.label)) {
 			blockGroup.push(prior);
 		}
 
@@ -333,9 +329,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 	} else {
 		// But first remove any prior prior
-		blockGroup = blockGroup.filter((bg) => {
-			return bg.label !== prior.label;
-		});
+		blockGroup = blockGroup.filter((bg) => bg.label !== prior.label);
 	}
 
 	// Can be in preset or template field, so the old one in the template
@@ -521,9 +515,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	Twinkle.block.dsinfo.then((dsinfo) => {
 		const $select = $('[name="dstopic"]');
-		const $options = $.map(dsinfo, (value, key) => {
-			return $('<option>').val(value.code).text(key).prop('label', key);
-		});
+		const $options = $.map(dsinfo, (value, key) => $('<option>').val(value.code).text(key).prop('label', key));
 		$select.append($options);
 	});
 
@@ -1547,9 +1539,7 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 		new RegExp('( <!--|;) ' + 'see also ' + Twinkle.block.seeAlsos.join(' and ') + '( -->)?'), ''
 	);
 
-	Twinkle.block.seeAlsos = Twinkle.block.seeAlsos.filter((el) => {
-		return el !== this.value;
-	});
+	Twinkle.block.seeAlsos = Twinkle.block.seeAlsos.filter((el) => el !== this.value);
 
 	if (this.checked) {
 		Twinkle.block.seeAlsos.push(this.value);
@@ -1643,9 +1633,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		// Add any preset options; in practice, just used for prior block settings
 		if (data.restrictions) {
 			if (data.restrictions.pages && !$pageSelect.val().length) {
-				const pages = data.restrictions.pages.map((pr) => {
-					return pr.title;
-				});
+				const pages = data.restrictions.pages.map((pr) => pr.title);
 				// since page restrictions use an ajax source, we
 				// short-circuit that and just add a new option
 				pages.forEach((page) => {
@@ -1974,16 +1962,12 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 				};
 				text += '|area=' + (params.indefinite ? 'certain ' : 'from certain ');
 				if (params.pagerestrictions.length) {
-					text += 'pages (' + makeSentence(params.pagerestrictions.map((p) => {
-						return '[[:' + p + ']]';
-					}));
+					text += 'pages (' + makeSentence(params.pagerestrictions.map((p) => '[[:' + p + ']]'));
 					text += params.namespacerestrictions.length ? ') and certain ' : ')';
 				}
 				if (params.namespacerestrictions.length) {
 					// 1 => Talk, 2 => User, etc.
-					const namespaceNames = params.namespacerestrictions.map((id) => {
-						return menuFormattedNamespaces[id];
-					});
+					const namespaceNames = params.namespacerestrictions.map((id) => menuFormattedNamespaces[id]);
 					text += '[[Wikipedia:Namespace|namespaces]] (' + makeSentence(namespaceNames) + ')';
 				}
 			} else if (params.area) {

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -4,7 +4,7 @@
 (function($) {
 
 let api = new mw.Api(), relevantUserName, blockedUserName;
-let menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
+const menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
 menuFormattedNamespaces[0] = '(Article)';
 
 /*
@@ -34,7 +34,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
 
-	let Window = new Morebits.simpleWindow(650, 530);
+	const Window = new Morebits.simpleWindow(650, 530);
 	// need to be verbose about who we're blocking
 	Window.setTitle('Block or issue block template to ' + relevantUserName);
 	Window.setScriptName('Twinkle');
@@ -47,8 +47,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	// Always added, hidden later if actual user not blocked
 	Window.addFooterLink('Unblock this user', 'Special:Unblock/' + relevantUserName, true);
 
-	let form = new Morebits.quickForm(Twinkle.block.callback.evaluate);
-	let actionfield = form.append({
+	const form = new Morebits.quickForm(Twinkle.block.callback.evaluate);
+	const actionfield = form.append({
 		type: 'field',
 		label: 'Type of action'
 	});
@@ -92,9 +92,9 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	  (mis)treated as separate by MediaWiki's logging ([[phab:T146628]]),
 	  using Morebits.ip.get64 provides a modicum of relief in thise case.
 	*/
-	let sixtyFour = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
+	const sixtyFour = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 	if (sixtyFour && sixtyFour !== mw.config.get('wgRelevantUserName')) {
-		let block64field = form.append({
+		const block64field = form.append({
 			type: 'field',
 			label: 'Convert to /64 rangeblock',
 			name: 'field_64'
@@ -124,7 +124,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 
 	form.append({ type: 'submit' });
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 	result.root = result;
@@ -140,7 +140,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 		Twinkle.block.transformBlockPresets();
 
 		// init the controls after user and block info have been fetched
-		let evt = document.createEvent('Event');
+		const evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 
 		if (result.block64 && result.block64.checked) {
@@ -187,7 +187,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 	blockedUserName = Twinkle.block.currentBlockInfo && Twinkle.block.currentBlockInfo.user;
 
 	// Toggle unblock link if not the user in question; always first
-	let unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
+	const unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
 	if (blockedUserName !== relevantUserName) {
 		unblockLink.hidden = true, unblockLink.nextSibling.hidden = true; // link+trailing bullet
 	} else {
@@ -212,7 +212,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 };
 
 Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
-	let query = {
+	const query = {
 		format: 'json',
 		action: 'query',
 		list: 'blocks|users|logevents',
@@ -250,11 +250,11 @@ Twinkle.block.callback.saveFieldset = function twinkleblockCallbacksaveFieldset(
 };
 
 Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock64(e) {
-	let $form = $(e.target.form), $block64 = $form.find('[name=block64]');
+	const $form = $(e.target.form), $block64 = $form.find('[name=block64]');
 
 	// Show/hide block64 button
 	// Single IPv6, or IPv6 range smaller than a /64
-	let priorName = relevantUserName;
+	const priorName = relevantUserName;
 	if ($block64.is(':checked')) {
 		relevantUserName = Morebits.ip.get64(mw.config.get('wgRelevantUserName'));
 	} else {
@@ -262,20 +262,20 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 	}
 	// No templates for ranges, but if the original user is a single IP, offer the option
 	// (done separately in Twinkle.block.callback.issue_template)
-	let originalIsRange = Morebits.ip.isRange(mw.config.get('wgRelevantUserName'));
+	const originalIsRange = Morebits.ip.isRange(mw.config.get('wgRelevantUserName'));
 	$form.find('[name=actiontype][value=template]').prop('disabled', originalIsRange).prop('checked', !originalIsRange);
 
 	// Refetch/reprocess user info then regenerate the main content
-	let regenerateForm = function() {
+	const regenerateForm = function() {
 		// Tweak titlebar text.  In theory, we could save the dialog
 		// at initialization and then use `.setTitle` or
 		// `dialog('option', 'title')`, but in practice that swallows
 		// the scriptName and requires `.display`ing, which jumps the
 		// window.  It's just a line of text, so this is fine.
-		let titleBar = document.querySelector('.ui-dialog-title').firstChild.nextSibling;
+		const titleBar = document.querySelector('.ui-dialog-title').firstChild.nextSibling;
 		titleBar.nodeValue = titleBar.nodeValue.replace(priorName, relevantUserName);
 		// Tweak unblock link
-		let unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
+		const unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
 		unblockLink.href = unblockLink.href.replace(priorName, relevantUserName);
 		unblockLink.title = unblockLink.title.replace(priorName, relevantUserName);
 
@@ -299,16 +299,16 @@ Twinkle.block.callback.change_block64 = function twinkleblockCallbackChangeBlock
 Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction(e) {
 	let field_preset, field_template_options, field_block_options, $form = $(e.target.form);
 	// Make ifs shorter
-	let blockBox = $form.find('[name=actiontype][value=block]').is(':checked');
-	let templateBox = $form.find('[name=actiontype][value=template]').is(':checked');
-	let $partial = $form.find('[name=actiontype][value=partial]');
-	let partialBox = $partial.is(':checked');
+	const blockBox = $form.find('[name=actiontype][value=block]').is(':checked');
+	const templateBox = $form.find('[name=actiontype][value=template]').is(':checked');
+	const $partial = $form.find('[name=actiontype][value=partial]');
+	const partialBox = $partial.is(':checked');
 	let blockGroup = partialBox ? Twinkle.block.blockGroupsPartial : Twinkle.block.blockGroups;
 
 	$partial.prop('disabled', !blockBox && !templateBox);
 
 	// Add current block parameters as default preset
-	let prior = { label: 'Prior block' };
+	const prior = { label: 'Prior block' };
 	if (blockedUserName === relevantUserName) {
 		Twinkle.block.blockPresetsInfo.prior = Twinkle.block.currentBlockInfo;
 		// value not a valid template selection, chosen below by setting templateName
@@ -402,7 +402,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				value: '',
 				tooltip: '10 page max.'
 			});
-			let ns = field_block_options.append({
+			const ns = field_block_options.append({
 				type: 'select',
 				multiple: true,
 				name: 'namespacerestrictions',
@@ -418,7 +418,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			});
 		}
 
-		let blockoptions = [
+		const blockoptions = [
 			{
 				checked: Twinkle.block.field_block_options.nocreate,
 				label: 'Block account creation',
@@ -520,8 +520,8 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	Twinkle.block.dsinfo = Morebits.wiki.getCachedJson('Template:Ds/topics.json');
 
 	Twinkle.block.dsinfo.then(function(dsinfo) {
-		let $select = $('[name="dstopic"]');
-		let $options = $.map(dsinfo, function (value, key) {
+		const $select = $('[name="dstopic"]');
+		const $options = $.map(dsinfo, function (value, key) {
 			return $('<option>').val(value.code).text(key).prop('label', key);
 		});
 		$select.append($options);
@@ -529,7 +529,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 
 	// DS selection visible in either the template field set or preset,
 	// joint settings saved here
-	let dsSelectSettings = {
+	const dsSelectSettings = {
 		type: 'select',
 		name: 'dstopic',
 		label: 'DS topic',
@@ -623,7 +623,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			});
 		}
 
-		let $previewlink = $('<a id="twinkleblock-preview-link">Preview</a>');
+		const $previewlink = $('<a id="twinkleblock-preview-link">Preview</a>');
 		$previewlink.off('click').on('click', function() {
 			Twinkle.block.callback.preview($form[0]);
 		});
@@ -664,7 +664,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				dataType: 'json',
 				delay: 100,
 				data: function(params) {
-					let title = mw.Title.newFromText(params.term);
+					const title = mw.Title.newFromText(params.term);
 					if (!title) {
 						return;
 					}
@@ -680,7 +680,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				processResults: function(data) {
 					return {
 						results: data.query.allpages.map(function(page) {
-							let title = mw.Title.newFromText(page.title, page.ns).toText();
+							const title = mw.Title.newFromText(page.title, page.ns).toText();
 							return {
 								id: title,
 								text: title
@@ -739,7 +739,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	if (Twinkle.block.currentBlockInfo) {
 		// false for an ip covered by a range or a smaller range within a larger range;
 		// true for a user, single ip block, or the exact range for a range block
-		let sameUser = blockedUserName === relevantUserName;
+		const sameUser = blockedUserName === relevantUserName;
 
 		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
 		let statusStr = relevantUserName + ' is ' + (Twinkle.block.currentBlockInfo.partial === '' ? 'partially blocked' : 'blocked sitewide');
@@ -751,7 +751,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 			} else {
 				statusStr += ' within a' + (Morebits.ip.get64(relevantUserName) === blockedUserName ? ' /64' : '') + ' rangeblock';
 				// Link to the full range
-				let $rangeblockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: blockedUserName, type: 'block'}) + '">' + blockedUserName + '</a>)'));
+				const $rangeblockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: blockedUserName, type: 'block'}) + '">' + blockedUserName + '</a>)'));
 				statusStr += ' (' + $rangeblockloglink.html() + ')';
 			}
 		}
@@ -786,9 +786,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	// only return the correct block log if wgRelevantUserName is the
 	// exact range, not merely a funtional equivalent
 	if (Twinkle.block.hasBlockLog) {
-		let $blockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: relevantUserName, type: 'block'}) + '">block log</a>)'));
+		const $blockloglink = $('<span>').append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: relevantUserName, type: 'block'}) + '">block log</a>)'));
 		if (!Twinkle.block.currentBlockInfo) {
-			let lastBlockAction = Twinkle.block.blockLog[0];
+			const lastBlockAction = Twinkle.block.blockLog[0];
 			if (lastBlockAction.action === 'unblock') {
 				$blockloglink.append(' (unblocked ' + new Morebits.date(lastBlockAction.timestamp).calendar('utc') + ')');
 			} else { // block or reblock
@@ -1453,7 +1453,7 @@ Twinkle.block.blockGroupsPartial = [
 
 Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(group, show_template) {
 	return $.map(group, function(blockGroup) {
-		let list = $.map(blockGroup.list, function(blockPreset) {
+		const list = $.map(blockGroup.list, function(blockPreset) {
 			switch (blockPreset.value) {
 				case 'uw-talkrevoked':
 					if (blockedUserName !== relevantUserName) {
@@ -1482,7 +1482,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 					break;
 			}
 
-			let blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
+			const blockSettings = Twinkle.block.blockPresetsInfo[blockPreset.value];
 
 			let registrationRestrict;
 			if (blockSettings.forRegisteredOnly) {
@@ -1494,7 +1494,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 			}
 
 			if (!(blockSettings.templateName && show_template) && registrationRestrict) {
-				let templateName = blockSettings.templateName || blockPreset.value;
+				const templateName = blockSettings.templateName || blockPreset.value;
 				return {
 					label: (show_template ? '{{' + templateName + '}}: ' : '') + blockPreset.label,
 					value: blockPreset.value,
@@ -1517,7 +1517,7 @@ Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilt
 };
 
 Twinkle.block.callback.change_preset = function twinkleblockCallbackChangePreset(e) {
-	let form = e.target.form, key = form.preset.value;
+	const form = e.target.form, key = form.preset.value;
 	if (!key) {
 		return;
 	}
@@ -1532,7 +1532,7 @@ Twinkle.block.callback.change_preset = function twinkleblockCallbackChangePreset
 };
 
 Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry(e) {
-	let expiry = e.target.form.expiry;
+	const expiry = e.target.form.expiry;
 	if (e.target.value === 'custom') {
 		Morebits.quickForm.setElementVisibility(expiry.parentNode, true);
 	} else {
@@ -1543,7 +1543,7 @@ Twinkle.block.callback.change_expiry = function twinkleblockCallbackChangeExpiry
 
 Twinkle.block.seeAlsos = [];
 Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSeeAlso() {
-	let reason = this.form.reason.value.replace(
+	const reason = this.form.reason.value.replace(
 		new RegExp('( <!--|;) ' + 'see also ' + Twinkle.block.seeAlsos.join(' and ') + '( -->)?'), ''
 	);
 
@@ -1554,7 +1554,7 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 	if (this.checked) {
 		Twinkle.block.seeAlsos.push(this.value);
 	}
-	let seeAlsoMessage = Twinkle.block.seeAlsos.join(' and ');
+	const seeAlsoMessage = Twinkle.block.seeAlsos.join(' and ');
 
 	if (!Twinkle.block.seeAlsos.length) {
 		this.form.reason.value = reason;
@@ -1567,13 +1567,13 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 
 Twinkle.block.dsReason = '';
 Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSReason() {
-	let reason = this.form.reason.value.replace(
+	const reason = this.form.reason.value.replace(
 		new RegExp(' ?\\(\\[\\[' + Twinkle.block.dsReason + '\\]\\]\\)'), ''
 	);
 
 	Twinkle.block.dsinfo.then(function(dsinfo) {
-		let sanctionCode = this.selectedIndex;
-		let sanctionName = this.options[sanctionCode].label;
+		const sanctionCode = this.selectedIndex;
+		const sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;
 		if (!this.value) {
 			this.form.reason.value = reason;
@@ -1618,7 +1618,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 			return;
 		}
 
-		let check = data[el.name] === '' || !!data[el.name];
+		const check = data[el.name] === '' || !!data[el.name];
 		$(el).prop('checked', check);
 	});
 
@@ -1630,8 +1630,8 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 
 	// Clear and/or set any partial page or namespace restrictions
 	if (form.pagerestrictions) {
-		let $pageSelect = $(form).find('[name=pagerestrictions]');
-		let $namespaceSelect = $(form).find('[name=namespacerestrictions]');
+		const $pageSelect = $(form).find('[name=pagerestrictions]');
+		const $namespaceSelect = $(form).find('[name=namespacerestrictions]');
 
 		// Respect useInitialOptions by clearing data when switching presets
 		// In practice, this will always clear, since no partial presets use it
@@ -1643,14 +1643,14 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		// Add any preset options; in practice, just used for prior block settings
 		if (data.restrictions) {
 			if (data.restrictions.pages && !$pageSelect.val().length) {
-				let pages = data.restrictions.pages.map(function(pr) {
+				const pages = data.restrictions.pages.map(function(pr) {
 					return pr.title;
 				});
 				// since page restrictions use an ajax source, we
 				// short-circuit that and just add a new option
 				pages.forEach(function(page) {
 					if (!$pageSelect.find("option[value='" + $.escapeSelector(page) + "']").length) {
-						let newOption = new Option(page, page, true, true);
+						const newOption = new Option(page, page, true, true);
 						$pageSelect.append(newOption);
 					}
 				});
@@ -1664,11 +1664,11 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 };
 
 Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemplate(e) {
-	let form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
+	const form = e.target.form, value = form.template.value, settings = Twinkle.block.blockPresetsInfo[value];
 
-	let blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
-	let partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
-	let templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
+	const blockBox = $(form).find('[name=actiontype][value=block]').is(':checked');
+	const partialBox = $(form).find('[name=actiontype][value=partial]').is(':checked');
+	const templateBox = $(form).find('[name=actiontype][value=template]').is(':checked');
 
 	// Block form is not present
 	if (!blockBox) {
@@ -1713,7 +1713,7 @@ Twinkle.block.callback.change_template = function twinkleblockcallbackChangeTemp
 Twinkle.block.prev_template_expiry = null;
 
 Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
-	let params = {
+	const params = {
 		article: form.article.value,
 		blank_duration: form.blank_duration ? form.blank_duration.checked : false,
 		disabletalk: form.disabletalk.checked || (form.notalk ? form.notalk.checked : false),
@@ -1731,7 +1731,7 @@ Twinkle.block.callback.preview = function twinkleblockcallbackPreview(form) {
 		area: form.area.value
 	};
 
-	let templateText = Twinkle.block.callback.getBlockNoticeWikitext(params);
+	const templateText = Twinkle.block.callback.getBlockNoticeWikitext(params);
 
 	form.previewer.beginRender(templateText, 'User_talk:' + relevantUserName); // Force wikitext/correct username
 };
@@ -1795,7 +1795,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 
 		Morebits.simpleWindow.setButtonsEnabled(false);
 		Morebits.status.init(e.target);
-		let statusElement = new Morebits.status('Executing block');
+		const statusElement = new Morebits.status('Executing block');
 		blockoptions.action = 'block';
 
 		blockoptions.user = relevantUserName;
@@ -1830,7 +1830,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		  a block expired (different statuses, confirmation) or the
 		  same block is still active (same status, no confirmation).
 		*/
-		let query = {
+		const query = {
 			format: 'json',
 			action: 'query',
 			list: 'blocks|logevents',
@@ -1855,8 +1855,8 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			if (data.query.blocks.length > 1 && block.user !== relevantUserName) {
 				block = data.query.blocks[1];
 			}
-			let logevents = data.query.logevents[0];
-			let logid = data.query.logevents.length ? logevents.logid : false;
+			const logevents = data.query.logevents[0];
+			const logid = data.query.logevents.length ? logevents.logid : false;
 
 			if (logid !== Twinkle.block.blockLogId || !!block !== !!Twinkle.block.currentBlockInfo) {
 				let message = 'The block status of ' + blockoptions.user + ' has changed. ';
@@ -1871,7 +1871,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 					if (logevents.params.duration === 'infinity') {
 						logExpiry = 'indefinitely';
 					} else {
-						let expiryDate = new Morebits.date(logevents.params.expiry);
+						const expiryDate = new Morebits.date(logevents.params.expiry);
 						logExpiry += (expiryDate.isBefore(new Date()) ? ', expired ' : ' until ') + expiryDate.calendar();
 					}
 				} else { // no duration, action=unblock, just show timestamp
@@ -1890,7 +1890,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			// execute block
 			blockoptions.tags = Twinkle.changeTags;
 			blockoptions.token = mw.user.tokens.get('csrfToken');
-			let mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
+			const mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
 				statusElement.info('Completed');
 				if (toWarn) {
 					Twinkle.block.callback.issue_template(templateoptions);
@@ -1911,9 +1911,9 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTemplate(formData) {
 	// Use wgRelevantUserName to ensure the block template goes to a single IP and not to the
 	// "talk page" of an IP range (which does not exist)
-	let userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
+	const userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
-	let params = $.extend(formData, {
+	const params = $.extend(formData, {
 		messageData: Twinkle.block.blockPresetsInfo[formData.template],
 		reason: Twinkle.block.field_template_options.block_reason,
 		disabletalk: Twinkle.block.field_template_options.notalk,
@@ -1924,7 +1924,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Actions complete, loading user talk page in a few seconds';
 
-	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	const wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.block.callback.main);
 };
@@ -1964,11 +1964,11 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 		// Building the template, however, takes a fair bit of logic
 		if (params.partial) {
 			if (params.pagerestrictions.length || params.namespacerestrictions.length) {
-				let makeSentence = function (array) {
+				const makeSentence = function (array) {
 					if (array.length < 3) {
 						return array.join(' and ');
 					}
-					let last = array.pop();
+					const last = array.pop();
 					return array.join(', ') + ', and ' + last;
 
 				};
@@ -1981,7 +1981,7 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 				}
 				if (params.namespacerestrictions.length) {
 					// 1 => Talk, 2 => User, etc.
-					let namespaceNames = params.namespacerestrictions.map(function(id) {
+					const namespaceNames = params.namespacerestrictions.map(function(id) {
 						return menuFormattedNamespaces[id];
 					});
 					text += '[[Wikipedia:Namespace|namespaces]] (' + makeSentence(namespaceNames) + ')';
@@ -2028,7 +2028,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 		// If dateHeaderRegexResult is null then lastHeaderIndex is never checked. If it is not null but
 		// \n== is not found, then the date header must be at the very start of the page. lastIndexOf
 		// returns -1 in this case, so lastHeaderIndex gets set to 0 as desired.
-		let lastHeaderIndex = text.lastIndexOf('\n==') + 1;
+		const lastHeaderIndex = text.lastIndexOf('\n==') + 1;
 
 		if (text.length > 0) {
 			text += '\n\n';

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -2059,7 +2059,7 @@ Twinkle.block.callback.main = function twinkleblockcallbackMain(pageobj) {
 };
 
 Twinkle.addInitCallback(Twinkle.block, 'block');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -129,7 +129,7 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Window.display();
 	result.root = result;
 
-	Twinkle.block.fetchUserInfo(function() {
+	Twinkle.block.fetchUserInfo(() => {
 		// Toggle initial partial state depending on prior block type,
 		// will override the defaultToPartialBlocks pref
 		if (blockedUserName === relevantUserName) {
@@ -170,7 +170,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 
 	Twinkle.block.isRegistered = !!userinfo.userid;
 	if (Twinkle.block.isRegistered) {
-		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map(function(e) {
+		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map((e) => {
 			return e.group;
 		}).indexOf('bot') !== -1;
 	} else {
@@ -232,9 +232,9 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 		query.usprop = 'groupmemberships';
 	}
 
-	api.get(query).then(function(data) {
+	api.get(query).then((data) => {
 		Twinkle.block.processUserInfo(data, fn);
-	}, function(msg) {
+	}, (msg) => {
 		Morebits.status.init($('div[name="currentblock"] span').last()[0]);
 		Morebits.status.warn('Error fetching user info', msg);
 	});
@@ -242,7 +242,7 @@ Twinkle.block.fetchUserInfo = function twinkleblockFetchUserInfo(fn) {
 
 Twinkle.block.callback.saveFieldset = function twinkleblockCallbacksaveFieldset(fieldset) {
 	Twinkle.block[$(fieldset).prop('name')] = {};
-	$(fieldset).serializeArray().forEach(function(el) {
+	$(fieldset).serializeArray().forEach((el) => {
 		// namespaces and pages for partial blocks are overwritten
 		// here, but we're handling them elsewhere so that's fine
 		Twinkle.block[$(fieldset).prop('name')][el.name] = el.value;
@@ -315,7 +315,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		prior.list = [{ label: 'Prior block settings', value: 'prior', selected: true }];
 
 		// Arrays of objects are annoying to check
-		if (!blockGroup.some(function(bg) {
+		if (!blockGroup.some((bg) => {
 			return bg.label === prior.label;
 		})) {
 			blockGroup.push(prior);
@@ -333,7 +333,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 	} else {
 		// But first remove any prior prior
-		blockGroup = blockGroup.filter(function(bg) {
+		blockGroup = blockGroup.filter((bg) => {
 			return bg.label !== prior.label;
 		});
 	}
@@ -410,7 +410,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				value: '',
 				tooltip: 'Block from editing these namespaces.'
 			});
-			$.each(menuFormattedNamespaces, function(number, name) {
+			$.each(menuFormattedNamespaces, (number, name) => {
 				// Ignore -1: Special; -2: Media; and 2300-2303: Gadget (talk) and Gadget definition (talk)
 				if (number >= 0 && number < 830) {
 					ns.append({ type: 'option', label: name, value: number });
@@ -519,9 +519,9 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 	// grab discretionary sanctions list from en-wiki
 	Twinkle.block.dsinfo = Morebits.wiki.getCachedJson('Template:Ds/topics.json');
 
-	Twinkle.block.dsinfo.then(function(dsinfo) {
+	Twinkle.block.dsinfo.then((dsinfo) => {
 		const $select = $('[name="dstopic"]');
-		const $options = $.map(dsinfo, function (value, key) {
+		const $options = $.map(dsinfo, (value, key) => {
 			return $('<option>').val(value.code).text(key).prop('label', key);
 		});
 		$select.append($options);
@@ -624,7 +624,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 		}
 
 		const $previewlink = $('<a id="twinkleblock-preview-link">Preview</a>');
-		$previewlink.off('click').on('click', function() {
+		$previewlink.off('click').on('click', () => {
 			Twinkle.block.callback.preview($form[0]);
 		});
 		$previewlink.css({cursor: 'pointer'});
@@ -679,7 +679,7 @@ Twinkle.block.callback.change_action = function twinkleblockCallbackChangeAction
 				},
 				processResults: function(data) {
 					return {
-						results: data.query.allpages.map(function(page) {
+						results: data.query.allpages.map((page) => {
 							const title = mw.Title.newFromText(page.title, page.ns).toText();
 							return {
 								id: title,
@@ -1333,7 +1333,7 @@ Twinkle.block.blockPresetsInfo = {
 
 Twinkle.block.transformBlockPresets = function twinkleblockTransformBlockPresets() {
 	// supply sensible defaults
-	$.each(Twinkle.block.blockPresetsInfo, function(preset, settings) {
+	$.each(Twinkle.block.blockPresetsInfo, (preset, settings) => {
 		settings.summary = settings.summary || settings.reason;
 		settings.sig = settings.sig !== undefined ? settings.sig : 'yes';
 		settings.indefinite = settings.indefinite || Morebits.string.isInfinity(settings.expiry);
@@ -1452,8 +1452,8 @@ Twinkle.block.blockGroupsPartial = [
 
 
 Twinkle.block.callback.filtered_block_groups = function twinkleblockCallbackFilteredBlockGroups(group, show_template) {
-	return $.map(group, function(blockGroup) {
-		const list = $.map(blockGroup.list, function(blockPreset) {
+	return $.map(group, (blockGroup) => {
+		const list = $.map(blockGroup.list, (blockPreset) => {
 			switch (blockPreset.value) {
 				case 'uw-talkrevoked':
 					if (blockedUserName !== relevantUserName) {
@@ -1547,9 +1547,9 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 		new RegExp('( <!--|;) ' + 'see also ' + Twinkle.block.seeAlsos.join(' and ') + '( -->)?'), ''
 	);
 
-	Twinkle.block.seeAlsos = Twinkle.block.seeAlsos.filter(function(el) {
+	Twinkle.block.seeAlsos = Twinkle.block.seeAlsos.filter((el) => {
 		return el !== this.value;
-	}.bind(this));
+	});
 
 	if (this.checked) {
 		Twinkle.block.seeAlsos.push(this.value);
@@ -1571,7 +1571,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 		new RegExp(' ?\\(\\[\\[' + Twinkle.block.dsReason + '\\]\\]\\)'), ''
 	);
 
-	Twinkle.block.dsinfo.then(function(dsinfo) {
+	Twinkle.block.dsinfo.then((dsinfo) => {
 		const sanctionCode = this.selectedIndex;
 		const sanctionName = this.options[sanctionCode].label;
 		Twinkle.block.dsReason = dsinfo[sanctionName].page;
@@ -1580,7 +1580,7 @@ Twinkle.block.callback.toggle_ds_reason = function twinkleblockCallbackToggleDSR
 		} else {
 			this.form.reason.value = reason + ' ([[' + Twinkle.block.dsReason + ']])';
 		}
-	}.bind(this));
+	});
 };
 
 Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, data) {
@@ -1612,7 +1612,7 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		data.autoblock = false;
 	}
 
-	$(form).find('[name=field_block_options]').find(':checkbox').each(function(i, el) {
+	$(form).find('[name=field_block_options]').find(':checkbox').each((i, el) => {
 		// don't override original options if useInitialOptions is set
 		if (data.useInitialOptions && data[el.name] === undefined) {
 			return;
@@ -1643,12 +1643,12 @@ Twinkle.block.callback.update_form = function twinkleblockCallbackUpdateForm(e, 
 		// Add any preset options; in practice, just used for prior block settings
 		if (data.restrictions) {
 			if (data.restrictions.pages && !$pageSelect.val().length) {
-				const pages = data.restrictions.pages.map(function(pr) {
+				const pages = data.restrictions.pages.map((pr) => {
 					return pr.title;
 				});
 				// since page restrictions use an ajax source, we
 				// short-circuit that and just add a new option
-				pages.forEach(function(page) {
+				pages.forEach((page) => {
 					if (!$pageSelect.find("option[value='" + $.escapeSelector(page) + "']").length) {
 						const newOption = new Option(page, page, true, true);
 						$pageSelect.append(newOption);
@@ -1844,7 +1844,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 		} else {
 			query.bkusers = blockoptions.user;
 		}
-		api.get(query).then(function(data) {
+		api.get(query).then((data) => {
 			let block = data.query.blocks[0];
 			// As with the initial data fetch, if an IP is blocked
 			// *and* rangeblocked, this would only grab whichever
@@ -1890,12 +1890,12 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 			// execute block
 			blockoptions.tags = Twinkle.changeTags;
 			blockoptions.token = mw.user.tokens.get('csrfToken');
-			const mbApi = new Morebits.wiki.api('Executing block', blockoptions, function() {
+			const mbApi = new Morebits.wiki.api('Executing block', blockoptions, (() => {
 				statusElement.info('Completed');
 				if (toWarn) {
 					Twinkle.block.callback.issue_template(templateoptions);
 				}
-			});
+			}));
 			mbApi.post();
 		});
 	} else if (toWarn) {
@@ -1974,14 +1974,14 @@ Twinkle.block.callback.getBlockNoticeWikitext = function(params) {
 				};
 				text += '|area=' + (params.indefinite ? 'certain ' : 'from certain ');
 				if (params.pagerestrictions.length) {
-					text += 'pages (' + makeSentence(params.pagerestrictions.map(function(p) {
+					text += 'pages (' + makeSentence(params.pagerestrictions.map((p) => {
 						return '[[:' + p + ']]';
 					}));
 					text += params.namespacerestrictions.length ? ') and certain ' : ')';
 				}
 				if (params.namespacerestrictions.length) {
 					// 1 => Talk, 2 => User, etc.
-					const namespaceNames = params.namespacerestrictions.map(function(id) {
+					const namespaceNames = params.namespacerestrictions.map((id) => {
 						return menuFormattedNamespaces[id];
 					});
 					text += '[[Wikipedia:Namespace|namespaces]] (' + makeSentence(namespaceNames) + ')';

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -974,13 +974,13 @@ Twinkle.config.init = function twinkleconfigInit() {
 		document.getElementById('twinkle-config').removeAttribute('style');
 		document.getElementById('twinkle-config-titlebar').removeAttribute('style');
 
-		let contentdiv = document.getElementById('twinkle-config-content');
+		const contentdiv = document.getElementById('twinkle-config-content');
 		contentdiv.textContent = '';  // clear children
 
 		// let user know about possible conflict with skin js/common.js file
 		// (settings in that file will still work, but they will be overwritten by twinkleoptions.js settings)
 		if (window.TwinkleConfig || window.FriendlyConfig) {
-			let contentnotice = document.createElement('p');
+			const contentnotice = document.createElement('p');
 			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="morebits-mbox-image">' +
 				'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" /></td>' +
 				'<td class="morebits-mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
@@ -992,20 +992,20 @@ Twinkle.config.init = function twinkleconfigInit() {
 		}
 
 		// start a table of contents
-		let toctable = document.createElement('div');
+		const toctable = document.createElement('div');
 		toctable.className = 'toc';
 		toctable.style.marginLeft = '0.4em';
 		// create TOC title
-		let toctitle = document.createElement('div');
+		const toctitle = document.createElement('div');
 		toctitle.id = 'toctitle';
-		let toch2 = document.createElement('h2');
+		const toch2 = document.createElement('h2');
 		toch2.textContent = 'Contents ';
 		toctitle.appendChild(toch2);
 		// add TOC show/hide link
-		let toctoggle = document.createElement('span');
+		const toctoggle = document.createElement('span');
 		toctoggle.className = 'toctoggle';
 		toctoggle.appendChild(document.createTextNode('['));
-		let toctogglelink = document.createElement('a');
+		const toctogglelink = document.createElement('a');
 		toctogglelink.className = 'internal';
 		toctogglelink.setAttribute('href', '#tw-tocshowhide');
 		toctogglelink.textContent = 'hide';
@@ -1014,9 +1014,9 @@ Twinkle.config.init = function twinkleconfigInit() {
 		toctitle.appendChild(toctoggle);
 		toctable.appendChild(toctitle);
 		// create item container: this is what we add stuff to
-		let tocul = document.createElement('ul');
+		const tocul = document.createElement('ul');
 		toctogglelink.addEventListener('click', function twinkleconfigTocToggle() {
-			let $tocul = $(tocul);
+			const $tocul = $(tocul);
 			$tocul.toggle();
 			if ($tocul.find(':visible').length) {
 				toctogglelink.textContent = 'hide';
@@ -1027,12 +1027,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 		toctable.appendChild(tocul);
 		contentdiv.appendChild(toctable);
 
-		let contentform = document.createElement('form');
+		const contentform = document.createElement('form');
 		contentform.setAttribute('action', 'javascript:void(0)');  // was #tw-save - changed to void(0) to work around Chrome issue
 		contentform.addEventListener('submit', Twinkle.config.save, true);
 		contentdiv.appendChild(contentform);
 
-		let container = document.createElement('table');
+		const container = document.createElement('table');
 		container.style.width = '100%';
 		contentform.appendChild(container);
 
@@ -1042,9 +1042,9 @@ Twinkle.config.init = function twinkleconfigInit() {
 			}
 
 			// add to TOC
-			let tocli = document.createElement('li');
+			const tocli = document.createElement('li');
 			tocli.className = 'toclevel-1';
-			let toca = document.createElement('a');
+			const toca = document.createElement('a');
 			toca.setAttribute('href', '#' + section.module);
 			toca.appendChild(document.createTextNode(section.title));
 			tocli.appendChild(toca);
@@ -1053,7 +1053,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 			let row = document.createElement('tr');
 			let cell = document.createElement('td');
 			cell.setAttribute('colspan', '3');
-			let heading = document.createElement('h4');
+			const heading = document.createElement('h4');
 			heading.style.borderBottom = '1px solid gray';
 			heading.style.marginTop = '0.2em';
 			heading.id = section.module;
@@ -1144,7 +1144,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						input.setAttribute('id', pref.name);
 						input.setAttribute('name', pref.name);
 						$.each(pref.enumValues, function(enumvalue, enumdisplay) {
-							let option = document.createElement('option');
+							const option = document.createElement('option');
 							option.setAttribute('value', enumvalue);
 							if ((gotPref === enumvalue) ||
 								// Hack to convert old boolean watchlist prefs
@@ -1170,10 +1170,10 @@ Twinkle.config.init = function twinkleconfigInit() {
 						var checkdiv = document.createElement('div');
 						checkdiv.style.paddingLeft = '1em';
 						var worker = function(itemkey, itemvalue) {
-							let checklabel = document.createElement('label');
+							const checklabel = document.createElement('label');
 							checklabel.style.marginRight = '0.7em';
 							checklabel.style.display = 'inline-block';
-							let check = document.createElement('input');
+							const check = document.createElement('input');
 							check.setAttribute('type', 'checkbox');
 							check.setAttribute('id', pref.name + '_' + itemkey);
 							check.setAttribute('name', pref.name + '_' + itemkey);
@@ -1246,7 +1246,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 				}
 				// add reset link (custom lists don't need this, as their config value isn't displayed on the form)
 				if (pref.type !== 'customList') {
-					let resetlink = document.createElement('a');
+					const resetlink = document.createElement('a');
 					resetlink.setAttribute('href', '#tw-reset');
 					resetlink.setAttribute('id', 'twinkle-config-reset-' + pref.name);
 					resetlink.addEventListener('click', Twinkle.config.resetPrefLink, false);
@@ -1263,18 +1263,18 @@ Twinkle.config.init = function twinkleconfigInit() {
 			return true;
 		});
 
-		let footerbox = document.createElement('div');
+		const footerbox = document.createElement('div');
 		footerbox.setAttribute('id', 'twinkle-config-buttonpane');
-		let button = document.createElement('button');
+		const button = document.createElement('button');
 		button.setAttribute('id', 'twinkle-config-submit');
 		button.setAttribute('type', 'submit');
 		button.appendChild(document.createTextNode('Save changes'));
 		footerbox.appendChild(button);
-		let footerspan = document.createElement('span');
+		const footerspan = document.createElement('span');
 		footerspan.className = 'plainlinks';
 		footerspan.style.marginLeft = '2.4em';
 		footerspan.style.fontSize = '90%';
-		let footera = document.createElement('a');
+		const footera = document.createElement('a');
 		footera.setAttribute('href', '#tw-reset-all');
 		footera.setAttribute('id', 'twinkle-config-resetall');
 		footera.addEventListener('click', Twinkle.config.resetAllPrefs, false);
@@ -1285,7 +1285,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 
 		// since all the section headers exist now, we can try going to the requested anchor
 		if (window.location.hash) {
-			let loc = window.location.hash;
+			const loc = window.location.hash;
 			window.location.hash = '';
 			window.location.hash = loc;
 		}
@@ -1294,7 +1294,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 			mw.config.get('wgTitle').indexOf(mw.config.get('wgUserName')) === 0 &&
 			mw.config.get('wgPageName').slice(-3) === '.js') {
 
-		let box = document.createElement('div');
+		const box = document.createElement('div');
 		// Styled in twinkle.css
 		box.setAttribute('id', 'twinkle-config-headerbox');
 
@@ -1375,11 +1375,11 @@ Twinkle.config.listDialog.addRow = function twinkleconfigListDialogAddRow($dlgta
 };
 
 Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
-	let $prefbutton = $(e.target);
-	let curvalue = $prefbutton.data('value');
-	let curpref = $prefbutton.data('pref');
+	const $prefbutton = $(e.target);
+	const curvalue = $prefbutton.data('value');
+	const curpref = $prefbutton.data('pref');
 
-	let dialog = new Morebits.simpleWindow(720, 400);
+	const dialog = new Morebits.simpleWindow(720, 400);
 	dialog.setTitle(curpref.label);
 	dialog.setScriptName('Twinkle preferences');
 
@@ -1463,14 +1463,14 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 // old data value again (less surprising behaviour)
 Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button, $tbody) {
 	// reset value on button
-	let curpref = $button.data('pref');
-	let oldvalue = $button.data('value');
+	const curpref = $button.data('pref');
+	const oldvalue = $button.data('value');
 	Twinkle.config.resetPref(curpref);
 
 	// reset form
 	$tbody.find('tr').slice(1).remove();  // all rows except the first (header) row
 	// add the new values
-	let curvalue = $button.data('value');
+	const curvalue = $button.data('value');
 	$.each(curvalue, function(k, v) {
 		Twinkle.config.listDialog.addRow($tbody, v.value, v.label);
 	});
@@ -1480,7 +1480,7 @@ Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button,
 };
 
 Twinkle.config.listDialog.save = function twinkleconfigListDialogSave($button, $tbody) {
-	let result = [];
+	const result = [];
 	let current = {};
 	$tbody.find('input[type="text"]').each(function(inputkey, input) {
 		if ($(input).hasClass('twinkle-config-customlist-value')) {
@@ -1499,7 +1499,7 @@ Twinkle.config.listDialog.save = function twinkleconfigListDialogSave($button, $
 // reset/restore defaults
 
 Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
-	let wantedpref = e.target.id.substring(21); // "twinkle-config-reset-" prefix is stripped
+	const wantedpref = e.target.id.substring(21); // "twinkle-config-reset-" prefix is stripped
 
 	// search tactics
 	$(Twinkle.config.sections).each(function(sectionkey, section) {
@@ -1575,8 +1575,8 @@ Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 Twinkle.config.save = function twinkleconfigSave(e) {
 	Morebits.status.init(document.getElementById('twinkle-config-content'));
 
-	let userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
-	let wikipedia_page = new Morebits.wiki.page(userjs, 'Saving preferences to ' + userjs);
+	const userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
+	const wikipedia_page = new Morebits.wiki.page(userjs, 'Saving preferences to ' + userjs);
 	wikipedia_page.setCallbackParameters(e.target);
 	wikipedia_page.load(Twinkle.config.writePrefs);
 
@@ -1584,23 +1584,23 @@ Twinkle.config.save = function twinkleconfigSave(e) {
 };
 
 Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
-	let form = pageobj.getCallbackParameters();
+	const form = pageobj.getCallbackParameters();
 
 	// this is the object which gets serialized into JSON; only
 	// preferences that this script knows about are kept
-	let newConfig = {optionsVersion: 2.1};
+	const newConfig = {optionsVersion: 2.1};
 
 	// a comparison function is needed later on
 	// it is just enough for our purposes (i.e. comparing strings, numbers, booleans,
 	// arrays of strings, and arrays of { value, label })
 	// and it is not very robust: e.g. compare([2], ["2"]) === true, and
 	// compare({}, {}) === false, but it's good enough for our purposes here
-	let compare = function(a, b) {
+	const compare = function(a, b) {
 		if (Array.isArray(a)) {
 			if (a.length !== b.length) {
 				return false;
 			}
-			let asort = a.sort(), bsort = b.sort();
+			const asort = a.sort(), bsort = b.sort();
 			for (let i = 0; asort[i]; ++i) {
 				// comparison of the two properties of custom lists
 				if ((typeof asort[i] === 'object') && (asort[i].label !== bsort[i].label ||
@@ -1717,14 +1717,14 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 Twinkle.config.saveSuccess = function twinkleconfigSaveSuccess(pageobj) {
 	pageobj.getStatusElement().info('successful');
 
-	let noticebox = document.createElement('div');
+	const noticebox = document.createElement('div');
 	noticebox.className = 'cdx-message cdx-message--success';
 	noticebox.style.fontSize = '100%';
 	noticebox.innerHTML = '<p><b>Your Twinkle preferences have been saved.</b> To see the changes, you will need to clear your browser cache entirely (see <a href="' + mw.util.getUrl('WP:BYPASS') + '" title="WP:BYPASS">WP:BYPASS</a> for instructions).</p>';
 	mw.loader.using('mediawiki.htmlform.codex.styles', function() {
 		Morebits.status.root.appendChild(noticebox);
 	});
-	let noticeclear = document.createElement('br');
+	const noticeclear = document.createElement('br');
 	noticeclear.style.clear = 'both';
 	Morebits.status.root.appendChild(noticeclear);
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -974,13 +974,13 @@ Twinkle.config.init = function twinkleconfigInit() {
 		document.getElementById('twinkle-config').removeAttribute('style');
 		document.getElementById('twinkle-config-titlebar').removeAttribute('style');
 
-		var contentdiv = document.getElementById('twinkle-config-content');
+		let contentdiv = document.getElementById('twinkle-config-content');
 		contentdiv.textContent = '';  // clear children
 
 		// let user know about possible conflict with skin js/common.js file
 		// (settings in that file will still work, but they will be overwritten by twinkleoptions.js settings)
 		if (window.TwinkleConfig || window.FriendlyConfig) {
-			var contentnotice = document.createElement('p');
+			let contentnotice = document.createElement('p');
 			contentnotice.innerHTML = '<table class="plainlinks morebits-ombox morebits-ombox-content"><tr><td class="morebits-mbox-image">' +
 				'<img alt="" src="https://upload.wikimedia.org/wikipedia/commons/3/38/Imbox_content.png" /></td>' +
 				'<td class="morebits-mbox-text"><p><big><b>Before modifying your settings here,</b> you must remove your old Twinkle and Friendly settings from your personal skin JavaScript.</big></p>' +
@@ -992,20 +992,20 @@ Twinkle.config.init = function twinkleconfigInit() {
 		}
 
 		// start a table of contents
-		var toctable = document.createElement('div');
+		let toctable = document.createElement('div');
 		toctable.className = 'toc';
 		toctable.style.marginLeft = '0.4em';
 		// create TOC title
-		var toctitle = document.createElement('div');
+		let toctitle = document.createElement('div');
 		toctitle.id = 'toctitle';
-		var toch2 = document.createElement('h2');
+		let toch2 = document.createElement('h2');
 		toch2.textContent = 'Contents ';
 		toctitle.appendChild(toch2);
 		// add TOC show/hide link
-		var toctoggle = document.createElement('span');
+		let toctoggle = document.createElement('span');
 		toctoggle.className = 'toctoggle';
 		toctoggle.appendChild(document.createTextNode('['));
-		var toctogglelink = document.createElement('a');
+		let toctogglelink = document.createElement('a');
 		toctogglelink.className = 'internal';
 		toctogglelink.setAttribute('href', '#tw-tocshowhide');
 		toctogglelink.textContent = 'hide';
@@ -1014,9 +1014,9 @@ Twinkle.config.init = function twinkleconfigInit() {
 		toctitle.appendChild(toctoggle);
 		toctable.appendChild(toctitle);
 		// create item container: this is what we add stuff to
-		var tocul = document.createElement('ul');
+		let tocul = document.createElement('ul');
 		toctogglelink.addEventListener('click', function twinkleconfigTocToggle() {
-			var $tocul = $(tocul);
+			let $tocul = $(tocul);
 			$tocul.toggle();
 			if ($tocul.find(':visible').length) {
 				toctogglelink.textContent = 'hide';
@@ -1027,12 +1027,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 		toctable.appendChild(tocul);
 		contentdiv.appendChild(toctable);
 
-		var contentform = document.createElement('form');
+		let contentform = document.createElement('form');
 		contentform.setAttribute('action', 'javascript:void(0)');  // was #tw-save - changed to void(0) to work around Chrome issue
 		contentform.addEventListener('submit', Twinkle.config.save, true);
 		contentdiv.appendChild(contentform);
 
-		var container = document.createElement('table');
+		let container = document.createElement('table');
 		container.style.width = '100%';
 		contentform.appendChild(container);
 
@@ -1042,18 +1042,18 @@ Twinkle.config.init = function twinkleconfigInit() {
 			}
 
 			// add to TOC
-			var tocli = document.createElement('li');
+			let tocli = document.createElement('li');
 			tocli.className = 'toclevel-1';
-			var toca = document.createElement('a');
+			let toca = document.createElement('a');
 			toca.setAttribute('href', '#' + section.module);
 			toca.appendChild(document.createTextNode(section.title));
 			tocli.appendChild(toca);
 			tocul.appendChild(tocli);
 
-			var row = document.createElement('tr');
-			var cell = document.createElement('td');
+			let row = document.createElement('tr');
+			let cell = document.createElement('td');
 			cell.setAttribute('colspan', '3');
-			var heading = document.createElement('h4');
+			let heading = document.createElement('h4');
 			heading.style.borderBottom = '1px solid gray';
 			heading.style.marginTop = '0.2em';
 			heading.id = section.module;
@@ -1062,7 +1062,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 			row.appendChild(cell);
 			container.appendChild(row);
 
-			var rowcount = 1;  // for row banding
+			let rowcount = 1;  // for row banding
 
 			// add each of the preferences to the form
 			$(section.preferences).each(function(prefkey, pref) {
@@ -1078,7 +1078,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 				}
 				cell = document.createElement('td');
 
-				var label, input, gotPref = Twinkle.getPref(pref.name);
+				let label, input, gotPref = Twinkle.getPref(pref.name);
 				switch (pref.type) {
 
 					case 'boolean':  // create a checkbox
@@ -1144,7 +1144,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						input.setAttribute('id', pref.name);
 						input.setAttribute('name', pref.name);
 						$.each(pref.enumValues, function(enumvalue, enumdisplay) {
-							var option = document.createElement('option');
+							let option = document.createElement('option');
 							option.setAttribute('value', enumvalue);
 							if ((gotPref === enumvalue) ||
 								// Hack to convert old boolean watchlist prefs
@@ -1170,10 +1170,10 @@ Twinkle.config.init = function twinkleconfigInit() {
 						var checkdiv = document.createElement('div');
 						checkdiv.style.paddingLeft = '1em';
 						var worker = function(itemkey, itemvalue) {
-							var checklabel = document.createElement('label');
+							let checklabel = document.createElement('label');
 							checklabel.style.marginRight = '0.7em';
 							checklabel.style.display = 'inline-block';
-							var check = document.createElement('input');
+							let check = document.createElement('input');
 							check.setAttribute('type', 'checkbox');
 							check.setAttribute('id', pref.name + '_' + itemkey);
 							check.setAttribute('name', pref.name + '_' + itemkey);
@@ -1246,7 +1246,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 				}
 				// add reset link (custom lists don't need this, as their config value isn't displayed on the form)
 				if (pref.type !== 'customList') {
-					var resetlink = document.createElement('a');
+					let resetlink = document.createElement('a');
 					resetlink.setAttribute('href', '#tw-reset');
 					resetlink.setAttribute('id', 'twinkle-config-reset-' + pref.name);
 					resetlink.addEventListener('click', Twinkle.config.resetPrefLink, false);
@@ -1263,18 +1263,18 @@ Twinkle.config.init = function twinkleconfigInit() {
 			return true;
 		});
 
-		var footerbox = document.createElement('div');
+		let footerbox = document.createElement('div');
 		footerbox.setAttribute('id', 'twinkle-config-buttonpane');
-		var button = document.createElement('button');
+		let button = document.createElement('button');
 		button.setAttribute('id', 'twinkle-config-submit');
 		button.setAttribute('type', 'submit');
 		button.appendChild(document.createTextNode('Save changes'));
 		footerbox.appendChild(button);
-		var footerspan = document.createElement('span');
+		let footerspan = document.createElement('span');
 		footerspan.className = 'plainlinks';
 		footerspan.style.marginLeft = '2.4em';
 		footerspan.style.fontSize = '90%';
-		var footera = document.createElement('a');
+		let footera = document.createElement('a');
 		footera.setAttribute('href', '#tw-reset-all');
 		footera.setAttribute('id', 'twinkle-config-resetall');
 		footera.addEventListener('click', Twinkle.config.resetAllPrefs, false);
@@ -1285,7 +1285,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 
 		// since all the section headers exist now, we can try going to the requested anchor
 		if (window.location.hash) {
-			var loc = window.location.hash;
+			let loc = window.location.hash;
 			window.location.hash = '';
 			window.location.hash = loc;
 		}
@@ -1294,11 +1294,11 @@ Twinkle.config.init = function twinkleconfigInit() {
 			mw.config.get('wgTitle').indexOf(mw.config.get('wgUserName')) === 0 &&
 			mw.config.get('wgPageName').slice(-3) === '.js') {
 
-		var box = document.createElement('div');
+		let box = document.createElement('div');
 		// Styled in twinkle.css
 		box.setAttribute('id', 'twinkle-config-headerbox');
 
-		var link,
+		let link,
 			scriptPageName = mw.config.get('wgPageName').slice(mw.config.get('wgPageName').lastIndexOf('/') + 1,
 				mw.config.get('wgPageName').lastIndexOf('.js'));
 
@@ -1338,7 +1338,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 Twinkle.config.listDialog = {};
 
 Twinkle.config.listDialog.addRow = function twinkleconfigListDialogAddRow($dlgtable, value, label) {
-	var $contenttr, $valueInput, $labelInput;
+	let $contenttr, $valueInput, $labelInput;
 
 	$dlgtable.append(
 		$contenttr = $('<tr>').append(
@@ -1375,15 +1375,15 @@ Twinkle.config.listDialog.addRow = function twinkleconfigListDialogAddRow($dlgta
 };
 
 Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
-	var $prefbutton = $(e.target);
-	var curvalue = $prefbutton.data('value');
-	var curpref = $prefbutton.data('pref');
+	let $prefbutton = $(e.target);
+	let curvalue = $prefbutton.data('value');
+	let curpref = $prefbutton.data('pref');
 
-	var dialog = new Morebits.simpleWindow(720, 400);
+	let dialog = new Morebits.simpleWindow(720, 400);
 	dialog.setTitle(curpref.label);
 	dialog.setScriptName('Twinkle preferences');
 
-	var $dlgtbody;
+	let $dlgtbody;
 
 	dialog.setContent(
 		$('<div>').append(
@@ -1446,7 +1446,7 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 	);
 
 	// content rows
-	var gotRow = false;
+	let gotRow = false;
 	$.each(curvalue, function(k, v) {
 		gotRow = true;
 		Twinkle.config.listDialog.addRow($dlgtbody, v.value, v.label);
@@ -1463,14 +1463,14 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 // old data value again (less surprising behaviour)
 Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button, $tbody) {
 	// reset value on button
-	var curpref = $button.data('pref');
-	var oldvalue = $button.data('value');
+	let curpref = $button.data('pref');
+	let oldvalue = $button.data('value');
 	Twinkle.config.resetPref(curpref);
 
 	// reset form
 	$tbody.find('tr').slice(1).remove();  // all rows except the first (header) row
 	// add the new values
-	var curvalue = $button.data('value');
+	let curvalue = $button.data('value');
 	$.each(curvalue, function(k, v) {
 		Twinkle.config.listDialog.addRow($tbody, v.value, v.label);
 	});
@@ -1480,8 +1480,8 @@ Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button,
 };
 
 Twinkle.config.listDialog.save = function twinkleconfigListDialogSave($button, $tbody) {
-	var result = [];
-	var current = {};
+	let result = [];
+	let current = {};
 	$tbody.find('input[type="text"]').each(function(inputkey, input) {
 		if ($(input).hasClass('twinkle-config-customlist-value')) {
 			current = { value: input.value };
@@ -1499,7 +1499,7 @@ Twinkle.config.listDialog.save = function twinkleconfigListDialogSave($button, $
 // reset/restore defaults
 
 Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
-	var wantedpref = e.target.id.substring(21); // "twinkle-config-reset-" prefix is stripped
+	let wantedpref = e.target.id.substring(21); // "twinkle-config-reset-" prefix is stripped
 
 	// search tactics
 	$(Twinkle.config.sections).each(function(sectionkey, section) {
@@ -1507,7 +1507,7 @@ Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
 			return true;  // continue: skip impossibilities
 		}
 
-		var foundit = false;
+		let foundit = false;
 
 		$(section.preferences).each(function(prefkey, pref) {
 			if (pref.name !== wantedpref) {
@@ -1575,8 +1575,8 @@ Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 Twinkle.config.save = function twinkleconfigSave(e) {
 	Morebits.status.init(document.getElementById('twinkle-config-content'));
 
-	var userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
-	var wikipedia_page = new Morebits.wiki.page(userjs, 'Saving preferences to ' + userjs);
+	let userjs = mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceIds').user] + ':' + mw.config.get('wgUserName') + '/twinkleoptions.js';
+	let wikipedia_page = new Morebits.wiki.page(userjs, 'Saving preferences to ' + userjs);
 	wikipedia_page.setCallbackParameters(e.target);
 	wikipedia_page.load(Twinkle.config.writePrefs);
 
@@ -1584,24 +1584,24 @@ Twinkle.config.save = function twinkleconfigSave(e) {
 };
 
 Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
-	var form = pageobj.getCallbackParameters();
+	let form = pageobj.getCallbackParameters();
 
 	// this is the object which gets serialized into JSON; only
 	// preferences that this script knows about are kept
-	var newConfig = {optionsVersion: 2.1};
+	let newConfig = {optionsVersion: 2.1};
 
 	// a comparison function is needed later on
 	// it is just enough for our purposes (i.e. comparing strings, numbers, booleans,
 	// arrays of strings, and arrays of { value, label })
 	// and it is not very robust: e.g. compare([2], ["2"]) === true, and
 	// compare({}, {}) === false, but it's good enough for our purposes here
-	var compare = function(a, b) {
+	let compare = function(a, b) {
 		if (Array.isArray(a)) {
 			if (a.length !== b.length) {
 				return false;
 			}
-			var asort = a.sort(), bsort = b.sort();
-			for (var i = 0; asort[i]; ++i) {
+			let asort = a.sort(), bsort = b.sort();
+			for (let i = 0; asort[i]; ++i) {
 				// comparison of the two properties of custom lists
 				if ((typeof asort[i] === 'object') && (asort[i].label !== bsort[i].label ||
 					asort[i].value !== bsort[i].value)) {
@@ -1623,7 +1623,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 
 		// reach each of the preferences from the form
 		$(section.preferences).each(function(prefkey, pref) {
-			var userValue;  // = undefined
+			let userValue;  // = undefined
 
 			// only read form values for those prefs that have them
 			if (!pref.adminOnly || Morebits.userIsSysop) {
@@ -1687,7 +1687,7 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 		});
 	});
 
-	var text =
+	let text =
 		'// twinkleoptions.js: personal Twinkle preferences file\n' +
 		'//\n' +
 		'// NOTE: The easiest way to change your Twinkle preferences is by using the\n' +
@@ -1717,14 +1717,14 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 Twinkle.config.saveSuccess = function twinkleconfigSaveSuccess(pageobj) {
 	pageobj.getStatusElement().info('successful');
 
-	var noticebox = document.createElement('div');
+	let noticebox = document.createElement('div');
 	noticebox.className = 'cdx-message cdx-message--success';
 	noticebox.style.fontSize = '100%';
 	noticebox.innerHTML = '<p><b>Your Twinkle preferences have been saved.</b> To see the changes, you will need to clear your browser cache entirely (see <a href="' + mw.util.getUrl('WP:BYPASS') + '" title="WP:BYPASS">WP:BYPASS</a> for instructions).</p>';
 	mw.loader.using('mediawiki.htmlform.codex.styles', function() {
 		Morebits.status.root.appendChild(noticebox);
 	});
-	var noticeclear = document.createElement('br');
+	let noticeclear = document.createElement('br');
 	noticeclear.style.clear = 'both';
 	Morebits.status.root.appendChild(noticeclear);
 };

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1730,7 +1730,7 @@ Twinkle.config.saveSuccess = function twinkleconfigSaveSuccess(pageobj) {
 };
 
 Twinkle.addInitCallback(Twinkle.config.init);
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1015,7 +1015,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 		toctable.appendChild(toctitle);
 		// create item container: this is what we add stuff to
 		const tocul = document.createElement('ul');
-		toctogglelink.addEventListener('click', function twinkleconfigTocToggle() {
+		toctogglelink.addEventListener('click', () => {
 			const $tocul = $(tocul);
 			$tocul.toggle();
 			if ($tocul.find(':visible').length) {
@@ -1036,7 +1036,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 		container.style.width = '100%';
 		contentform.appendChild(container);
 
-		$(Twinkle.config.sections).each(function(sectionkey, section) {
+		$(Twinkle.config.sections).each((sectionkey, section) => {
 			if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 				return true;  // i.e. "continue" in this context
 			}
@@ -1065,7 +1065,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 			let rowcount = 1;  // for row banding
 
 			// add each of the preferences to the form
-			$(section.preferences).each(function(prefkey, pref) {
+			$(section.preferences).each((prefkey, pref) => {
 				if (pref.adminOnly && !Morebits.userIsSysop) {
 					return true;  // i.e. "continue" in this context
 				}
@@ -1143,7 +1143,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						input = document.createElement('select');
 						input.setAttribute('id', pref.name);
 						input.setAttribute('name', pref.name);
-						$.each(pref.enumValues, function(enumvalue, enumdisplay) {
+						$.each(pref.enumValues, (enumvalue, enumdisplay) => {
 							const option = document.createElement('option');
 							option.setAttribute('value', enumvalue);
 							if ((gotPref === enumvalue) ||
@@ -1192,7 +1192,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 						};
 						if (pref.setDisplayOrder) {
 							// add check boxes according to the given display order
-							$.each(pref.setDisplayOrder, function(itemkey, item) {
+							$.each(pref.setDisplayOrder, (itemkey, item) => {
 								worker(item, pref.setValues[item]);
 							});
 						} else {
@@ -1345,7 +1345,7 @@ Twinkle.config.listDialog.addRow = function twinkleconfigListDialogAddRow($dlgta
 			$('<td>').append(
 				$('<button>')
 					.attr('type', 'button')
-					.on('click', function () {
+					.on('click', () => {
 						$contenttr.remove();
 					})
 					.text('Remove')
@@ -1416,7 +1416,7 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 										.text('Add')
 										.css('min-width', '8em')
 										.attr('type', 'button')
-										.on('click', function () {
+										.on('click', () => {
 											Twinkle.config.listDialog.addRow($dlgtbody);
 										})
 								)
@@ -1426,20 +1426,20 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 			$('<button>')
 				.text('Save changes')
 				.attr('type', 'submit') // so Morebits.simpleWindow puts the button in the button pane
-				.on('click', function () {
+				.on('click', () => {
 					Twinkle.config.listDialog.save($prefbutton, $dlgtbody);
 					dialog.close();
 				}),
 			$('<button>')
 				.text('Reset')
 				.attr('type', 'submit')
-				.on('click', function () {
+				.on('click', () => {
 					Twinkle.config.listDialog.reset($prefbutton, $dlgtbody);
 				}),
 			$('<button>')
 				.text('Cancel')
 				.attr('type', 'submit')
-				.on('click', function () {
+				.on('click', () => {
 					dialog.close();
 				})
 		)[0]
@@ -1447,7 +1447,7 @@ Twinkle.config.listDialog.display = function twinkleconfigListDialogDisplay(e) {
 
 	// content rows
 	let gotRow = false;
-	$.each(curvalue, function(k, v) {
+	$.each(curvalue, (k, v) => {
 		gotRow = true;
 		Twinkle.config.listDialog.addRow($dlgtbody, v.value, v.label);
 	});
@@ -1471,7 +1471,7 @@ Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button,
 	$tbody.find('tr').slice(1).remove();  // all rows except the first (header) row
 	// add the new values
 	const curvalue = $button.data('value');
-	$.each(curvalue, function(k, v) {
+	$.each(curvalue, (k, v) => {
 		Twinkle.config.listDialog.addRow($tbody, v.value, v.label);
 	});
 
@@ -1482,7 +1482,7 @@ Twinkle.config.listDialog.reset = function twinkleconfigListDialogReset($button,
 Twinkle.config.listDialog.save = function twinkleconfigListDialogSave($button, $tbody) {
 	const result = [];
 	let current = {};
-	$tbody.find('input[type="text"]').each(function(inputkey, input) {
+	$tbody.find('input[type="text"]').each((inputkey, input) => {
 		if ($(input).hasClass('twinkle-config-customlist-value')) {
 			current = { value: input.value };
 		} else {
@@ -1502,14 +1502,14 @@ Twinkle.config.resetPrefLink = function twinkleconfigResetPrefLink(e) {
 	const wantedpref = e.target.id.substring(21); // "twinkle-config-reset-" prefix is stripped
 
 	// search tactics
-	$(Twinkle.config.sections).each(function(sectionkey, section) {
+	$(Twinkle.config.sections).each((sectionkey, section) => {
 		if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 			return true;  // continue: skip impossibilities
 		}
 
 		let foundit = false;
 
-		$(section.preferences).each(function(prefkey, pref) {
+		$(section.preferences).each((prefkey, pref) => {
 			if (pref.name !== wantedpref) {
 				return true;  // continue
 			}
@@ -1539,7 +1539,7 @@ Twinkle.config.resetPref = function twinkleconfigResetPref(pref) {
 			break;
 
 		case 'set':
-			$.each(pref.setValues, function(itemkey) {
+			$.each(pref.setValues, (itemkey) => {
 				if (document.getElementById(pref.name + '_' + itemkey)) {
 					document.getElementById(pref.name + '_' + itemkey).checked = Twinkle.defaultConfig[pref.name].indexOf(itemkey) !== -1;
 				}
@@ -1558,11 +1558,11 @@ Twinkle.config.resetPref = function twinkleconfigResetPref(pref) {
 
 Twinkle.config.resetAllPrefs = function twinkleconfigResetAllPrefs() {
 	// no confirmation message - the user can just refresh/close the page to abort
-	$(Twinkle.config.sections).each(function(sectionkey, section) {
+	$(Twinkle.config.sections).each((sectionkey, section) => {
 		if (section.hidden || (section.adminOnly && !Morebits.userIsSysop)) {
 			return true;  // continue: skip impossibilities
 		}
-		$(section.preferences).each(function(prefkey, pref) {
+		$(section.preferences).each((prefkey, pref) => {
 			if (!pref.adminOnly || Morebits.userIsSysop) {
 				Twinkle.config.resetPref(pref);
 			}
@@ -1616,13 +1616,13 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 
 	};
 
-	$(Twinkle.config.sections).each(function(sectionkey, section) {
+	$(Twinkle.config.sections).each((sectionkey, section) => {
 		if (section.adminOnly && !Morebits.userIsSysop) {
 			return;  // i.e. "continue" in this context
 		}
 
 		// reach each of the preferences from the form
-		$(section.preferences).each(function(prefkey, pref) {
+		$(section.preferences).each((prefkey, pref) => {
 			let userValue;  // = undefined
 
 			// only read form values for those prefs that have them
@@ -1650,14 +1650,14 @@ Twinkle.config.writePrefs = function twinkleconfigWritePrefs(pageobj) {
 							userValue = [];
 							if (pref.setDisplayOrder) {
 							// read only those keys specified in the display order
-								$.each(pref.setDisplayOrder, function(itemkey, item) {
+								$.each(pref.setDisplayOrder, (itemkey, item) => {
 									if (form[pref.name + '_' + item].checked) {
 										userValue.push(item);
 									}
 								});
 							} else {
 							// read all the keys in the list of values
-								$.each(pref.setValues, function(itemkey) {
+								$.each(pref.setValues, (itemkey) => {
 									if (form[pref.name + '_' + itemkey].checked) {
 										userValue.push(itemkey);
 									}
@@ -1721,7 +1721,7 @@ Twinkle.config.saveSuccess = function twinkleconfigSaveSuccess(pageobj) {
 	noticebox.className = 'cdx-message cdx-message--success';
 	noticebox.style.fontSize = '100%';
 	noticebox.innerHTML = '<p><b>Your Twinkle preferences have been saved.</b> To see the changes, you will need to clear your browser cache entirely (see <a href="' + mw.util.getUrl('WP:BYPASS') + '" title="WP:BYPASS">WP:BYPASS</a> for instructions).</p>';
-	mw.loader.using('mediawiki.htmlform.codex.styles', function() {
+	mw.loader.using('mediawiki.htmlform.codex.styles', () => {
 		Morebits.status.root.appendChild(noticebox);
 	});
 	const noticeclear = document.createElement('br');

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -23,25 +23,25 @@ Twinkle.deprod = function() {
 	Twinkle.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
 
-var concerns = {};
+let concerns = {};
 
 Twinkle.deprod.callback = function() {
-	var Window = new Morebits.simpleWindow(800, 400);
+	let Window = new Morebits.simpleWindow(800, 400);
 	Window.setTitle('PROD cleaning');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Proposed deletion', 'WP:PROD');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#deprod');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(callback_commit);
+	let form = new Morebits.quickForm(callback_commit);
 
-	var statusdiv = document.createElement('div');
+	let statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	var query = {
+	let query = {
 		action: 'query',
 		generator: 'categorymembers',
 		gcmtitle: mw.config.get('wgPageName'),
@@ -53,26 +53,26 @@ Twinkle.deprod.callback = function() {
 		format: 'json'
 	};
 
-	var statelem = new Morebits.status('Grabbing list of pages');
-	var wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var pages = (response.query && response.query.pages) || [];
-		var list = [];
-		var re = /\{\{Proposed deletion/;
+	let statelem = new Morebits.status('Grabbing list of pages');
+	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		let response = apiobj.getResponse();
+		let pages = (response.query && response.query.pages) || [];
+		let list = [];
+		let re = /\{\{Proposed deletion/;
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			var metadata = [];
+			let metadata = [];
 
-			var content = page.revisions[0].content;
-			var res = re.exec(content);
-			var title = page.title;
+			let content = page.revisions[0].content;
+			let res = re.exec(content);
+			let title = page.title;
 			if (res) {
-				var parsed = Morebits.wikitext.parseTemplate(content, res.index);
+				let parsed = Morebits.wikitext.parseTemplate(content, res.index);
 				concerns[title] = parsed.parameters.concern || '';
 				metadata.push(concerns[title]);
 			}
 
-			var editProt = page.protection.filter(function(pr) {
+			let editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -111,7 +111,7 @@ Twinkle.deprod.callback = function() {
 			type: 'submit'
 		});
 
-		var rendered = apiobj.params.form.render();
+		let rendered = apiobj.params.form.render();
 		apiobj.params.Window.setContent(rendered);
 		Morebits.quickForm.getElements(rendered, 'pages').forEach(Twinkle.generateBatchPageLinks);
 	}, statelem);
@@ -121,28 +121,28 @@ Twinkle.deprod.callback = function() {
 };
 
 var callback_commit = function(event) {
-		var pages = Morebits.quickForm.getInputData(event.target).pages;
+		let pages = Morebits.quickForm.getInputData(event.target).pages;
 		Morebits.status.init(event.target);
 
-		var batchOperation = new Morebits.batchOperation('Deleting pages');
+		let batchOperation = new Morebits.batchOperation('Deleting pages');
 		batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		batchOperation.setOption('preserveIndividualStatusLines', true);
 		batchOperation.setPageList(pages);
 		batchOperation.run(function(pageName) {
-			var params = { page: pageName, reason: concerns[page] };
+			let params = { page: pageName, reason: concerns[page] };
 
-			var query = {
+			let query = {
 				action: 'query',
 				titles: pageName,
 				prop: 'redirects',
 				rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			};
-			var wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, callback_deleteRedirects);
+			let wikipedia_api = new Morebits.wiki.api('Grabbing redirects', query, callback_deleteRedirects);
 			wikipedia_api.params = params;
 			wikipedia_api.post();
 
-			var pageTitle = mw.Title.newFromText(pageName);
+			let pageTitle = mw.Title.newFromText(pageName);
 			// Don't delete user talk pages, limiting this to Talk: pages since only article and user pages appear in deprod
 			if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 				pageTitle.namespace++;  // now pageTitle is the talk page title!
@@ -170,17 +170,17 @@ var callback_commit = function(event) {
 			return;
 		}
 
-		var page = new Morebits.wiki.page('Talk:' + apiobj.params.page, 'Deleting talk page of page ' + apiobj.params.page);
+		let page = new Morebits.wiki.page('Talk:' + apiobj.params.page, 'Deleting talk page of page ' + apiobj.params.page);
 		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
 		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	callback_deleteRedirects = function(apiobj) {
-		var response = apiobj.getResponse();
-		var redirects = response.query.pages[0].redirects || [];
+		let response = apiobj.getResponse();
+		let redirects = response.query.pages[0].redirects || [];
 		redirects.forEach(function(rd) {
-			var title = rd.title;
-			var page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
+			let title = rd.title;
+			let page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
 			page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
 			page.setChangeTags(Twinkle.changeTags);
 			page.deletePage();

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -23,25 +23,25 @@ Twinkle.deprod = function() {
 	Twinkle.addPortletLink(Twinkle.deprod.callback, 'Deprod', 'tw-deprod', 'Delete prod pages found in this category');
 };
 
-let concerns = {};
+const concerns = {};
 
 Twinkle.deprod.callback = function() {
-	let Window = new Morebits.simpleWindow(800, 400);
+	const Window = new Morebits.simpleWindow(800, 400);
 	Window.setTitle('PROD cleaning');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Proposed deletion', 'WP:PROD');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#deprod');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(callback_commit);
+	const form = new Morebits.quickForm(callback_commit);
 
-	let statusdiv = document.createElement('div');
+	const statusdiv = document.createElement('div');
 	statusdiv.style.padding = '15px';  // just so it doesn't look broken
 	Window.setContent(statusdiv);
 	Morebits.status.init(statusdiv);
 	Window.display();
 
-	let query = {
+	const query = {
 		action: 'query',
 		generator: 'categorymembers',
 		gcmtitle: mw.config.get('wgPageName'),
@@ -53,26 +53,26 @@ Twinkle.deprod.callback = function() {
 		format: 'json'
 	};
 
-	let statelem = new Morebits.status('Grabbing list of pages');
-	let wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
-		let response = apiobj.getResponse();
-		let pages = (response.query && response.query.pages) || [];
-		let list = [];
-		let re = /\{\{Proposed deletion/;
+	const statelem = new Morebits.status('Grabbing list of pages');
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+		const response = apiobj.getResponse();
+		const pages = (response.query && response.query.pages) || [];
+		const list = [];
+		const re = /\{\{Proposed deletion/;
 		pages.sort(Twinkle.sortByNamespace);
 		pages.forEach(function(page) {
-			let metadata = [];
+			const metadata = [];
 
-			let content = page.revisions[0].content;
-			let res = re.exec(content);
-			let title = page.title;
+			const content = page.revisions[0].content;
+			const res = re.exec(content);
+			const title = page.title;
 			if (res) {
-				let parsed = Morebits.wikitext.parseTemplate(content, res.index);
+				const parsed = Morebits.wikitext.parseTemplate(content, res.index);
 				concerns[title] = parsed.parameters.concern || '';
 				metadata.push(concerns[title]);
 			}
 
-			let editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -111,7 +111,7 @@ Twinkle.deprod.callback = function() {
 			type: 'submit'
 		});
 
-		let rendered = apiobj.params.form.render();
+		const rendered = apiobj.params.form.render();
 		apiobj.params.Window.setContent(rendered);
 		Morebits.quickForm.getElements(rendered, 'pages').forEach(Twinkle.generateBatchPageLinks);
 	}, statelem);
@@ -121,15 +121,15 @@ Twinkle.deprod.callback = function() {
 };
 
 var callback_commit = function(event) {
-		let pages = Morebits.quickForm.getInputData(event.target).pages;
+		const pages = Morebits.quickForm.getInputData(event.target).pages;
 		Morebits.status.init(event.target);
 
-		let batchOperation = new Morebits.batchOperation('Deleting pages');
+		const batchOperation = new Morebits.batchOperation('Deleting pages');
 		batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		batchOperation.setOption('preserveIndividualStatusLines', true);
 		batchOperation.setPageList(pages);
 		batchOperation.run(function(pageName) {
-			let params = { page: pageName, reason: concerns[page] };
+			const params = { page: pageName, reason: concerns[page] };
 
 			let query = {
 				action: 'query',
@@ -142,7 +142,7 @@ var callback_commit = function(event) {
 			wikipedia_api.params = params;
 			wikipedia_api.post();
 
-			let pageTitle = mw.Title.newFromText(pageName);
+			const pageTitle = mw.Title.newFromText(pageName);
 			// Don't delete user talk pages, limiting this to Talk: pages since only article and user pages appear in deprod
 			if (pageTitle && pageTitle.namespace % 2 === 0 && pageTitle.namespace !== 2) {
 				pageTitle.namespace++;  // now pageTitle is the talk page title!
@@ -170,17 +170,17 @@ var callback_commit = function(event) {
 			return;
 		}
 
-		let page = new Morebits.wiki.page('Talk:' + apiobj.params.page, 'Deleting talk page of page ' + apiobj.params.page);
+		const page = new Morebits.wiki.page('Talk:' + apiobj.params.page, 'Deleting talk page of page ' + apiobj.params.page);
 		page.setEditSummary('[[WP:CSD#G8|G8]]: [[Help:Talk page|Talk page]] of deleted page "' + apiobj.params.page + '"');
 		page.setChangeTags(Twinkle.changeTags);
 		page.deletePage();
 	},
 	callback_deleteRedirects = function(apiobj) {
-		let response = apiobj.getResponse();
-		let redirects = response.query.pages[0].redirects || [];
+		const response = apiobj.getResponse();
+		const redirects = response.query.pages[0].redirects || [];
 		redirects.forEach(function(rd) {
-			let title = rd.title;
-			let page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
+			const title = rd.title;
+			const page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
 			page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');
 			page.setChangeTags(Twinkle.changeTags);
 			page.deletePage();

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -72,9 +72,7 @@ Twinkle.deprod.callback = function() {
 				metadata.push(concerns[title]);
 			}
 
-			const editProt = page.protection.filter((pr) => {
-				return pr.type === 'edit' && pr.level === 'sysop';
-			}).pop();
+			const editProt = page.protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 			if (editProt) {
 				metadata.push('fully protected' +
 					(editProt.expiry === 'infinity' ? ' indefinitely' : ', expires ' + editProt.expiry));

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -54,13 +54,13 @@ Twinkle.deprod.callback = function() {
 	};
 
 	const statelem = new Morebits.status('Grabbing list of pages');
-	const wikipedia_api = new Morebits.wiki.api('loading...', query, function(apiobj) {
+	const wikipedia_api = new Morebits.wiki.api('loading...', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		const pages = (response.query && response.query.pages) || [];
 		const list = [];
 		const re = /\{\{Proposed deletion/;
 		pages.sort(Twinkle.sortByNamespace);
-		pages.forEach(function(page) {
+		pages.forEach((page) => {
 			const metadata = [];
 
 			const content = page.revisions[0].content;
@@ -72,7 +72,7 @@ Twinkle.deprod.callback = function() {
 				metadata.push(concerns[title]);
 			}
 
-			const editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter((pr) => {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -114,7 +114,7 @@ Twinkle.deprod.callback = function() {
 		const rendered = apiobj.params.form.render();
 		apiobj.params.Window.setContent(rendered);
 		Morebits.quickForm.getElements(rendered, 'pages').forEach(Twinkle.generateBatchPageLinks);
-	}, statelem);
+	}), statelem);
 
 	wikipedia_api.params = { form: form, Window: Window };
 	wikipedia_api.post();
@@ -128,7 +128,7 @@ var callback_commit = function(event) {
 		batchOperation.setOption('chunkSize', Twinkle.getPref('batchChunks'));
 		batchOperation.setOption('preserveIndividualStatusLines', true);
 		batchOperation.setPageList(pages);
-		batchOperation.run(function(pageName) {
+		batchOperation.run((pageName) => {
 			const params = { page: pageName, reason: concerns[page] };
 
 			let query = {
@@ -178,7 +178,7 @@ var callback_commit = function(event) {
 	callback_deleteRedirects = function(apiobj) {
 		const response = apiobj.getResponse();
 		const redirects = response.query.pages[0].redirects || [];
-		redirects.forEach(function(rd) {
+		redirects.forEach((rd) => {
 			const title = rd.title;
 			const page = new Morebits.wiki.page(title, 'Deleting redirecting page ' + title);
 			page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + apiobj.params.page + '"');

--- a/modules/twinkledeprod.js
+++ b/modules/twinkledeprod.js
@@ -188,7 +188,7 @@ var callback_commit = function(event) {
 	};
 
 Twinkle.addInitCallback(Twinkle.deprod, 'deprod');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -77,7 +77,7 @@ Twinkle.diff.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.diff, 'diff');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -37,14 +37,14 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 	if (me) {
 		user = mw.config.get('wgUserName');
 	} else {
-		let node = document.getElementById('mw-diff-ntitle2');
+		const node = document.getElementById('mw-diff-ntitle2');
 		if (!node) {
 			// nothing to do?
 			return;
 		}
 		user = $(node).find('a').first().text();
 	}
-	let query = {
+	const query = {
 		prop: 'revisions',
 		action: 'query',
 		titles: mw.config.get('wgPageName'),
@@ -55,15 +55,15 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 		format: 'json'
 	};
 	Morebits.status.init(document.getElementById('mw-content-text'));
-	let wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);
+	const wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);
 	wikipedia_api.params = { user: user };
 	wikipedia_api.post();
 };
 
 Twinkle.diff.callbacks = {
 	main: function(self) {
-		let rev = self.response.query.pages[0].revisions;
-		let revid = rev && rev[0].revid;
+		const rev = self.response.query.pages[0].revisions;
+		const revid = rev && rev[0].revid;
 
 		if (!revid) {
 			self.statelem.error('no suitable earlier revision found, or ' + self.params.user + ' is the only contributor. Aborting.');

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -33,18 +33,18 @@ Twinkle.diff = function twinklediff() {
 
 Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 
-	var user;
+	let user;
 	if (me) {
 		user = mw.config.get('wgUserName');
 	} else {
-		var node = document.getElementById('mw-diff-ntitle2');
+		let node = document.getElementById('mw-diff-ntitle2');
 		if (!node) {
 			// nothing to do?
 			return;
 		}
 		user = $(node).find('a').first().text();
 	}
-	var query = {
+	let query = {
 		prop: 'revisions',
 		action: 'query',
 		titles: mw.config.get('wgPageName'),
@@ -55,15 +55,15 @@ Twinkle.diff.evaluate = function twinklediffEvaluate(me) {
 		format: 'json'
 	};
 	Morebits.status.init(document.getElementById('mw-content-text'));
-	var wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);
+	let wikipedia_api = new Morebits.wiki.api('Grabbing data of initial contributor', query, Twinkle.diff.callbacks.main);
 	wikipedia_api.params = { user: user };
 	wikipedia_api.post();
 };
 
 Twinkle.diff.callbacks = {
 	main: function(self) {
-		var rev = self.response.query.pages[0].revisions;
-		var revid = rev && rev[0].revid;
+		let rev = self.response.query.pages[0].revisions;
+		let revid = rev && rev[0].revid;
 
 		if (!revid) {
 			self.statelem.error('no suitable earlier revision found, or ' + self.params.user + ' is the only contributor. Aborting.');

--- a/modules/twinklediff.js
+++ b/modules/twinklediff.js
@@ -20,10 +20,10 @@ Twinkle.diff = function twinklediff() {
 
 	// Show additional tabs only on diff pages
 	if (mw.config.get('wgDiffNewId')) {
-		Twinkle.addPortletLink(function() {
+		Twinkle.addPortletLink(() => {
 			Twinkle.diff.evaluate(false);
 		}, 'Since', 'tw-since', 'Show difference between last diff and the revision made by previous user');
-		Twinkle.addPortletLink(function() {
+		Twinkle.addPortletLink(() => {
 			Twinkle.diff.evaluate(true);
 		}, 'Since mine', 'tw-sincemine', 'Show difference between last diff and my last revision');
 

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -67,14 +67,14 @@ Twinkle.fluff.hiddenName = 'an unknown user';
 // Consolidated construction of fluff links
 Twinkle.fluff.linkBuilder = {
 	spanTag: function(color, content) {
-		let span = document.createElement('span');
+		const span = document.createElement('span');
 		span.style.color = color;
 		span.appendChild(document.createTextNode(content));
 		return span;
 	},
 
 	buildLink: function(color, text) {
-		let link = document.createElement('a');
+		const link = document.createElement('a');
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag('Black', '['));
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag(color, text));
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag('Black', ']'));
@@ -93,8 +93,8 @@ Twinkle.fluff.linkBuilder = {
 	rollbackLinks: function(vandal, inline, rev, page) {
 		vandal = vandal || null;
 
-		let elem = inline ? 'span' : 'div';
-		let revNode = document.createElement(elem);
+		const elem = inline ? 'span' : 'div';
+		const revNode = document.createElement(elem);
 
 		rev = parseInt(rev, 10);
 		if (rev) {
@@ -103,19 +103,19 @@ Twinkle.fluff.linkBuilder = {
 			revNode.setAttribute('id', 'tw-revert');
 		}
 
-		let separator = inline ? ' ' : ' || ';
-		let sepNode1 = document.createElement('span');
-		let sepText = document.createTextNode(separator);
+		const separator = inline ? ' ' : ' || ';
+		const sepNode1 = document.createElement('span');
+		const sepText = document.createTextNode(separator);
 		sepNode1.setAttribute('class', 'tw-rollback-link-separator');
 		sepNode1.appendChild(sepText);
 
-		let sepNode2 = sepNode1.cloneNode(true);
+		const sepNode2 = sepNode1.cloneNode(true);
 
-		let normNode = document.createElement('span');
-		let vandNode = document.createElement('span');
+		const normNode = document.createElement('span');
+		const vandNode = document.createElement('span');
 
-		let normLink = Twinkle.fluff.linkBuilder.buildLink('SteelBlue', 'rollback');
-		let vandLink = Twinkle.fluff.linkBuilder.buildLink('Red', 'vandalism');
+		const normLink = Twinkle.fluff.linkBuilder.buildLink('SteelBlue', 'rollback');
+		const vandLink = Twinkle.fluff.linkBuilder.buildLink('Red', 'vandalism');
 
 		normLink.style.fontWeight = 'bold';
 		vandLink.style.fontWeight = 'bold';
@@ -141,8 +141,8 @@ Twinkle.fluff.linkBuilder = {
 		vandNode.appendChild(vandLink);
 
 		if (!inline) {
-			let agfNode = document.createElement('span');
-			let agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
+			const agfNode = document.createElement('span');
+			const agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
 			$(agfLink).click(function(e) {
 				e.preventDefault();
 				Twinkle.fluff.revert('agf', vandal, rev, page);
@@ -165,13 +165,13 @@ Twinkle.fluff.linkBuilder = {
 		// If not a specific revision number, should be wgDiffNewId/wgDiffOldId/wgRevisionId
 		revisionRef = typeof revisionRef === 'number' ? revisionRef : mw.config.get(revisionRef);
 
-		let elem = inline ? 'span' : 'div';
-		let revertToRevisionNode = document.createElement(elem);
+		const elem = inline ? 'span' : 'div';
+		const revertToRevisionNode = document.createElement(elem);
 
 		revertToRevisionNode.setAttribute('id', 'tw-revert-to-' + revisionRef);
 		revertToRevisionNode.style.fontWeight = 'bold';
 
-		let revertToRevisionLink = Twinkle.fluff.linkBuilder.buildLink('SaddleBrown', 'restore this version');
+		const revertToRevisionLink = Twinkle.fluff.linkBuilder.buildLink('SaddleBrown', 'restore this version');
 		$(revertToRevisionLink).click(function(e) {
 			e.preventDefault();
 			Twinkle.fluff.revertToRevision(revisionRef);
@@ -191,19 +191,19 @@ Twinkle.fluff.addLinks = {
 		// $('sp-contributions-footer-anon-range') relies on the fmbox
 		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
 		// is used to show rollback/vandalism links for IP ranges
-		let isRange = !!$('#sp-contributions-footer-anon-range')[0];
+		const isRange = !!$('#sp-contributions-footer-anon-range')[0];
 		if (mw.config.exists('wgRelevantUserName') || isRange) {
 			// Get the username these contributions are for
 			let username = mw.config.get('wgRelevantUserName');
 			if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
 				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
 				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
-				let $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
+				const $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
 				$list.each(function(key, current) {
 					// revid is also available in the href of both
 					// .mw-changeslist-date or .mw-changeslist-diff
-					let page = $(current).find('.mw-contributions-title').text();
+					const page = $(current).find('.mw-contributions-title').text();
 
 					// Get username for IP ranges (wgRelevantUserName is null)
 					if (isRange) {
@@ -231,10 +231,10 @@ Twinkle.fluff.addLinks = {
 			$list.each(function(key, current) {
 				// The :not is possibly unnecessary, as it appears that
 				// .mw-userlink is simply not present if the username is hidden
-				let vandal = $(current).find('.mw-userlink:not(.history-deleted)').text();
-				let href = $(current).find('.mw-changeslist-diff').attr('href');
-				let rev = mw.util.getParamValue('diff', href);
-				let page = current.dataset.targetPage;
+				const vandal = $(current).find('.mw-userlink:not(.history-deleted)').text();
+				const href = $(current).find('.mw-changeslist-diff').attr('href');
+				const rev = mw.util.getParamValue('diff', href);
+				const page = current.dataset.targetPage;
 				current.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(vandal, true, rev, page));
 			});
 		}
@@ -243,19 +243,19 @@ Twinkle.fluff.addLinks = {
 	history: function() {
 		if (Twinkle.getPref('showRollbackLinks').indexOf('history') !== -1) {
 			// All revs
-			let histList = $('#pagehistory li').toArray();
+			const histList = $('#pagehistory li').toArray();
 
 			// On first page of results, so add revert/rollback
 			// links to the top revision
 			if (!$('a.mw-firstlink').length) {
-				let firstRow = histList.shift();
-				let firstUser = $(firstRow).find('.mw-userlink:not(.history-deleted)').text();
+				const firstRow = histList.shift();
+				const firstUser = $(firstRow).find('.mw-userlink:not(.history-deleted)').text();
 
 				// Check for first username different than the top user,
 				// only apply rollback links if/when found
 				// for() faster than every()
 				for (let i = 0; i < histList.length; i++) {
-					let hasMoreThanOneUser = $(histList[i]).find('.mw-userlink').text() !== firstUser;
+					const hasMoreThanOneUser = $(histList[i]).find('.mw-userlink').text() !== firstUser;
 					if (hasMoreThanOneUser) {
 						firstRow.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(firstUser, true));
 						break;
@@ -268,8 +268,8 @@ Twinkle.fluff.addLinks = {
 				// From restoreThisRevision, non-transferable
 				// If the text has been revdel'd, it gets wrapped in a span with .history-deleted,
 				// and href will be undefined (and thus oldid is NaN)
-				let href = rev.querySelector('.mw-changeslist-date').href;
-				let oldid = parseInt(mw.util.getParamValue('oldid', href), 10);
+				const href = rev.querySelector('.mw-changeslist-date').href;
+				const oldid = parseInt(mw.util.getParamValue('oldid', href), 10);
 				if (!isNaN(oldid)) {
 					rev.appendChild(Twinkle.fluff.linkBuilder.restoreThisRevisionLink(oldid, true));
 				}
@@ -281,15 +281,15 @@ Twinkle.fluff.addLinks = {
 
 	diff: function() {
 		// Autofill user talk links on diffs with vanarticle for easy warning, but don't autowarn
-		let warnFromTalk = function(xtitle) {
-			let talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
+		const warnFromTalk = function(xtitle) {
+			const talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
 			if (talkLink.length) {
 				let extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
 				// diffIDs for vanarticlerevid
 				extraParams += '&vanarticlerevid=';
 				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
 
-				let href = talkLink.attr('href');
+				const href = talkLink.attr('href');
 				if (href.indexOf('?') === -1) {
 					talkLink.attr('href', href + '?' + extraParams);
 				} else {
@@ -303,7 +303,7 @@ Twinkle.fluff.addLinks = {
 		// Don't load if there's a single revision or weird diff (cur on latest)
 		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
 			// Add a [restore this revision] link to the older revision
-			let oldTitle = document.getElementById('mw-diff-otitle1').parentNode;
+			const oldTitle = document.getElementById('mw-diff-otitle1').parentNode;
 			oldTitle.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffOldId'), oldTitle.firstChild);
 		}
 
@@ -313,7 +313,7 @@ Twinkle.fluff.addLinks = {
 		// Don't show if there's a single revision or weird diff (prev on first)
 		if (document.getElementById('differences-nextlink')) {
 			// Not latest revision, add [restore this revision] link to newer revision
-			let newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
+			const newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
 			newTitle.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffNewId'), newTitle.firstChild);
 		} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
 			// Normally .mw-userlink is a link, but if the
@@ -332,16 +332,16 @@ Twinkle.fluff.addLinks = {
 			let vandal = $('#mw-diff-ntitle2').find('.mw-userlink')[0];
 			// See #1337
 			vandal = vandal ? vandal.text : '';
-			let ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
+			const ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
 
 			ntitle.insertBefore(Twinkle.fluff.linkBuilder.rollbackLinks(vandal), ntitle.firstChild);
 		}
 	},
 
 	oldid: function() { // Add a [restore this revision] link on old revisions
-		let revisionInfo = document.getElementById('mw-revision-info');
+		const revisionInfo = document.getElementById('mw-revision-info');
 		if (revisionInfo) {
-			let title = revisionInfo.parentNode;
+			const title = revisionInfo.parentNode;
 			title.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgRevisionId'), title.firstChild);
 		}
 	}
@@ -360,11 +360,11 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		vandal = Morebits.ip.sanitizeIPv6(vandal);
 	}
 
-	let pagename = page || mw.config.get('wgPageName');
-	let revid = rev || mw.config.get('wgCurRevisionId');
+	const pagename = page || mw.config.get('wgPageName');
+	const revid = rev || mw.config.get('wgCurRevisionId');
 
 	if (Twinkle.fluff.rollbackInPlace) {
-		let notifyStatus = document.createElement('span');
+		const notifyStatus = document.createElement('span');
 		mw.notify(notifyStatus, {
 			autoHide: false,
 			title: 'Rollback on ' + page,
@@ -376,7 +376,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		$('#catlinks').remove();
 	}
 
-	let params = {
+	const params = {
 		type: type,
 		user: vandal,
 		userHidden: !vandal, // Keep track of whether the username was hidden
@@ -384,7 +384,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		revid: revid
 	};
 
-	let query = {
+	const query = {
 		action: 'query',
 		prop: ['info', 'revisions', 'flagged'],
 		titles: pagename,
@@ -397,7 +397,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		type: 'csrf',
 		format: 'json'
 	};
-	let wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
+	const wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
 	wikipedia_api.params = params;
 	wikipedia_api.post();
 };
@@ -406,7 +406,7 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 
 	Morebits.status.init(document.getElementById('mw-content-text'));
 
-	let query = {
+	const query = {
 		action: 'query',
 		prop: ['info', 'revisions'],
 		titles: mw.config.get('wgPageName'),
@@ -419,42 +419,42 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 		type: 'csrf',
 		format: 'json'
 	};
-	let wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision);
+	const wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision);
 	wikipedia_api.params = { rev: oldrev };
 	wikipedia_api.post();
 };
 
 Twinkle.fluff.callbacks = {
 	toRevision: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 
-		let loadtimestamp = response.curtimestamp;
-		let csrftoken = response.query.tokens.csrftoken;
+		const loadtimestamp = response.curtimestamp;
+		const csrftoken = response.query.tokens.csrftoken;
 
-		let page = response.query.pages[0];
-		let lastrevid = parseInt(page.lastrevid, 10);
-		let touched = page.touched;
+		const page = response.query.pages[0];
+		const lastrevid = parseInt(page.lastrevid, 10);
+		const touched = page.touched;
 
-		let rev = page.revisions[0];
-		let revertToRevID = parseInt(rev.revid, 10);
-		let revertToUser = rev.user;
-		let revertToUserHidden = !!rev.userhidden;
+		const rev = page.revisions[0];
+		const revertToRevID = parseInt(rev.revid, 10);
+		const revertToUser = rev.user;
+		const revertToUserHidden = !!rev.userhidden;
 
 		if (revertToRevID !== apiobj.params.rev) {
 			apiobj.statelem.error('The retrieved revision does not match the requested revision. Stopping revert.');
 			return;
 		}
 
-		let optional_summary = prompt('Please specify a reason for the revert:                                ', '');  // padded out to widen prompt in Firefox
+		const optional_summary = prompt('Please specify a reason for the revert:                                ', '');  // padded out to widen prompt in Firefox
 		if (optional_summary === null) {
 			apiobj.statelem.error('Aborted by user.');
 			return;
 		}
 
-		let summary = Twinkle.fluff.formatSummary('Restored revision ' + revertToRevID + ' by $USER',
+		const summary = Twinkle.fluff.formatSummary('Restored revision ' + revertToRevID + ' by $USER',
 			revertToUserHidden ? null : revertToUser, optional_summary);
 
-		let query = {
+		const query = {
 			action: 'edit',
 			title: mw.config.get('wgPageName'),
 			summary: summary,
@@ -469,7 +469,7 @@ Twinkle.fluff.callbacks = {
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1) {
-			let watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+			const watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {
 				query.watchlist = 'nochange';
@@ -487,36 +487,36 @@ Twinkle.fluff.callbacks = {
 		Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 		Morebits.wiki.actionCompleted.notice = 'Reversion completed';
 
-		let wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, apiobj.statelem);
+		const wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, apiobj.statelem);
 		wikipedia_api.params = apiobj.params;
 		wikipedia_api.post();
 	},
 	main: function(apiobj) {
-		let response = apiobj.getResponse();
+		const response = apiobj.getResponse();
 
-		let loadtimestamp = response.curtimestamp;
-		let csrftoken = response.query.tokens.csrftoken;
+		const loadtimestamp = response.curtimestamp;
+		const csrftoken = response.query.tokens.csrftoken;
 
-		let page = response.query.pages[0];
+		const page = response.query.pages[0];
 		if (!page.actions.edit) {
 			apiobj.statelem.error("Unable to edit the page, it's probably protected.");
 			return;
 		}
 
-		let lastrevid = parseInt(page.lastrevid, 10);
-		let touched = page.touched;
+		const lastrevid = parseInt(page.lastrevid, 10);
+		const touched = page.touched;
 
-		let revs = page.revisions;
+		const revs = page.revisions;
 
-		let statelem = apiobj.statelem;
-		let params = apiobj.params;
+		const statelem = apiobj.statelem;
+		const params = apiobj.params;
 
 		if (revs.length < 1) {
 			statelem.error('We have less than one additional revision, thus impossible to revert.');
 			return;
 		}
-		let top = revs[0];
-		let lastuser = top.user;
+		const top = revs[0];
+		const lastuser = top.user;
 
 		if (lastrevid < params.revid) {
 			Morebits.status.error('Error', [ 'The most recent revision ID received from the server, ', Morebits.htmlNode('strong', lastrevid), ', is less than the ID of the displayed revision. This could indicate that the current revision has been deleted, the server is lagging, or that bad data has been received. Stopping revert.' ]);
@@ -619,7 +619,7 @@ Twinkle.fluff.callbacks = {
 			return;
 		}
 
-		let good_revision = revs[found];
+		const good_revision = revs[found];
 		let userHasAlreadyConfirmedAction = false;
 		if (params.type !== 'vand' && count > 1) {
 			if (!confirm(userNorm + ' has made ' + mw.language.convertNumber(count) + ' edits in a row. Are you sure you want to revert them all?')) {
@@ -690,7 +690,7 @@ Twinkle.fluff.callbacks = {
 		}
 
 		// figure out whether we need to/can review the edit
-		let flagged = page.flagged;
+		const flagged = page.flagged;
 		if ((Morebits.userIsInGroup('reviewer') || Morebits.userIsSysop) &&
 				!!flagged &&
 				flagged.stable_revid >= params.goodid &&
@@ -699,7 +699,7 @@ Twinkle.fluff.callbacks = {
 			params.csrftoken = csrftoken;
 		}
 
-		let query = {
+		const query = {
 			action: 'edit',
 			title: params.pagename,
 			summary: summary,
@@ -714,7 +714,7 @@ Twinkle.fluff.callbacks = {
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1) {
-			let watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+			const watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {
 				query.watchlist = 'nochange';
@@ -734,15 +734,15 @@ Twinkle.fluff.callbacks = {
 		}
 		Morebits.wiki.actionCompleted.notice = 'Reversion completed';
 
-		let wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, statelem);
+		const wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, statelem);
 		wikipedia_api.params = params;
 		wikipedia_api.post();
 
 	},
 	complete: function (apiobj) {
 		// TODO Most of this is copy-pasted from Morebits.wiki.page#fnSaveSuccess. Unify it
-		let response = apiobj.getResponse();
-		let edit = response.edit;
+		const response = apiobj.getResponse();
+		const edit = response.edit;
 
 		if (edit.captcha) {
 			apiobj.statelem.error('Could not rollback, because the wiki server wanted you to fill out a CAPTCHA.');
@@ -750,12 +750,12 @@ Twinkle.fluff.callbacks = {
 			apiobj.statelem.error('Revision we are reverting to is identical to current revision, stopping revert.');
 		} else {
 			apiobj.statelem.info('done');
-			let params = apiobj.params;
+			const params = apiobj.params;
 
 			if (params.notifyUser && !params.userHidden) { // notifyUser only from main, not from toRevision
 				Morebits.status.info('Info', [ 'Opening user talk page edit form for user ', Morebits.htmlNode('strong', params.user) ]);
 
-				let url = mw.util.getUrl('User talk:' + params.user, {
+				const url = mw.util.getUrl('User talk:' + params.user, {
 					action: 'edit',
 					preview: 'yes',
 					vanarticle: params.pagename.replace(/_/g, ' '),
@@ -793,14 +793,14 @@ Twinkle.fluff.callbacks = {
 
 			// review the revert, if needed
 			if (apiobj.params.reviewRevert) {
-				let query = {
+				const query = {
 					action: 'review',
 					revid: edit.newrevid,
 					token: apiobj.params.csrftoken,
 					comment: 'Automatically reviewing reversion' + Twinkle.summaryAd // until the below
 					// 'tags': Twinkle.changeTags // flaggedrevs tag support: [[phab:T247721]]
 				};
-				let wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);
+				const wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);
 				wikipedia_api.post();
 			}
 		}
@@ -822,11 +822,11 @@ Twinkle.fluff.formatSummary = function(builtInString, userName, customString) {
 	// over the 499-byte limit
 	if (/\$USER/.test(builtInString)) {
 		if (userName) {
-			let resultLen = unescape(encodeURIComponent(result.replace('$USER', ''))).length;
-			let contribsLink = '[[Special:Contributions/' + userName + '|' + userName + ']]';
-			let contribsLen = unescape(encodeURIComponent(contribsLink)).length;
+			const resultLen = unescape(encodeURIComponent(result.replace('$USER', ''))).length;
+			const contribsLink = '[[Special:Contributions/' + userName + '|' + userName + ']]';
+			const contribsLen = unescape(encodeURIComponent(contribsLink)).length;
 			if (resultLen + contribsLen <= 499) {
-				let talkLink = ' ([[User talk:' + userName + '|talk]])';
+				const talkLink = ' ([[User talk:' + userName + '|talk]])';
 				if (resultLen + contribsLen + unescape(encodeURIComponent(talkLink)).length <= 499) {
 					result = Morebits.string.safeReplace(result, '$USER', contribsLink + talkLink);
 				} else {

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -67,14 +67,14 @@ Twinkle.fluff.hiddenName = 'an unknown user';
 // Consolidated construction of fluff links
 Twinkle.fluff.linkBuilder = {
 	spanTag: function(color, content) {
-		var span = document.createElement('span');
+		let span = document.createElement('span');
 		span.style.color = color;
 		span.appendChild(document.createTextNode(content));
 		return span;
 	},
 
 	buildLink: function(color, text) {
-		var link = document.createElement('a');
+		let link = document.createElement('a');
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag('Black', '['));
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag(color, text));
 		link.appendChild(Twinkle.fluff.linkBuilder.spanTag('Black', ']'));
@@ -93,8 +93,8 @@ Twinkle.fluff.linkBuilder = {
 	rollbackLinks: function(vandal, inline, rev, page) {
 		vandal = vandal || null;
 
-		var elem = inline ? 'span' : 'div';
-		var revNode = document.createElement(elem);
+		let elem = inline ? 'span' : 'div';
+		let revNode = document.createElement(elem);
 
 		rev = parseInt(rev, 10);
 		if (rev) {
@@ -103,19 +103,19 @@ Twinkle.fluff.linkBuilder = {
 			revNode.setAttribute('id', 'tw-revert');
 		}
 
-		var separator = inline ? ' ' : ' || ';
-		var sepNode1 = document.createElement('span');
-		var sepText = document.createTextNode(separator);
+		let separator = inline ? ' ' : ' || ';
+		let sepNode1 = document.createElement('span');
+		let sepText = document.createTextNode(separator);
 		sepNode1.setAttribute('class', 'tw-rollback-link-separator');
 		sepNode1.appendChild(sepText);
 
-		var sepNode2 = sepNode1.cloneNode(true);
+		let sepNode2 = sepNode1.cloneNode(true);
 
-		var normNode = document.createElement('span');
-		var vandNode = document.createElement('span');
+		let normNode = document.createElement('span');
+		let vandNode = document.createElement('span');
 
-		var normLink = Twinkle.fluff.linkBuilder.buildLink('SteelBlue', 'rollback');
-		var vandLink = Twinkle.fluff.linkBuilder.buildLink('Red', 'vandalism');
+		let normLink = Twinkle.fluff.linkBuilder.buildLink('SteelBlue', 'rollback');
+		let vandLink = Twinkle.fluff.linkBuilder.buildLink('Red', 'vandalism');
 
 		normLink.style.fontWeight = 'bold';
 		vandLink.style.fontWeight = 'bold';
@@ -141,8 +141,8 @@ Twinkle.fluff.linkBuilder = {
 		vandNode.appendChild(vandLink);
 
 		if (!inline) {
-			var agfNode = document.createElement('span');
-			var agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
+			let agfNode = document.createElement('span');
+			let agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
 			$(agfLink).click(function(e) {
 				e.preventDefault();
 				Twinkle.fluff.revert('agf', vandal, rev, page);
@@ -165,13 +165,13 @@ Twinkle.fluff.linkBuilder = {
 		// If not a specific revision number, should be wgDiffNewId/wgDiffOldId/wgRevisionId
 		revisionRef = typeof revisionRef === 'number' ? revisionRef : mw.config.get(revisionRef);
 
-		var elem = inline ? 'span' : 'div';
-		var revertToRevisionNode = document.createElement(elem);
+		let elem = inline ? 'span' : 'div';
+		let revertToRevisionNode = document.createElement(elem);
 
 		revertToRevisionNode.setAttribute('id', 'tw-revert-to-' + revisionRef);
 		revertToRevisionNode.style.fontWeight = 'bold';
 
-		var revertToRevisionLink = Twinkle.fluff.linkBuilder.buildLink('SaddleBrown', 'restore this version');
+		let revertToRevisionLink = Twinkle.fluff.linkBuilder.buildLink('SaddleBrown', 'restore this version');
 		$(revertToRevisionLink).click(function(e) {
 			e.preventDefault();
 			Twinkle.fluff.revertToRevision(revisionRef);
@@ -191,19 +191,19 @@ Twinkle.fluff.addLinks = {
 		// $('sp-contributions-footer-anon-range') relies on the fmbox
 		// id in [[MediaWiki:Sp-contributions-footer-anon-range]] and
 		// is used to show rollback/vandalism links for IP ranges
-		var isRange = !!$('#sp-contributions-footer-anon-range')[0];
+		let isRange = !!$('#sp-contributions-footer-anon-range')[0];
 		if (mw.config.exists('wgRelevantUserName') || isRange) {
 			// Get the username these contributions are for
-			var username = mw.config.get('wgRelevantUserName');
+			let username = mw.config.get('wgRelevantUserName');
 			if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
 				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
 				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
-				var $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
+				let $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
 				$list.each(function(key, current) {
 					// revid is also available in the href of both
 					// .mw-changeslist-date or .mw-changeslist-diff
-					var page = $(current).find('.mw-contributions-title').text();
+					let page = $(current).find('.mw-contributions-title').text();
 
 					// Get username for IP ranges (wgRelevantUserName is null)
 					if (isRange) {
@@ -223,7 +223,7 @@ Twinkle.fluff.addLinks = {
 	recentchanges: function() {
 		if (Twinkle.getPref('showRollbackLinks').indexOf('recent') !== -1) {
 			// Latest and revertable (not page creations, logs, categorizations, etc.)
-			var $list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
+			let $list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
 			// Exclude top-level header if "group changes" preference is used
 			// and find only individual lines or nested lines
 			$list = $list.not('.mw-rcfilters-ui-highlights-enhanced-toplevel').find('.mw-changeslist-line-inner, td.mw-enhanced-rc-nested');
@@ -231,10 +231,10 @@ Twinkle.fluff.addLinks = {
 			$list.each(function(key, current) {
 				// The :not is possibly unnecessary, as it appears that
 				// .mw-userlink is simply not present if the username is hidden
-				var vandal = $(current).find('.mw-userlink:not(.history-deleted)').text();
-				var href = $(current).find('.mw-changeslist-diff').attr('href');
-				var rev = mw.util.getParamValue('diff', href);
-				var page = current.dataset.targetPage;
+				let vandal = $(current).find('.mw-userlink:not(.history-deleted)').text();
+				let href = $(current).find('.mw-changeslist-diff').attr('href');
+				let rev = mw.util.getParamValue('diff', href);
+				let page = current.dataset.targetPage;
 				current.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(vandal, true, rev, page));
 			});
 		}
@@ -243,19 +243,19 @@ Twinkle.fluff.addLinks = {
 	history: function() {
 		if (Twinkle.getPref('showRollbackLinks').indexOf('history') !== -1) {
 			// All revs
-			var histList = $('#pagehistory li').toArray();
+			let histList = $('#pagehistory li').toArray();
 
 			// On first page of results, so add revert/rollback
 			// links to the top revision
 			if (!$('a.mw-firstlink').length) {
-				var firstRow = histList.shift();
-				var firstUser = $(firstRow).find('.mw-userlink:not(.history-deleted)').text();
+				let firstRow = histList.shift();
+				let firstUser = $(firstRow).find('.mw-userlink:not(.history-deleted)').text();
 
 				// Check for first username different than the top user,
 				// only apply rollback links if/when found
 				// for() faster than every()
-				for (var i = 0; i < histList.length; i++) {
-					var hasMoreThanOneUser = $(histList[i]).find('.mw-userlink').text() !== firstUser;
+				for (let i = 0; i < histList.length; i++) {
+					let hasMoreThanOneUser = $(histList[i]).find('.mw-userlink').text() !== firstUser;
 					if (hasMoreThanOneUser) {
 						firstRow.appendChild(Twinkle.fluff.linkBuilder.rollbackLinks(firstUser, true));
 						break;
@@ -268,8 +268,8 @@ Twinkle.fluff.addLinks = {
 				// From restoreThisRevision, non-transferable
 				// If the text has been revdel'd, it gets wrapped in a span with .history-deleted,
 				// and href will be undefined (and thus oldid is NaN)
-				var href = rev.querySelector('.mw-changeslist-date').href;
-				var oldid = parseInt(mw.util.getParamValue('oldid', href), 10);
+				let href = rev.querySelector('.mw-changeslist-date').href;
+				let oldid = parseInt(mw.util.getParamValue('oldid', href), 10);
 				if (!isNaN(oldid)) {
 					rev.appendChild(Twinkle.fluff.linkBuilder.restoreThisRevisionLink(oldid, true));
 				}
@@ -281,15 +281,15 @@ Twinkle.fluff.addLinks = {
 
 	diff: function() {
 		// Autofill user talk links on diffs with vanarticle for easy warning, but don't autowarn
-		var warnFromTalk = function(xtitle) {
-			var talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
+		let warnFromTalk = function(xtitle) {
+			let talkLink = $('#mw-diff-' + xtitle + '2 .mw-usertoollinks a').first();
 			if (talkLink.length) {
-				var extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
+				let extraParams = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm) + '&' + 'noautowarn=true';
 				// diffIDs for vanarticlerevid
 				extraParams += '&vanarticlerevid=';
 				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
 
-				var href = talkLink.attr('href');
+				let href = talkLink.attr('href');
 				if (href.indexOf('?') === -1) {
 					talkLink.attr('href', href + '?' + extraParams);
 				} else {
@@ -303,7 +303,7 @@ Twinkle.fluff.addLinks = {
 		// Don't load if there's a single revision or weird diff (cur on latest)
 		if (mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId'))) {
 			// Add a [restore this revision] link to the older revision
-			var oldTitle = document.getElementById('mw-diff-otitle1').parentNode;
+			let oldTitle = document.getElementById('mw-diff-otitle1').parentNode;
 			oldTitle.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffOldId'), oldTitle.firstChild);
 		}
 
@@ -313,7 +313,7 @@ Twinkle.fluff.addLinks = {
 		// Don't show if there's a single revision or weird diff (prev on first)
 		if (document.getElementById('differences-nextlink')) {
 			// Not latest revision, add [restore this revision] link to newer revision
-			var newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
+			let newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
 			newTitle.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgDiffNewId'), newTitle.firstChild);
 		} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
 			// Normally .mw-userlink is a link, but if the
@@ -329,19 +329,19 @@ Twinkle.fluff.addLinks = {
 			// &unhide=1), since the username will be available by
 			// checking a.mw-userlink instead, but revert() will
 			// need reworking around userHidden
-			var vandal = $('#mw-diff-ntitle2').find('.mw-userlink')[0];
+			let vandal = $('#mw-diff-ntitle2').find('.mw-userlink')[0];
 			// See #1337
 			vandal = vandal ? vandal.text : '';
-			var ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
+			let ntitle = document.getElementById('mw-diff-ntitle1').parentNode;
 
 			ntitle.insertBefore(Twinkle.fluff.linkBuilder.rollbackLinks(vandal), ntitle.firstChild);
 		}
 	},
 
 	oldid: function() { // Add a [restore this revision] link on old revisions
-		var revisionInfo = document.getElementById('mw-revision-info');
+		let revisionInfo = document.getElementById('mw-revision-info');
 		if (revisionInfo) {
-			var title = revisionInfo.parentNode;
+			let title = revisionInfo.parentNode;
 			title.insertBefore(Twinkle.fluff.linkBuilder.restoreThisRevisionLink('wgRevisionId'), title.firstChild);
 		}
 	}
@@ -360,11 +360,11 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		vandal = Morebits.ip.sanitizeIPv6(vandal);
 	}
 
-	var pagename = page || mw.config.get('wgPageName');
-	var revid = rev || mw.config.get('wgCurRevisionId');
+	let pagename = page || mw.config.get('wgPageName');
+	let revid = rev || mw.config.get('wgCurRevisionId');
 
 	if (Twinkle.fluff.rollbackInPlace) {
-		var notifyStatus = document.createElement('span');
+		let notifyStatus = document.createElement('span');
 		mw.notify(notifyStatus, {
 			autoHide: false,
 			title: 'Rollback on ' + page,
@@ -376,7 +376,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		$('#catlinks').remove();
 	}
 
-	var params = {
+	let params = {
 		type: type,
 		user: vandal,
 		userHidden: !vandal, // Keep track of whether the username was hidden
@@ -384,7 +384,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		revid: revid
 	};
 
-	var query = {
+	let query = {
 		action: 'query',
 		prop: ['info', 'revisions', 'flagged'],
 		titles: pagename,
@@ -397,7 +397,7 @@ Twinkle.fluff.revert = function revertPage(type, vandal, rev, page) {
 		type: 'csrf',
 		format: 'json'
 	};
-	var wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
+	let wikipedia_api = new Morebits.wiki.api('Grabbing data of earlier revisions', query, Twinkle.fluff.callbacks.main);
 	wikipedia_api.params = params;
 	wikipedia_api.post();
 };
@@ -406,7 +406,7 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 
 	Morebits.status.init(document.getElementById('mw-content-text'));
 
-	var query = {
+	let query = {
 		action: 'query',
 		prop: ['info', 'revisions'],
 		titles: mw.config.get('wgPageName'),
@@ -419,42 +419,42 @@ Twinkle.fluff.revertToRevision = function revertToRevision(oldrev) {
 		type: 'csrf',
 		format: 'json'
 	};
-	var wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision);
+	let wikipedia_api = new Morebits.wiki.api('Grabbing data of the earlier revision', query, Twinkle.fluff.callbacks.toRevision);
 	wikipedia_api.params = { rev: oldrev };
 	wikipedia_api.post();
 };
 
 Twinkle.fluff.callbacks = {
 	toRevision: function(apiobj) {
-		var response = apiobj.getResponse();
+		let response = apiobj.getResponse();
 
-		var loadtimestamp = response.curtimestamp;
-		var csrftoken = response.query.tokens.csrftoken;
+		let loadtimestamp = response.curtimestamp;
+		let csrftoken = response.query.tokens.csrftoken;
 
-		var page = response.query.pages[0];
-		var lastrevid = parseInt(page.lastrevid, 10);
-		var touched = page.touched;
+		let page = response.query.pages[0];
+		let lastrevid = parseInt(page.lastrevid, 10);
+		let touched = page.touched;
 
-		var rev = page.revisions[0];
-		var revertToRevID = parseInt(rev.revid, 10);
-		var revertToUser = rev.user;
-		var revertToUserHidden = !!rev.userhidden;
+		let rev = page.revisions[0];
+		let revertToRevID = parseInt(rev.revid, 10);
+		let revertToUser = rev.user;
+		let revertToUserHidden = !!rev.userhidden;
 
 		if (revertToRevID !== apiobj.params.rev) {
 			apiobj.statelem.error('The retrieved revision does not match the requested revision. Stopping revert.');
 			return;
 		}
 
-		var optional_summary = prompt('Please specify a reason for the revert:                                ', '');  // padded out to widen prompt in Firefox
+		let optional_summary = prompt('Please specify a reason for the revert:                                ', '');  // padded out to widen prompt in Firefox
 		if (optional_summary === null) {
 			apiobj.statelem.error('Aborted by user.');
 			return;
 		}
 
-		var summary = Twinkle.fluff.formatSummary('Restored revision ' + revertToRevID + ' by $USER',
+		let summary = Twinkle.fluff.formatSummary('Restored revision ' + revertToRevID + ' by $USER',
 			revertToUserHidden ? null : revertToUser, optional_summary);
 
-		var query = {
+		let query = {
 			action: 'edit',
 			title: mw.config.get('wgPageName'),
 			summary: summary,
@@ -469,7 +469,7 @@ Twinkle.fluff.callbacks = {
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1) {
-			var watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+			let watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {
 				query.watchlist = 'nochange';
@@ -487,36 +487,36 @@ Twinkle.fluff.callbacks = {
 		Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 		Morebits.wiki.actionCompleted.notice = 'Reversion completed';
 
-		var wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, apiobj.statelem);
+		let wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, apiobj.statelem);
 		wikipedia_api.params = apiobj.params;
 		wikipedia_api.post();
 	},
 	main: function(apiobj) {
-		var response = apiobj.getResponse();
+		let response = apiobj.getResponse();
 
-		var loadtimestamp = response.curtimestamp;
-		var csrftoken = response.query.tokens.csrftoken;
+		let loadtimestamp = response.curtimestamp;
+		let csrftoken = response.query.tokens.csrftoken;
 
-		var page = response.query.pages[0];
+		let page = response.query.pages[0];
 		if (!page.actions.edit) {
 			apiobj.statelem.error("Unable to edit the page, it's probably protected.");
 			return;
 		}
 
-		var lastrevid = parseInt(page.lastrevid, 10);
-		var touched = page.touched;
+		let lastrevid = parseInt(page.lastrevid, 10);
+		let touched = page.touched;
 
-		var revs = page.revisions;
+		let revs = page.revisions;
 
-		var statelem = apiobj.statelem;
-		var params = apiobj.params;
+		let statelem = apiobj.statelem;
+		let params = apiobj.params;
 
 		if (revs.length < 1) {
 			statelem.error('We have less than one additional revision, thus impossible to revert.');
 			return;
 		}
-		var top = revs[0];
-		var lastuser = top.user;
+		let top = revs[0];
+		let lastuser = top.user;
 
 		if (lastrevid < params.revid) {
 			Morebits.status.error('Error', [ 'The most recent revision ID received from the server, ', Morebits.htmlNode('strong', lastrevid), ', is less than the ID of the displayed revision. This could indicate that the current revision has been deleted, the server is lagging, or that bad data has been received. Stopping revert.' ]);
@@ -524,8 +524,8 @@ Twinkle.fluff.callbacks = {
 		}
 
 		// Used for user-facing alerts, messages, etc., not edits or summaries
-		var userNorm = params.user || Twinkle.fluff.hiddenName;
-		var index = 1;
+		let userNorm = params.user || Twinkle.fluff.hiddenName;
+		let index = 1;
 		if (params.revid !== lastrevid) {
 			Morebits.status.warn('Warning', [ 'Latest revision ', Morebits.htmlNode('strong', lastrevid), ' doesn\'t equal our revision ', Morebits.htmlNode('strong', params.revid) ]);
 			// Treat ipv6 users on same 64 block as the same
@@ -589,11 +589,11 @@ Twinkle.fluff.callbacks = {
 					break;
 			}
 		}
-		var found = false;
-		var count = 0;
-		var seen64 = false;
+		let found = false;
+		let count = 0;
+		let seen64 = false;
 
-		for (var i = index; i < revs.length; ++i) {
+		for (let i = index; i < revs.length; ++i) {
 			++count;
 			if (revs[i].user !== params.user) {
 				// Treat ipv6 users on same 64 block as the same
@@ -619,8 +619,8 @@ Twinkle.fluff.callbacks = {
 			return;
 		}
 
-		var good_revision = revs[found];
-		var userHasAlreadyConfirmedAction = false;
+		let good_revision = revs[found];
+		let userHasAlreadyConfirmedAction = false;
 		if (params.type !== 'vand' && count > 1) {
 			if (!confirm(userNorm + ' has made ' + mw.language.convertNumber(count) + ' edits in a row. Are you sure you want to revert them all?')) {
 				Morebits.status.info('Notice', 'Stopping revert.');
@@ -637,7 +637,7 @@ Twinkle.fluff.callbacks = {
 
 		statelem.status([ ' revision ', Morebits.htmlNode('strong', params.goodid), ' that was made ', Morebits.htmlNode('strong', mw.language.convertNumber(count)), ' revisions ago by ', Morebits.htmlNode('strong', params.gooduserHidden ? Twinkle.fluff.hiddenName : params.gooduser) ]);
 
-		var summary, extra_summary;
+		let summary, extra_summary;
 		switch (params.type) {
 			case 'agf':
 				extra_summary = prompt('An optional comment for the edit summary:                              ', '');  // padded out to widen prompt in Firefox
@@ -690,7 +690,7 @@ Twinkle.fluff.callbacks = {
 		}
 
 		// figure out whether we need to/can review the edit
-		var flagged = page.flagged;
+		let flagged = page.flagged;
 		if ((Morebits.userIsInGroup('reviewer') || Morebits.userIsSysop) &&
 				!!flagged &&
 				flagged.stable_revid >= params.goodid &&
@@ -699,7 +699,7 @@ Twinkle.fluff.callbacks = {
 			params.csrftoken = csrftoken;
 		}
 
-		var query = {
+		let query = {
 			action: 'edit',
 			title: params.pagename,
 			summary: summary,
@@ -714,7 +714,7 @@ Twinkle.fluff.callbacks = {
 		};
 		// Handle watching, possible expiry
 		if (Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1) {
-			var watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
+			let watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {
 				query.watchlist = 'nochange';
@@ -734,15 +734,15 @@ Twinkle.fluff.callbacks = {
 		}
 		Morebits.wiki.actionCompleted.notice = 'Reversion completed';
 
-		var wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, statelem);
+		let wikipedia_api = new Morebits.wiki.api('Saving reverted contents', query, Twinkle.fluff.callbacks.complete, statelem);
 		wikipedia_api.params = params;
 		wikipedia_api.post();
 
 	},
 	complete: function (apiobj) {
 		// TODO Most of this is copy-pasted from Morebits.wiki.page#fnSaveSuccess. Unify it
-		var response = apiobj.getResponse();
-		var edit = response.edit;
+		let response = apiobj.getResponse();
+		let edit = response.edit;
 
 		if (edit.captcha) {
 			apiobj.statelem.error('Could not rollback, because the wiki server wanted you to fill out a CAPTCHA.');
@@ -750,12 +750,12 @@ Twinkle.fluff.callbacks = {
 			apiobj.statelem.error('Revision we are reverting to is identical to current revision, stopping revert.');
 		} else {
 			apiobj.statelem.info('done');
-			var params = apiobj.params;
+			let params = apiobj.params;
 
 			if (params.notifyUser && !params.userHidden) { // notifyUser only from main, not from toRevision
 				Morebits.status.info('Info', [ 'Opening user talk page edit form for user ', Morebits.htmlNode('strong', params.user) ]);
 
-				var url = mw.util.getUrl('User talk:' + params.user, {
+				let url = mw.util.getUrl('User talk:' + params.user, {
 					action: 'edit',
 					preview: 'yes',
 					vanarticle: params.pagename.replace(/_/g, ' '),
@@ -793,14 +793,14 @@ Twinkle.fluff.callbacks = {
 
 			// review the revert, if needed
 			if (apiobj.params.reviewRevert) {
-				var query = {
+				let query = {
 					action: 'review',
 					revid: edit.newrevid,
 					token: apiobj.params.csrftoken,
 					comment: 'Automatically reviewing reversion' + Twinkle.summaryAd // until the below
 					// 'tags': Twinkle.changeTags // flaggedrevs tag support: [[phab:T247721]]
 				};
-				var wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);
+				let wikipedia_api = new Morebits.wiki.api('Automatically accepting your changes', query);
 				wikipedia_api.post();
 			}
 		}
@@ -810,7 +810,7 @@ Twinkle.fluff.callbacks = {
 // If builtInString contains the string "$USER", it will be replaced
 // by an appropriate user link if a user name is provided
 Twinkle.fluff.formatSummary = function(builtInString, userName, customString) {
-	var result = builtInString;
+	let result = builtInString;
 
 	// append user's custom reason
 	if (customString) {
@@ -822,11 +822,11 @@ Twinkle.fluff.formatSummary = function(builtInString, userName, customString) {
 	// over the 499-byte limit
 	if (/\$USER/.test(builtInString)) {
 		if (userName) {
-			var resultLen = unescape(encodeURIComponent(result.replace('$USER', ''))).length;
-			var contribsLink = '[[Special:Contributions/' + userName + '|' + userName + ']]';
-			var contribsLen = unescape(encodeURIComponent(contribsLink)).length;
+			let resultLen = unescape(encodeURIComponent(result.replace('$USER', ''))).length;
+			let contribsLink = '[[Special:Contributions/' + userName + '|' + userName + ']]';
+			let contribsLen = unescape(encodeURIComponent(contribsLink)).length;
 			if (resultLen + contribsLen <= 499) {
-				var talkLink = ' ([[User talk:' + userName + '|talk]])';
+				let talkLink = ' ([[User talk:' + userName + '|talk]])';
 				if (resultLen + contribsLen + unescape(encodeURIComponent(talkLink)).length <= 499) {
 					result = Morebits.string.safeReplace(result, '$USER', contribsLink + talkLink);
 				} else {

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -26,7 +26,7 @@ Twinkle.fluff = function twinklefluff() {
 		// wgDiffOldId included for clarity in if else loop [[phab:T214985]]
 		if (mw.config.get('wgDiffNewId') || mw.config.get('wgDiffOldId')) {
 			// Reload alongside the revision slider
-			mw.hook('wikipage.diff').add(function () {
+			mw.hook('wikipage.diff').add(() => {
 				Twinkle.fluff.addLinks.diff();
 			});
 		} else if (mw.config.get('wgAction') === 'view' && mw.config.get('wgRevisionId') && mw.config.get('wgCurRevisionId') !== mw.config.get('wgRevisionId')) {
@@ -43,7 +43,7 @@ Twinkle.fluff = function twinklefluff() {
 		} else if (mw.config.get('wgCanonicalSpecialPageName') === 'Recentchanges' || mw.config.get('wgCanonicalSpecialPageName') === 'Recentchangeslinked') {
 			// Reload with recent changes updates
 			// structuredChangeFilters.ui.initialized is just on load
-			mw.hook('wikipage.content').add(function(item) {
+			mw.hook('wikipage.content').add((item) => {
 				if (item.is('div')) {
 					Twinkle.fluff.addLinks.recentchanges();
 				}
@@ -120,12 +120,12 @@ Twinkle.fluff.linkBuilder = {
 		normLink.style.fontWeight = 'bold';
 		vandLink.style.fontWeight = 'bold';
 
-		$(normLink).click(function(e) {
+		$(normLink).click((e) => {
 			e.preventDefault();
 			Twinkle.fluff.revert('norm', vandal, rev, page);
 			Twinkle.fluff.disableLinks(revNode);
 		});
-		$(vandLink).click(function(e) {
+		$(vandLink).click((e) => {
 			e.preventDefault();
 			Twinkle.fluff.revert('vand', vandal, rev, page);
 			Twinkle.fluff.disableLinks(revNode);
@@ -143,7 +143,7 @@ Twinkle.fluff.linkBuilder = {
 		if (!inline) {
 			const agfNode = document.createElement('span');
 			const agfLink = Twinkle.fluff.linkBuilder.buildLink('DarkOliveGreen', 'rollback (AGF)');
-			$(agfLink).click(function(e) {
+			$(agfLink).click((e) => {
 				e.preventDefault();
 				Twinkle.fluff.revert('agf', vandal, rev, page);
 				// Twinkle.fluff.disableLinks(revNode); // rollbackInPlace not relevant for any inline situations
@@ -172,7 +172,7 @@ Twinkle.fluff.linkBuilder = {
 		revertToRevisionNode.style.fontWeight = 'bold';
 
 		const revertToRevisionLink = Twinkle.fluff.linkBuilder.buildLink('SaddleBrown', 'restore this version');
-		$(revertToRevisionLink).click(function(e) {
+		$(revertToRevisionLink).click((e) => {
 			e.preventDefault();
 			Twinkle.fluff.revertToRevision(revisionRef);
 		});
@@ -200,7 +200,7 @@ Twinkle.fluff.addLinks = {
 				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
 				const $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
-				$list.each(function(key, current) {
+				$list.each((key, current) => {
 					// revid is also available in the href of both
 					// .mw-changeslist-date or .mw-changeslist-diff
 					const page = $(current).find('.mw-contributions-title').text();
@@ -228,7 +228,7 @@ Twinkle.fluff.addLinks = {
 			// and find only individual lines or nested lines
 			$list = $list.not('.mw-rcfilters-ui-highlights-enhanced-toplevel').find('.mw-changeslist-line-inner, td.mw-enhanced-rc-nested');
 
-			$list.each(function(key, current) {
+			$list.each((key, current) => {
 				// The :not is possibly unnecessary, as it appears that
 				// .mw-userlink is simply not present if the username is hidden
 				const vandal = $(current).find('.mw-userlink:not(.history-deleted)').text();
@@ -264,7 +264,7 @@ Twinkle.fluff.addLinks = {
 			}
 
 			// oldid
-			histList.forEach(function(rev) {
+			histList.forEach((rev) => {
 				// From restoreThisRevision, non-transferable
 				// If the text has been revdel'd, it gets wrapped in a span with .history-deleted,
 				// and href will be undefined (and thus oldid is NaN)
@@ -348,7 +348,7 @@ Twinkle.fluff.addLinks = {
 };
 
 Twinkle.fluff.disableLinks = function disablelinks(parentNode) {
-	$(parentNode).children().each(function(_ix, node) {
+	$(parentNode).children().each((_ix, node) => {
 		node.innerHTML = node.textContent; // Feels like cheating
 		$(node).css('font-weight', 'normal').css('color', 'darkgray');
 	});

--- a/modules/twinklefluff.js
+++ b/modules/twinklefluff.js
@@ -844,7 +844,7 @@ Twinkle.fluff.formatSummary = function(builtInString, userName, customString) {
 };
 
 Twinkle.addInitCallback(Twinkle.fluff, 'fluff');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -19,7 +19,7 @@ Twinkle.image = function twinkleimage() {
 };
 
 Twinkle.image.callback = function twinkleimageCallback() {
-	let Window = new Morebits.simpleWindow(600, 330);
+	const Window = new Morebits.simpleWindow(600, 330);
 	Window.setTitle('File for dated speedy deletion');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Speedy deletion policy', 'WP:CSD#Files');
@@ -27,7 +27,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#image');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.image.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.image.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -41,7 +41,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 		]
 	}
 	);
-	let field = form.append({
+	const field = form.append({
 		type: 'field',
 		label: 'Type of action wanted'
 	});
@@ -100,20 +100,20 @@ Twinkle.image.callback = function twinkleimageCallback() {
 	});
 	form.append({ type: 'submit' });
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// We must init the parameters
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.type[0].dispatchEvent(evt);
 };
 
 Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
-	let value = event.target.values;
-	let root = event.target.form;
-	let work_area = new Morebits.quickForm.element({
+	const value = event.target.values;
+	const root = event.target.form;
+	const work_area = new Morebits.quickForm.element({
 		type: 'div',
 		name: 'work_area'
 	});
@@ -182,7 +182,7 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 
 Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 
-	let input = Morebits.quickForm.getInputData(event.target);
+	const input = Morebits.quickForm.getInputData(event.target);
 	if (input.replacement) {
 		input.replacement = (new RegExp('^' + Morebits.namespaceRegex(6) + ':', 'i').test(input.replacement) ? '' : 'File:') + input.replacement;
 	}
@@ -211,10 +211,10 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 			throw new Error('Twinkle.image.callback.evaluate: unknown criterion');
 	}
 
-	let lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
-	let templatename = input.derivative ? 'dw ' + input.type : input.type;
+	const lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
+	const templatename = input.derivative ? 'dw ' + input.type : input.type;
 
-	let params = $.extend({
+	const params = $.extend({
 		templatename: templatename,
 		normalized: csdcrit,
 		lognomination: lognomination
@@ -227,7 +227,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete';
 
 	// Tagging image
-	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging file with deletion tag');
+	const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging file with deletion tag');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.image.callbacks.taggingImage);
 
@@ -240,7 +240,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 			Twinkle.image.callbacks.addToLog(params, null);
 		}
 		// No auto-notification, display what was going to be added.
-		let noteData = document.createElement('pre');
+		const noteData = document.createElement('pre');
 		noteData.appendChild(document.createTextNode('{{subst:di-' + templatename + '-notice|1=' + mw.config.get('wgTitle') + '}} ~~~~'));
 		Morebits.status.info('Notification', [ 'Following/similar data should be posted to the original uploader:', document.createElement('br'), noteData ]);
 	}
@@ -249,7 +249,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 Twinkle.image.callbacks = {
 	taggingImage: function(pageobj) {
 		let text = pageobj.getPageText();
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 
 		// remove "move to Commons" tag - deletion-tagged files cannot be moved to Commons
 		text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
@@ -285,14 +285,14 @@ Twinkle.image.callbacks = {
 		pageobj.save();
 	},
 	userNotification: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
-		let initialContrib = pageobj.getCreator();
+		const params = pageobj.getCallbackParameters();
+		const initialContrib = pageobj.getCreator();
 
 		// disallow warning yourself
 		if (initialContrib === mw.config.get('wgUserName')) {
 			pageobj.getStatusElement().warn('You (' + initialContrib + ') created this page; skipping user notification');
 		} else {
-			let usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
+			const usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
 			let notifytext = '\n{{subst:di-' + params.templatename + '-notice|1=' + mw.config.get('wgTitle');
 			if (params.type === 'no permission') {
 				notifytext += params.source ? '|source=' + params.source : '';
@@ -313,14 +313,14 @@ Twinkle.image.callbacks = {
 		}
 	},
 	addToLog: function(params, initialContrib) {
-		let usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
+		const usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
 		usl.initialText =
 			"This is a log of all [[WP:CSD|speedy deletion]] nominations made by this user using [[WP:TW|Twinkle]]'s CSD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 			(Morebits.userIsSysop ? '\n\nThis log does not track outright speedy deletions made using Twinkle.' : '');
 
-		let formatParamLog = function(normalize, csdparam, input) {
+		const formatParamLog = function(normalize, csdparam, input) {
 			if (normalize === 'F5' && csdparam === 'replacement') {
 				input = '[[:' + input + ']]';
 			}
@@ -330,7 +330,7 @@ Twinkle.image.callbacks = {
 		let extraInfo = '';
 
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-		let fileLogLink = ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])';
+		const fileLogLink = ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])';
 
 		let appendText = '# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ': DI [[WP:CSD#' + params.normalized.toUpperCase() + '|CSD ' + params.normalized.toUpperCase() + ']] ({{tl|di-' + params.templatename + '}})';
 
@@ -349,7 +349,7 @@ Twinkle.image.callbacks = {
 		}
 		appendText += ' ~~~~~\n';
 
-		let editsummary = 'Logging speedy deletion nomination of [[:' + Morebits.pageNameNorm + ']].';
+		const editsummary = 'Logging speedy deletion nomination of [[:' + Morebits.pageNameNorm + ']].';
 
 		usl.changeTags = Twinkle.changeTags;
 		usl.log(appendText, editsummary);

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -19,7 +19,7 @@ Twinkle.image = function twinkleimage() {
 };
 
 Twinkle.image.callback = function twinkleimageCallback() {
-	var Window = new Morebits.simpleWindow(600, 330);
+	let Window = new Morebits.simpleWindow(600, 330);
 	Window.setTitle('File for dated speedy deletion');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Speedy deletion policy', 'WP:CSD#Files');
@@ -27,7 +27,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#image');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.image.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.image.callback.evaluate);
 	form.append({
 		type: 'checkbox',
 		list: [
@@ -41,7 +41,7 @@ Twinkle.image.callback = function twinkleimageCallback() {
 		]
 	}
 	);
-	var field = form.append({
+	let field = form.append({
 		type: 'field',
 		label: 'Type of action wanted'
 	});
@@ -100,20 +100,20 @@ Twinkle.image.callback = function twinkleimageCallback() {
 	});
 	form.append({ type: 'submit' });
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// We must init the parameters
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.type[0].dispatchEvent(evt);
 };
 
 Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
-	var value = event.target.values;
-	var root = event.target.form;
-	var work_area = new Morebits.quickForm.element({
+	let value = event.target.values;
+	let root = event.target.form;
+	let work_area = new Morebits.quickForm.element({
 		type: 'div',
 		name: 'work_area'
 	});
@@ -182,12 +182,12 @@ Twinkle.image.callback.choice = function twinkleimageCallbackChoose(event) {
 
 Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 
-	var input = Morebits.quickForm.getInputData(event.target);
+	let input = Morebits.quickForm.getInputData(event.target);
 	if (input.replacement) {
 		input.replacement = (new RegExp('^' + Morebits.namespaceRegex(6) + ':', 'i').test(input.replacement) ? '' : 'File:') + input.replacement;
 	}
 
-	var csdcrit;
+	let csdcrit;
 	switch (input.type) {
 		case 'no source no license':
 		case 'no source':
@@ -211,10 +211,10 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 			throw new Error('Twinkle.image.callback.evaluate: unknown criterion');
 	}
 
-	var lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
-	var templatename = input.derivative ? 'dw ' + input.type : input.type;
+	let lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
+	let templatename = input.derivative ? 'dw ' + input.type : input.type;
 
-	var params = $.extend({
+	let params = $.extend({
 		templatename: templatename,
 		normalized: csdcrit,
 		lognomination: lognomination
@@ -227,7 +227,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete';
 
 	// Tagging image
-	var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging file with deletion tag');
+	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging file with deletion tag');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.image.callbacks.taggingImage);
 
@@ -240,7 +240,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 			Twinkle.image.callbacks.addToLog(params, null);
 		}
 		// No auto-notification, display what was going to be added.
-		var noteData = document.createElement('pre');
+		let noteData = document.createElement('pre');
 		noteData.appendChild(document.createTextNode('{{subst:di-' + templatename + '-notice|1=' + mw.config.get('wgTitle') + '}} ~~~~'));
 		Morebits.status.info('Notification', [ 'Following/similar data should be posted to the original uploader:', document.createElement('br'), noteData ]);
 	}
@@ -248,13 +248,13 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 
 Twinkle.image.callbacks = {
 	taggingImage: function(pageobj) {
-		var text = pageobj.getPageText();
-		var params = pageobj.getCallbackParameters();
+		let text = pageobj.getPageText();
+		let params = pageobj.getCallbackParameters();
 
 		// remove "move to Commons" tag - deletion-tagged files cannot be moved to Commons
 		text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
 
-		var tag = '{{di-' + params.templatename + '|date={{subst:#time:j F Y}}';
+		let tag = '{{di-' + params.templatename + '|date={{subst:#time:j F Y}}';
 		switch (params.type) {
 			case 'no source no license':
 			case 'no source':
@@ -285,15 +285,15 @@ Twinkle.image.callbacks = {
 		pageobj.save();
 	},
 	userNotification: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
-		var initialContrib = pageobj.getCreator();
+		let params = pageobj.getCallbackParameters();
+		let initialContrib = pageobj.getCreator();
 
 		// disallow warning yourself
 		if (initialContrib === mw.config.get('wgUserName')) {
 			pageobj.getStatusElement().warn('You (' + initialContrib + ') created this page; skipping user notification');
 		} else {
-			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
-			var notifytext = '\n{{subst:di-' + params.templatename + '-notice|1=' + mw.config.get('wgTitle');
+			let usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')');
+			let notifytext = '\n{{subst:di-' + params.templatename + '-notice|1=' + mw.config.get('wgTitle');
 			if (params.type === 'no permission') {
 				notifytext += params.source ? '|source=' + params.source : '';
 			}
@@ -313,26 +313,26 @@ Twinkle.image.callbacks = {
 		}
 	},
 	addToLog: function(params, initialContrib) {
-		var usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
+		let usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
 		usl.initialText =
 			"This is a log of all [[WP:CSD|speedy deletion]] nominations made by this user using [[WP:TW|Twinkle]]'s CSD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 			(Morebits.userIsSysop ? '\n\nThis log does not track outright speedy deletions made using Twinkle.' : '');
 
-		var formatParamLog = function(normalize, csdparam, input) {
+		let formatParamLog = function(normalize, csdparam, input) {
 			if (normalize === 'F5' && csdparam === 'replacement') {
 				input = '[[:' + input + ']]';
 			}
 			return ' {' + normalize + ' ' + csdparam + ': ' + input + '}';
 		};
 
-		var extraInfo = '';
+		let extraInfo = '';
 
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-		var fileLogLink = ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])';
+		let fileLogLink = ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])';
 
-		var appendText = '# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ': DI [[WP:CSD#' + params.normalized.toUpperCase() + '|CSD ' + params.normalized.toUpperCase() + ']] ({{tl|di-' + params.templatename + '}})';
+		let appendText = '# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ': DI [[WP:CSD#' + params.normalized.toUpperCase() + '|CSD ' + params.normalized.toUpperCase() + ']] ({{tl|di-' + params.templatename + '}})';
 
 		['reason', 'replacement', 'source'].forEach(function(item) {
 			if (params[item]) {
@@ -349,7 +349,7 @@ Twinkle.image.callbacks = {
 		}
 		appendText += ' ~~~~~\n';
 
-		var editsummary = 'Logging speedy deletion nomination of [[:' + Morebits.pageNameNorm + ']].';
+		let editsummary = 'Logging speedy deletion nomination of [[:' + Morebits.pageNameNorm + ']].';
 
 		usl.changeTags = Twinkle.changeTags;
 		usl.log(appendText, editsummary);

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -334,7 +334,7 @@ Twinkle.image.callbacks = {
 
 		let appendText = '# [[:' + Morebits.pageNameNorm + ']]' + fileLogLink + ': DI [[WP:CSD#' + params.normalized.toUpperCase() + '|CSD ' + params.normalized.toUpperCase() + ']] ({{tl|di-' + params.templatename + '}})';
 
-		['reason', 'replacement', 'source'].forEach(function(item) {
+		['reason', 'replacement', 'source'].forEach((item) => {
 			if (params[item]) {
 				extraInfo += formatParamLog(params.normalized.toUpperCase(), item, params[item]);
 				return false;

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -357,7 +357,7 @@ Twinkle.image.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.image, 'image');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -200,7 +200,7 @@ Twinkle.prod.callbacks = {
 		};
 
 		const wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
-		return wikipedia_api.post().then(function(apiobj) {
+		return wikipedia_api.post().then((apiobj) => {
 			const statelem = apiobj.statelem;
 
 			// Check talk page for templates indicating prior XfD or PROD
@@ -224,7 +224,7 @@ Twinkle.prod.callbacks = {
 		const ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
 		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
-		ts.lookupCreation(function(pageobj) {
+		ts.lookupCreation((pageobj) => {
 			params.initialContrib = pageobj.getCreator();
 			params.creation = pageobj.getCreationTimestamp();
 			pageobj.getStatusElement().info('Done, found ' + params.initialContrib);
@@ -238,7 +238,7 @@ Twinkle.prod.callbacks = {
 
 		const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		wikipedia_page.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
-		wikipedia_page.load(function(pageobj) {
+		wikipedia_page.load((pageobj) => {
 			const statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
@@ -377,7 +377,7 @@ Twinkle.prod.callbacks = {
 		usertalkpage.setChangeTags(Twinkle.changeTags);
 		usertalkpage.setCreateOption('recreate');
 		usertalkpage.setFollowRedirect(true, false);
-		usertalkpage.append(function onNotifySuccess() {
+		usertalkpage.append(() => {
 			// add nomination to the userspace log, if the user has enabled it
 			params.logInitialContrib = params.initialContrib;
 			def.resolve();
@@ -466,9 +466,9 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	// notification wasn't successful. Also, don't run if tagging was not done.
 	tm.add(cbs.addToLog, [ cbs.notifyAuthor, cbs.taggingPage ]);
 	// All set, go!
-	tm.execute().then(function() {
+	tm.execute().then(() => {
 		Morebits.status.actionCompleted('Tagging complete');
-		setTimeout(function () {
+		setTimeout(() => {
 			window.location.href = mw.util.getUrl(mw.config.get('wgPageName'));
 		}, Morebits.wiki.actionCompleted.timeOut);
 	});

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -38,11 +38,11 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 		// no default
 	}
 
-	let Window = new Morebits.simpleWindow(800, 410);
+	const Window = new Morebits.simpleWindow(800, 410);
 	Window.setTitle('Proposed deletion (PROD)');
 	Window.setScriptName('Twinkle');
 
-	let form = new Morebits.quickForm(Twinkle.prod.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.prod.callback.evaluate);
 
 	if (namespace === 'article') {
 		Window.addFooterLink('Proposed deletion policy', 'WP:PROD');
@@ -51,7 +51,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 		Window.addFooterLink('Proposed deletion policy', 'WP:PROD');
 	}
 
-	let field = form.append({
+	const field = form.append({
 		type: 'field',
 		label: 'PROD type',
 		id: 'prodtype_fieldset'
@@ -95,7 +95,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 
 	form.append({ type: 'submit', label: 'Propose deletion' });
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 
@@ -105,7 +105,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 	}
 
 	// Fake a change event on the first prod type radio, to initialize the type-dependent controls
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.prodtype[0].dispatchEvent(evt);
 
@@ -114,7 +114,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 
 Twinkle.prod.callback.prodtypechanged = function(event) {
 	// prepare frame for prod type dependant controls
-	let field = new Morebits.quickForm.element({
+	const field = new Morebits.quickForm.element({
 		type: 'field',
 		label: 'Parameters',
 		name: 'parameters'
@@ -185,13 +185,13 @@ let params = {};
 
 Twinkle.prod.callbacks = {
 	checkPriors: function twinkleprodcheckPriors() {
-		let talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		const talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
 		// Talk page templates for PROD-able discussions
-		let blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
+		const blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
 			'Template:Oldpuffull|' + // Legacy prior XfD template
 			'Template:Olddelrev|' + // Prior DRV template
 			'Template:Old prod';
-		let query = {
+		const query = {
 			action: 'query',
 			titles: talk_title,
 			prop: 'templates',
@@ -199,15 +199,15 @@ Twinkle.prod.callbacks = {
 			format: 'json'
 		};
 
-		let wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
+		const wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
 		return wikipedia_api.post().then(function(apiobj) {
-			let statelem = apiobj.statelem;
+			const statelem = apiobj.statelem;
 
 			// Check talk page for templates indicating prior XfD or PROD
-			let templates = apiobj.getResponse().query.pages[0].templates;
-			let numTemplates = templates && templates.length;
+			const templates = apiobj.getResponse().query.pages[0].templates;
+			const numTemplates = templates && templates.length;
 			if (numTemplates) {
-				let template = templates[0].title;
+				const template = templates[0].title;
 				if (numTemplates === 1 && template === 'Template:Old prod') {
 					params.oldProdPresent = true; // Mark for reference later, when deciding if to endorse
 				// if there are multiple templates, at least one of them would be a prior xfd template
@@ -220,8 +220,8 @@ Twinkle.prod.callbacks = {
 	},
 
 	fetchCreationInfo: function twinkleprodFetchCreationInfo() {
-		let def = $.Deferred();
-		let ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
+		const def = $.Deferred();
+		const ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
 		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 		ts.lookupCreation(function(pageobj) {
@@ -234,12 +234,12 @@ Twinkle.prod.callbacks = {
 	},
 
 	taggingPage: function twinkleprodTaggingPage() {
-		let def = $.Deferred();
+		const def = $.Deferred();
 
-		let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+		const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		wikipedia_page.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		wikipedia_page.load(function(pageobj) {
-			let statelem = pageobj.getStatusElement();
+			const statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist. Perhaps it has already been deleted.");
@@ -251,7 +251,7 @@ Twinkle.prod.callbacks = {
 			let text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			let tag_re = /{{(?:article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			const tag_re = /{{(?:article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();
@@ -259,7 +259,7 @@ Twinkle.prod.callbacks = {
 
 			// Remove tags that become superfluous with this action
 			text = text.replace(/{{\s*(userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:{{[^{}]*}}|[^{}])*)?}}\s*/gi, '');
-			let prod_re = /{{\s*(?:Prod blp|Proposed deletion)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
+			const prod_re = /{{\s*(?:Prod blp|Proposed deletion)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
 			let summaryText;
 
 			if (!prod_re.test(text)) {
@@ -288,11 +288,11 @@ Twinkle.prod.callbacks = {
 				}
 
 				// Insert tag after short description or any hatnotes
-				let wikipage = new Morebits.wikitext.page(text);
+				const wikipage = new Morebits.wikitext.page(text);
 				text = wikipage.insertAfterTemplates(tag + '\n', Twinkle.hatnoteRegex).getText();
 
 			} else {  // already tagged for PROD, so try endorsing it
-				let prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
+				const prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
 				if (prod2_re.test(text)) {
 					statelem.warn('Page already tagged with {{proposed deletion}} and {{proposed deletion endorsed}} templates, aborting procedure');
 					return def.reject();
@@ -331,16 +331,16 @@ Twinkle.prod.callbacks = {
 	},
 
 	addOldProd: function twinkleprodAddOldProd() {
-		let def = $.Deferred();
+		const def = $.Deferred();
 
 		if (params.oldProdPresent || params.blp) {
 			return def.resolve();
 		}
 
 		// Add {{Old prod}} to the talk page
-		let oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
-		let talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
-		let talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
+		const oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
+		const talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		const talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
 		talkpage.setPrependText(oldprodfull);
 		talkpage.setEditSummary('Adding {{Old prod}}');
 		talkpage.setChangeTags(Twinkle.changeTags);
@@ -351,7 +351,7 @@ Twinkle.prod.callbacks = {
 	},
 
 	notifyAuthor: function twinkleprodNotifyAuthor() {
-		let def = $.Deferred();
+		const def = $.Deferred();
 
 		if (!params.blp && !params.usertalk) {
 			return def.resolve();
@@ -369,9 +369,9 @@ Twinkle.prod.callbacks = {
 		} else {
 			notifyTemplate = 'proposed deletion notify';
 		}
-		let notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
+		const notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
 
-		let usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
+		const usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
 		usertalkpage.setAppendText(notifytext);
 		usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
 		usertalkpage.setChangeTags(Twinkle.changeTags);
@@ -390,7 +390,7 @@ Twinkle.prod.callbacks = {
 		if (!Twinkle.getPref('logProdPages')) {
 			return $.Deferred().resolve();
 		}
-		let usl = new Morebits.userspaceLogger(Twinkle.getPref('prodLogPageName'));
+		const usl = new Morebits.userspaceLogger(Twinkle.getPref('prodLogPageName'));
 		usl.initialText =
 			"This is a log of all [[WP:PROD|proposed deletion]] tags applied or endorsed by this user using [[WP:TW|Twinkle]]'s PROD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
@@ -425,8 +425,8 @@ Twinkle.prod.callbacks = {
 };
 
 Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
-	let form = e.target;
-	let input = Morebits.quickForm.getInputData(form);
+	const form = e.target;
+	const input = Morebits.quickForm.getInputData(form);
 
 	params = {
 		usertalk: input.notify || input.prodtype === 'prodblp',
@@ -443,8 +443,8 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	let tm = new Morebits.taskManager();
-	let cbs = Twinkle.prod.callbacks; // shortcut reference, cbs for `callbacks`
+	const tm = new Morebits.taskManager();
+	const cbs = Twinkle.prod.callbacks; // shortcut reference, cbs for `callbacks`
 
 	// Disable Morebits.wiki.numberOfActionsLeft system
 	Morebits.wiki.numberOfActionsLeft = 1000;

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -475,7 +475,7 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.prod, 'prod');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -23,7 +23,7 @@ Twinkle.prod = function twinkleprod() {
 };
 
 // Used in edit summaries, for comparisons, etc.
-var namespace;
+let namespace;
 
 Twinkle.prod.callback = function twinkleprodCallback() {
 	Twinkle.prod.defaultReason = Twinkle.getPref('prodReasonDefault');
@@ -38,11 +38,11 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 		// no default
 	}
 
-	var Window = new Morebits.simpleWindow(800, 410);
+	let Window = new Morebits.simpleWindow(800, 410);
 	Window.setTitle('Proposed deletion (PROD)');
 	Window.setScriptName('Twinkle');
 
-	var form = new Morebits.quickForm(Twinkle.prod.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.prod.callback.evaluate);
 
 	if (namespace === 'article') {
 		Window.addFooterLink('Proposed deletion policy', 'WP:PROD');
@@ -51,7 +51,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 		Window.addFooterLink('Proposed deletion policy', 'WP:PROD');
 	}
 
-	var field = form.append({
+	let field = form.append({
 		type: 'field',
 		label: 'PROD type',
 		id: 'prodtype_fieldset'
@@ -95,7 +95,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 
 	form.append({ type: 'submit', label: 'Propose deletion' });
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 
@@ -105,7 +105,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 	}
 
 	// Fake a change event on the first prod type radio, to initialize the type-dependent controls
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.prodtype[0].dispatchEvent(evt);
 
@@ -114,7 +114,7 @@ Twinkle.prod.callback = function twinkleprodCallback() {
 
 Twinkle.prod.callback.prodtypechanged = function(event) {
 	// prepare frame for prod type dependant controls
-	var field = new Morebits.quickForm.element({
+	let field = new Morebits.quickForm.element({
 		type: 'field',
 		label: 'Parameters',
 		name: 'parameters'
@@ -181,17 +181,17 @@ Twinkle.prod.callback.prodtypechanged = function(event) {
 
 // global params object, initially set in evaluate(), and
 // modified in various callback functions
-var params = {};
+let params = {};
 
 Twinkle.prod.callbacks = {
 	checkPriors: function twinkleprodcheckPriors() {
-		var talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		let talk_title = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
 		// Talk page templates for PROD-able discussions
-		var blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
+		let blocking_templates = 'Template:Old XfD multi|Template:Old MfD|Template:Oldffdfull|' + // Common prior XfD talk page templates
 			'Template:Oldpuffull|' + // Legacy prior XfD template
 			'Template:Olddelrev|' + // Prior DRV template
 			'Template:Old prod';
-		var query = {
+		let query = {
 			action: 'query',
 			titles: talk_title,
 			prop: 'templates',
@@ -199,15 +199,15 @@ Twinkle.prod.callbacks = {
 			format: 'json'
 		};
 
-		var wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
+		let wikipedia_api = new Morebits.wiki.api('Checking talk page for prior nominations', query);
 		return wikipedia_api.post().then(function(apiobj) {
-			var statelem = apiobj.statelem;
+			let statelem = apiobj.statelem;
 
 			// Check talk page for templates indicating prior XfD or PROD
-			var templates = apiobj.getResponse().query.pages[0].templates;
-			var numTemplates = templates && templates.length;
+			let templates = apiobj.getResponse().query.pages[0].templates;
+			let numTemplates = templates && templates.length;
 			if (numTemplates) {
-				var template = templates[0].title;
+				let template = templates[0].title;
 				if (numTemplates === 1 && template === 'Template:Old prod') {
 					params.oldProdPresent = true; // Mark for reference later, when deciding if to endorse
 				// if there are multiple templates, at least one of them would be a prior xfd template
@@ -220,8 +220,8 @@ Twinkle.prod.callbacks = {
 	},
 
 	fetchCreationInfo: function twinkleprodFetchCreationInfo() {
-		var def = $.Deferred();
-		var ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
+		let def = $.Deferred();
+		let ts = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Looking up page creator');
 		ts.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		ts.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 		ts.lookupCreation(function(pageobj) {
@@ -234,12 +234,12 @@ Twinkle.prod.callbacks = {
 	},
 
 	taggingPage: function twinkleprodTaggingPage() {
-		var def = $.Deferred();
+		let def = $.Deferred();
 
-		var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+		let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		wikipedia_page.setFollowRedirect(true);  // for NPP, and also because redirects are ineligible for PROD
 		wikipedia_page.load(function(pageobj) {
-			var statelem = pageobj.getStatusElement();
+			let statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist. Perhaps it has already been deleted.");
@@ -248,10 +248,10 @@ Twinkle.prod.callbacks = {
 				return def.reject();
 			}
 
-			var text = pageobj.getPageText();
+			let text = pageobj.getPageText();
 
 			// Check for already existing deletion tags
-			var tag_re = /{{(?:article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
+			let tag_re = /{{(?:article for deletion\/dated|AfDM|ffd\b)|#invoke:RfD/i;
 			if (tag_re.test(text)) {
 				statelem.warn('Page already tagged with a deletion template, aborting procedure');
 				return def.reject();
@@ -259,8 +259,8 @@ Twinkle.prod.callbacks = {
 
 			// Remove tags that become superfluous with this action
 			text = text.replace(/{{\s*(userspace draft|mtc|(copy|move) to wikimedia commons|(copy |move )?to ?commons)\s*(\|(?:{{[^{}]*}}|[^{}])*)?}}\s*/gi, '');
-			var prod_re = /{{\s*(?:Prod blp|Proposed deletion)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
-			var summaryText;
+			let prod_re = /{{\s*(?:Prod blp|Proposed deletion)\/dated(?: files)?\s*\|(?:{{[^{}]*}}|[^{}])*}}/i;
+			let summaryText;
 
 			if (!prod_re.test(text)) {
 
@@ -278,7 +278,7 @@ Twinkle.prod.callbacks = {
 					}
 				}
 
-				var tag;
+				let tag;
 				if (params.blp) {
 					summaryText = 'Proposing article for deletion per [[WP:BLPPROD]].';
 					tag = '{{subst:prod blp' + (params.usertalk ? '|help=off' : '') + '}}';
@@ -288,16 +288,16 @@ Twinkle.prod.callbacks = {
 				}
 
 				// Insert tag after short description or any hatnotes
-				var wikipage = new Morebits.wikitext.page(text);
+				let wikipage = new Morebits.wikitext.page(text);
 				text = wikipage.insertAfterTemplates(tag + '\n', Twinkle.hatnoteRegex).getText();
 
 			} else {  // already tagged for PROD, so try endorsing it
-				var prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
+				let prod2_re = /{{(?:Proposed deletion endorsed|prod-?2).*?}}/i;
 				if (prod2_re.test(text)) {
 					statelem.warn('Page already tagged with {{proposed deletion}} and {{proposed deletion endorsed}} templates, aborting procedure');
 					return def.reject();
 				}
-				var confirmtext = 'A {{proposed deletion}} tag was already found on this page. \nWould you like to add a {{proposed deletion endorsed}} tag with your explanation?';
+				let confirmtext = 'A {{proposed deletion}} tag was already found on this page. \nWould you like to add a {{proposed deletion endorsed}} tag with your explanation?';
 				if (params.blp && !/{{\s*Prod blp\/dated/.test(text)) {
 					confirmtext = 'A non-BLP {{proposed deletion}} tag was found on this article.\nWould you like to add a {{proposed deletion endorsed}} tag with explanation "article is a biography of a living person with no sources"?';
 				}
@@ -331,16 +331,16 @@ Twinkle.prod.callbacks = {
 	},
 
 	addOldProd: function twinkleprodAddOldProd() {
-		var def = $.Deferred();
+		let def = $.Deferred();
 
 		if (params.oldProdPresent || params.blp) {
 			return def.resolve();
 		}
 
 		// Add {{Old prod}} to the talk page
-		var oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
-		var talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
-		var talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
+		let oldprodfull = '{{Old prod|nom=' + mw.config.get('wgUserName') + '|nomdate={{subst:#time: Y-m-d}}}}\n';
+		let talktitle = new mw.Title(mw.config.get('wgPageName')).getTalkPage().getPrefixedText();
+		let talkpage = new Morebits.wiki.page(talktitle, 'Placing {{Old prod}} on talk page');
 		talkpage.setPrependText(oldprodfull);
 		talkpage.setEditSummary('Adding {{Old prod}}');
 		talkpage.setChangeTags(Twinkle.changeTags);
@@ -351,7 +351,7 @@ Twinkle.prod.callbacks = {
 	},
 
 	notifyAuthor: function twinkleprodNotifyAuthor() {
-		var def = $.Deferred();
+		let def = $.Deferred();
 
 		if (!params.blp && !params.usertalk) {
 			return def.resolve();
@@ -363,15 +363,15 @@ Twinkle.prod.callbacks = {
 			return def.resolve();
 		}
 		// [[Template:Proposed deletion notify]] supports File namespace
-		var notifyTemplate;
+		let notifyTemplate;
 		if (params.blp) {
 			notifyTemplate = 'prodwarningBLP';
 		} else {
 			notifyTemplate = 'proposed deletion notify';
 		}
-		var notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
+		let notifytext = '\n{{subst:' + notifyTemplate + '|1=' + Morebits.pageNameNorm + '|concern=' + params.reason + '}} ~~~~';
 
-		var usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
+		let usertalkpage = new Morebits.wiki.page('User talk:' + params.initialContrib, 'Notifying initial contributor (' + params.initialContrib + ')');
 		usertalkpage.setAppendText(notifytext);
 		usertalkpage.setEditSummary('Notification: proposed deletion of [[:' + Morebits.pageNameNorm + ']].');
 		usertalkpage.setChangeTags(Twinkle.changeTags);
@@ -390,14 +390,14 @@ Twinkle.prod.callbacks = {
 		if (!Twinkle.getPref('logProdPages')) {
 			return $.Deferred().resolve();
 		}
-		var usl = new Morebits.userspaceLogger(Twinkle.getPref('prodLogPageName'));
+		let usl = new Morebits.userspaceLogger(Twinkle.getPref('prodLogPageName'));
 		usl.initialText =
 			"This is a log of all [[WP:PROD|proposed deletion]] tags applied or endorsed by this user using [[WP:TW|Twinkle]]'s PROD module.\n\n" +
 			'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].';
 
-		var logText = '# [[:' + Morebits.pageNameNorm + ']]';
-		var summaryText;
+		let logText = '# [[:' + Morebits.pageNameNorm + ']]';
+		let summaryText;
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
 		logText += namespace === 'file' ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log]): ' : ': ';
 		if (params.logEndorsing) {
@@ -425,8 +425,8 @@ Twinkle.prod.callbacks = {
 };
 
 Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
-	var form = e.target;
-	var input = Morebits.quickForm.getInputData(form);
+	let form = e.target;
+	let input = Morebits.quickForm.getInputData(form);
 
 	params = {
 		usertalk: input.notify || input.prodtype === 'prodblp',
@@ -443,8 +443,8 @@ Twinkle.prod.callback.evaluate = function twinkleprodCallbackEvaluate(e) {
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	var tm = new Morebits.taskManager();
-	var cbs = Twinkle.prod.callbacks; // shortcut reference, cbs for `callbacks`
+	let tm = new Morebits.taskManager();
+	let cbs = Twinkle.prod.callbacks; // shortcut reference, cbs for `callbacks`
 
 	// Disable Morebits.wiki.numberOfActionsLeft system
 	Morebits.wiki.numberOfActionsLeft = 1000;

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -24,7 +24,7 @@ Twinkle.protect = function twinkleprotect() {
 };
 
 Twinkle.protect.callback = function twinkleprotectCallback() {
-	let Window = new Morebits.simpleWindow(620, 530);
+	const Window = new Morebits.simpleWindow(620, 530);
 	Window.setTitle(Morebits.userIsSysop ? 'Apply, request or tag page protection' : 'Request or tag page protection');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Protection templates', 'Template:Protection templates');
@@ -32,8 +32,8 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#protect');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.protect.callback.evaluate);
-	let actionfield = form.append({
+	const form = new Morebits.quickForm(Twinkle.protect.callback.evaluate);
+	const actionfield = form.append({
 		type: 'field',
 		label: 'Type of action'
 	});
@@ -78,12 +78,12 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 
 	form.append({ type: 'submit' });
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// We must init the controls
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.actiontype[0].dispatchEvent(evt);
 
@@ -104,11 +104,11 @@ Twinkle.protect.trustedBots = ['MusikBot II', 'TFA Protector Bot'];
 // FlaggedRevs extension is not registered.  Previously, this was done with
 // wgFlaggedRevsParams, but after 1.34-wmf4 it is no longer exported if empty
 // (https://gerrit.wikimedia.org/r/c/mediawiki/extensions/FlaggedRevs/+/508427)
-let hasFlaggedRevs = mw.loader.getState('ext.flaggedRevs.review') &&
+const hasFlaggedRevs = mw.loader.getState('ext.flaggedRevs.review') &&
 // FlaggedRevs only valid in some namespaces, hardcoded until [[phab:T218479]]
 (mw.config.get('wgNamespaceNumber') === 0 || mw.config.get('wgNamespaceNumber') === 4);
 // Limit template editor; a Twinkle restriction, not a site setting
-let isTemplate = mw.config.get('wgNamespaceNumber') === 10 || mw.config.get('wgNamespaceNumber') === 828;
+const isTemplate = mw.config.get('wgNamespaceNumber') === 10 || mw.config.get('wgNamespaceNumber') === 828;
 
 
 // Contains the current protection level in an object
@@ -129,7 +129,7 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 		letype: protType
 	}).then(function(data) {
 		// don't check log entries that have already been checked (e.g. don't go into an infinite loop!)
-		let event = data.query ? $.grep(data.query.logevents, function(le) {
+		const event = data.query ? $.grep(data.query.logevents, function(le) {
 			return $.inArray(le.logid, logIds);
 		})[0] : null;
 		if (!event) {
@@ -144,8 +144,8 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 
 Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLevel() {
 
-	let api = new mw.Api();
-	let protectDeferred = api.get({
+	const api = new mw.Api();
+	const protectDeferred = api.get({
 		format: 'json',
 		indexpageids: true,
 		action: 'query',
@@ -156,7 +156,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		inprop: 'protection|watched',
 		titles: mw.config.get('wgPageName')
 	});
-	let stableDeferred = api.get({
+	const stableDeferred = api.get({
 		format: 'json',
 		action: 'query',
 		list: 'logevents',
@@ -164,7 +164,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		letitle: mw.config.get('wgPageName')
 	});
 
-	let earlyDecision = [protectDeferred];
+	const earlyDecision = [protectDeferred];
 	if (hasFlaggedRevs) {
 		earlyDecision.push(stableDeferred);
 	}
@@ -177,8 +177,8 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		// This is annoying.
 		protectData = $(protectData).toArray();
 
-		let pageid = protectData[0].query.pageids[0];
-		let page = protectData[0].query.pages[pageid];
+		const pageid = protectData[0].query.pageids[0];
+		const page = protectData[0].query.pages[pageid];
 		let current = {}, adminEditDeferred;
 
 		// Save requested page's watched status for later in case needed when filing request
@@ -239,16 +239,16 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 };
 
 Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectCallbackShowLogAndCurrentProtectInfo() {
-	let currentlyProtected = !$.isEmptyObject(Twinkle.protect.currentProtectionLevels);
+	const currentlyProtected = !$.isEmptyObject(Twinkle.protect.currentProtectionLevels);
 
 	if (Twinkle.protect.hasProtectLog || Twinkle.protect.hasStableLog) {
-		let $linkMarkup = $('<span>');
+		const $linkMarkup = $('<span>');
 
 		if (Twinkle.protect.hasProtectLog) {
 			$linkMarkup.append(
 				$('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'protect'}) + '">protection log</a>'));
 			if (!currentlyProtected || (!Twinkle.protect.currentProtectionLevels.edit && !Twinkle.protect.currentProtectionLevels.move)) {
-				let lastProtectAction = Twinkle.protect.protectLog[0];
+				const lastProtectAction = Twinkle.protect.protectLog[0];
 				if (lastProtectAction.action === 'unprotect') {
 					$linkMarkup.append(' (unprotected ' + new Morebits.date(lastProtectAction.timestamp).calendar('utc') + ')');
 				} else { // protect or modify
@@ -261,7 +261,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 		if (Twinkle.protect.hasStableLog) {
 			$linkMarkup.append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'stable'}) + '">pending changes log</a>)'));
 			if (!currentlyProtected || !Twinkle.protect.currentProtectionLevels.stabilize) {
-				let lastStabilizeAction = Twinkle.protect.stableLog[0];
+				const lastStabilizeAction = Twinkle.protect.stableLog[0];
 				if (lastStabilizeAction.action === 'reset') {
 					$linkMarkup.append(' (reset ' + new Morebits.date(lastStabilizeAction.timestamp).calendar('utc') + ')');
 				} else { // config or modify
@@ -288,7 +288,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 				label = 'Cascading protection ';
 				protectionNode.push($('<b>' + label + '</b>')[0]);
 				if (settings.source) { // Should by definition exist
-					let sourceLink = '<a target="_blank" href="' + mw.util.getUrl(settings.source) + '">' + settings.source + '</a>';
+					const sourceLink = '<a target="_blank" href="' + mw.util.getUrl(settings.source) + '">' + settings.source + '</a>';
 					protectionNode.push($('<span>from ' + sourceLink + '</span>')[0]);
 				}
 			} else {
@@ -306,7 +306,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 				protectionNode.push(' (expires ' + new Morebits.date(settings.expiry).calendar('utc') + ') ');
 			}
 			if (settings.admin) {
-				let adminLink = '<a target="_blank" href="' + mw.util.getUrl('User talk:' + settings.admin) + '">' + settings.admin + '</a>';
+				const adminLink = '<a target="_blank" href="' + mw.util.getUrl('User talk:' + settings.admin) + '">' + settings.admin + '</a>';
 				protectionNode.push($('<span>by ' + adminLink + '</span>')[0]);
 			}
 			protectionNode.push($('<span> \u2022 </span>')[0]);
@@ -597,7 +597,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 
 	if (e.target.values === 'protect') {
 		// fake a change event on the preset dropdown
-		let evt = document.createEvent('Event');
+		const evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 		e.target.form.category.dispatchEvent(evt);
 
@@ -653,9 +653,9 @@ Twinkle.protect.formevents = {
 };
 
 Twinkle.protect.doCustomExpiry = function twinkleprotectDoCustomExpiry(target) {
-	let custom = prompt('Enter a custom expiry time.  \nYou can use relative times, like "1 minute" or "19 days", or absolute timestamps, "yyyymmddhhmm" (e.g. "200602011405" is Feb 1, 2006, at 14:05 UTC).', '');
+	const custom = prompt('Enter a custom expiry time.  \nYou can use relative times, like "1 minute" or "19 days", or absolute timestamps, "yyyymmddhhmm" (e.g. "200602011405" is Feb 1, 2006, at 14:05 UTC).', '');
 	if (custom) {
-		let option = document.createElement('option');
+		const option = document.createElement('option');
 		option.setAttribute('value', custom);
 		option.textContent = custom;
 		target.appendChild(option);
@@ -1007,9 +1007,9 @@ Twinkle.protect.protectionTags = [
 });
 
 Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePreset(e) {
-	let form = e.target.form;
+	const form = e.target.form;
 
-	let actiontypes = form.actiontype;
+	const actiontypes = form.actiontype;
 	let actiontype;
 	for (let i = 0; i < actiontypes.length; i++) {
 		if (!actiontypes[i].checked) {
@@ -1020,7 +1020,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 	}
 
 	if (actiontype === 'protect') {  // actually protecting the page
-		let item = Twinkle.protect.protectionPresetsInfo[form.category.value];
+		const item = Twinkle.protect.protectionPresetsInfo[form.category.value];
 
 		if (mw.config.get('wgArticleId')) {
 			if (item.edit) {
@@ -1066,7 +1066,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			form.createexpiry.value = item.expiry || 'infinity';
 		}
 
-		let reasonField = actiontype === 'protect' ? form.protectReason : form.reason;
+		const reasonField = actiontype === 'protect' ? form.protectReason : form.reason;
 		if (item.reason) {
 			reasonField.value = item.reason;
 		} else {
@@ -1085,10 +1085,10 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			Twinkle.protect.formevents.tagtype({ target: form.tagtype });
 
 			// Default settings for adding <noinclude> tags to protection templates
-			let isTemplateEditorProtection = form.category.value === 'pp-template';
-			let isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
-			let isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
-			let isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
+			const isTemplateEditorProtection = form.category.value === 'pp-template';
+			const isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
+			const isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
+			const isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
 			if ((isTemplateEditorProtection || isAFD) && !isCode) {
 				form.noinclude.checked = true;
 			} else if (isCode || isNotTemplateNamespace) {
@@ -1108,8 +1108,8 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 };
 
 Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
-	let form = e.target;
-	let input = Morebits.quickForm.getInputData(form);
+	const form = e.target;
+	const input = Morebits.quickForm.getInputData(form);
 
 	let tagparams;
 	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */)) {
@@ -1402,8 +1402,8 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 
 Twinkle.protect.protectReasonAnnotations = [];
 Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallbackAnnotateProtectReason(e) {
-	let form = e.target.form;
-	let protectReason = form.protectReason.value.replace(new RegExp('(?:; )?' + mw.util.escapeRegExp(Twinkle.protect.protectReasonAnnotations.join(': '))), '');
+	const form = e.target.form;
+	const protectReason = form.protectReason.value.replace(new RegExp('(?:; )?' + mw.util.escapeRegExp(Twinkle.protect.protectReasonAnnotations.join(': '))), '');
 
 	if (this.name === 'protectReason_notes_rfpp') {
 		if (this.checked) {
@@ -1419,7 +1419,7 @@ Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallback
 			return el.indexOf('[[Special:Permalink') === -1;
 		});
 		if (e.target.value.length) {
-			let permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
+			const permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
 			Twinkle.protect.protectReasonAnnotations.push(permalink);
 		}
 	}
@@ -1438,17 +1438,17 @@ Twinkle.protect.callbacks = {
 			return;
 		}
 
-		let protectedPage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+		const protectedPage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		protectedPage.setCallbackParameters(tagparams);
 		protectedPage.load(Twinkle.protect.callbacks.taggingPage);
 	},
 	taggingPage: function(protectedPage) {
-		let params = protectedPage.getCallbackParameters();
+		const params = protectedPage.getCallbackParameters();
 		let text = protectedPage.getPageText();
 		let tag, summary;
 
-		let oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?\s*/gi;
-		let re_result = oldtag_re.exec(text);
+		const oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?\s*/gi;
+		const re_result = oldtag_re.exec(text);
 		if (re_result) {
 			if (params.tag === 'none' || confirm('{{' + re_result[1] + '}} was found on the page. \nClick OK to remove it, or click Cancel to leave it there.')) {
 				text = text.replace(oldtag_re, '');
@@ -1475,7 +1475,7 @@ Twinkle.protect.callbacks = {
 					return;
 				}
 			} else {
-				let needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].indexOf(protectedPage.getContentModel()) !== -1;
+				const needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].indexOf(protectedPage.getContentModel()) !== -1;
 				if (needsTagToBeCommentedOut) {
 					if (params.noinclude) {
 						tag = '/* <noinclude>{{' + tag + '}}</noinclude> */';
@@ -1497,7 +1497,7 @@ Twinkle.protect.callbacks = {
 					}
 
 					// Insert tag after short description or any hatnotes
-					let wikipage = new Morebits.wikitext.page(text);
+					const wikipage = new Morebits.wikitext.page(text);
 					text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 				}
 			}
@@ -1515,17 +1515,17 @@ Twinkle.protect.callbacks = {
 
 	fileRequest: function(rppPage) {
 
-		let rppPage2 = new Morebits.wiki.page('Wikipedia:Requests for page protection/Decrease', 'Loading requests pages');
+		const rppPage2 = new Morebits.wiki.page('Wikipedia:Requests for page protection/Decrease', 'Loading requests pages');
 		rppPage2.load(function() {
-			let params = rppPage.getCallbackParameters();
+			const params = rppPage.getCallbackParameters();
 			let text = rppPage.getPageText();
-			let statusElement = rppPage.getStatusElement();
+			const statusElement = rppPage.getStatusElement();
 			let text2 = rppPage2.getPageText();
 
-			let rppRe = new RegExp('===\\s*(\\[\\[)?\\s*:?\\s*' + Morebits.string.escapeRegExp(Morebits.pageNameNorm) + '\\s*(\\]\\])?\\s*===', 'm');
-			let tag = rppRe.exec(text) || rppRe.exec(text2);
+			const rppRe = new RegExp('===\\s*(\\[\\[)?\\s*:?\\s*' + Morebits.string.escapeRegExp(Morebits.pageNameNorm) + '\\s*(\\]\\])?\\s*===', 'm');
+			const tag = rppRe.exec(text) || rppRe.exec(text2);
 
-			let rppLink = document.createElement('a');
+			const rppLink = document.createElement('a');
 			rppLink.setAttribute('href', mw.util.getUrl('Wikipedia:Requests for page protection'));
 			rppLink.appendChild(document.createTextNode('Wikipedia:Requests for page protection'));
 
@@ -1562,10 +1562,10 @@ Twinkle.protect.callbacks = {
 			// If either protection type results in a increased status, then post it under increase
 			// else we post it under decrease
 			let increase = false;
-			let protInfo = Twinkle.protect.protectionPresetsInfo[params.category];
+			const protInfo = Twinkle.protect.protectionPresetsInfo[params.category];
 
 			// function to compute protection weights (see comment at Twinkle.protect.protectionWeight)
-			let computeWeight = function(mainLevel, stabilizeLevel) {
+			const computeWeight = function(mainLevel, stabilizeLevel) {
 				let result = Twinkle.protect.protectionWeight[mainLevel || 'all'];
 				if (stabilizeLevel) {
 					if (result) {
@@ -1580,7 +1580,7 @@ Twinkle.protect.callbacks = {
 			};
 
 			// compare the page's current protection weights with the protection we are requesting
-			let editWeight = computeWeight(Twinkle.protect.currentProtectionLevels.edit &&
+			const editWeight = computeWeight(Twinkle.protect.currentProtectionLevels.edit &&
 				Twinkle.protect.currentProtectionLevels.edit.level,
 			Twinkle.protect.currentProtectionLevels.stabilize &&
 				Twinkle.protect.currentProtectionLevels.stabilize.level);
@@ -1593,10 +1593,10 @@ Twinkle.protect.callbacks = {
 			}
 
 			if (increase) {
-				let originalTextLength = text.length;
+				const originalTextLength = text.length;
 				text += '\n' + newtag;
 				if (text.length === originalTextLength) {
-					let linknode = document.createElement('a');
+					const linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode.appendChild(document.createTextNode('How to fix RPP'));
 					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode, '.' ]);
@@ -1610,13 +1610,13 @@ Twinkle.protect.callbacks = {
 				rppPage.setCreateOption('recreate');
 				rppPage.save(function() {
 					// Watch the page being requested
-					let watchPref = Twinkle.getPref('watchRequestedPages');
+					const watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.
 					// The watchdefault pref appears to reliably return '1' (string),
 					// but that's not consistent among prefs so might as well be "correct"
-					let watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
+					const watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
 					if (watch) {
-						let watch_query = {
+						const watch_query = {
 							action: 'watch',
 							titles: mw.config.get('wgPageName'),
 							token: mw.user.tokens.get('watchToken')
@@ -1629,10 +1629,10 @@ Twinkle.protect.callbacks = {
 					}
 				});
 			} else {
-				let originalTextLength2 = text2.length;
+				const originalTextLength2 = text2.length;
 				text2 += '\n' + newtag;
 				if (text2.length === originalTextLength2) {
-					let linknode2 = document.createElement('a');
+					const linknode2 = document.createElement('a');
 					linknode2.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode2.appendChild(document.createTextNode('How to fix RPP'));
 					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode2, '.' ]);
@@ -1646,13 +1646,13 @@ Twinkle.protect.callbacks = {
 				rppPage2.setCreateOption('recreate');
 				rppPage2.save(function() {
 					// Watch the page being requested
-					let watchPref = Twinkle.getPref('watchRequestedPages');
+					const watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.
 					// The watchdefault pref appears to reliably return '1' (string),
 					// but that's not consistent among prefs so might as well be "correct"
-					let watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
+					const watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
 					if (watch) {
-						let watch_query = {
+						const watch_query = {
 							action: 'watch',
 							titles: mw.config.get('wgPageName'),
 							token: mw.user.tokens.get('watchToken')

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -24,7 +24,7 @@ Twinkle.protect = function twinkleprotect() {
 };
 
 Twinkle.protect.callback = function twinkleprotectCallback() {
-	var Window = new Morebits.simpleWindow(620, 530);
+	let Window = new Morebits.simpleWindow(620, 530);
 	Window.setTitle(Morebits.userIsSysop ? 'Apply, request or tag page protection' : 'Request or tag page protection');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Protection templates', 'Template:Protection templates');
@@ -32,8 +32,8 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#protect');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.protect.callback.evaluate);
-	var actionfield = form.append({
+	let form = new Morebits.quickForm(Twinkle.protect.callback.evaluate);
+	let actionfield = form.append({
 		type: 'field',
 		label: 'Type of action'
 	});
@@ -78,12 +78,12 @@ Twinkle.protect.callback = function twinkleprotectCallback() {
 
 	form.append({ type: 'submit' });
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 
 	// We must init the controls
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.actiontype[0].dispatchEvent(evt);
 
@@ -104,11 +104,11 @@ Twinkle.protect.trustedBots = ['MusikBot II', 'TFA Protector Bot'];
 // FlaggedRevs extension is not registered.  Previously, this was done with
 // wgFlaggedRevsParams, but after 1.34-wmf4 it is no longer exported if empty
 // (https://gerrit.wikimedia.org/r/c/mediawiki/extensions/FlaggedRevs/+/508427)
-var hasFlaggedRevs = mw.loader.getState('ext.flaggedRevs.review') &&
+let hasFlaggedRevs = mw.loader.getState('ext.flaggedRevs.review') &&
 // FlaggedRevs only valid in some namespaces, hardcoded until [[phab:T218479]]
 (mw.config.get('wgNamespaceNumber') === 0 || mw.config.get('wgNamespaceNumber') === 4);
 // Limit template editor; a Twinkle restriction, not a site setting
-var isTemplate = mw.config.get('wgNamespaceNumber') === 10 || mw.config.get('wgNamespaceNumber') === 828;
+let isTemplate = mw.config.get('wgNamespaceNumber') === 10 || mw.config.get('wgNamespaceNumber') === 828;
 
 
 // Contains the current protection level in an object
@@ -129,7 +129,7 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 		letype: protType
 	}).then(function(data) {
 		// don't check log entries that have already been checked (e.g. don't go into an infinite loop!)
-		var event = data.query ? $.grep(data.query.logevents, function(le) {
+		let event = data.query ? $.grep(data.query.logevents, function(le) {
 			return $.inArray(le.logid, logIds);
 		})[0] : null;
 		if (!event) {
@@ -144,8 +144,8 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 
 Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLevel() {
 
-	var api = new mw.Api();
-	var protectDeferred = api.get({
+	let api = new mw.Api();
+	let protectDeferred = api.get({
 		format: 'json',
 		indexpageids: true,
 		action: 'query',
@@ -156,7 +156,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		inprop: 'protection|watched',
 		titles: mw.config.get('wgPageName')
 	});
-	var stableDeferred = api.get({
+	let stableDeferred = api.get({
 		format: 'json',
 		action: 'query',
 		list: 'logevents',
@@ -164,7 +164,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		letitle: mw.config.get('wgPageName')
 	});
 
-	var earlyDecision = [protectDeferred];
+	let earlyDecision = [protectDeferred];
 	if (hasFlaggedRevs) {
 		earlyDecision.push(stableDeferred);
 	}
@@ -177,9 +177,9 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		// This is annoying.
 		protectData = $(protectData).toArray();
 
-		var pageid = protectData[0].query.pageids[0];
-		var page = protectData[0].query.pages[pageid];
-		var current = {}, adminEditDeferred;
+		let pageid = protectData[0].query.pageids[0];
+		let page = protectData[0].query.pages[pageid];
+		let current = {}, adminEditDeferred;
 
 		// Save requested page's watched status for later in case needed when filing request
 		Twinkle.protect.watched = page.watchlistexpiry || page.watched === '';
@@ -239,16 +239,16 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 };
 
 Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectCallbackShowLogAndCurrentProtectInfo() {
-	var currentlyProtected = !$.isEmptyObject(Twinkle.protect.currentProtectionLevels);
+	let currentlyProtected = !$.isEmptyObject(Twinkle.protect.currentProtectionLevels);
 
 	if (Twinkle.protect.hasProtectLog || Twinkle.protect.hasStableLog) {
-		var $linkMarkup = $('<span>');
+		let $linkMarkup = $('<span>');
 
 		if (Twinkle.protect.hasProtectLog) {
 			$linkMarkup.append(
 				$('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'protect'}) + '">protection log</a>'));
 			if (!currentlyProtected || (!Twinkle.protect.currentProtectionLevels.edit && !Twinkle.protect.currentProtectionLevels.move)) {
-				var lastProtectAction = Twinkle.protect.protectLog[0];
+				let lastProtectAction = Twinkle.protect.protectLog[0];
 				if (lastProtectAction.action === 'unprotect') {
 					$linkMarkup.append(' (unprotected ' + new Morebits.date(lastProtectAction.timestamp).calendar('utc') + ')');
 				} else { // protect or modify
@@ -261,7 +261,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 		if (Twinkle.protect.hasStableLog) {
 			$linkMarkup.append($('<a target="_blank" href="' + mw.util.getUrl('Special:Log', {action: 'view', page: mw.config.get('wgPageName'), type: 'stable'}) + '">pending changes log</a>)'));
 			if (!currentlyProtected || !Twinkle.protect.currentProtectionLevels.stabilize) {
-				var lastStabilizeAction = Twinkle.protect.stableLog[0];
+				let lastStabilizeAction = Twinkle.protect.stableLog[0];
 				if (lastStabilizeAction.action === 'reset') {
 					$linkMarkup.append(' (reset ' + new Morebits.date(lastStabilizeAction.timestamp).calendar('utc') + ')');
 				} else { // config or modify
@@ -278,21 +278,21 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 	}
 
 	Morebits.status.init($('div[name="currentprot"] span')[0]);
-	var protectionNode = [], statusLevel = 'info';
+	let protectionNode = [], statusLevel = 'info';
 
 	if (currentlyProtected) {
 		$.each(Twinkle.protect.currentProtectionLevels, function(type, settings) {
-			var label = type === 'stabilize' ? 'Pending Changes' : Morebits.string.toUpperCaseFirstChar(type);
+			let label = type === 'stabilize' ? 'Pending Changes' : Morebits.string.toUpperCaseFirstChar(type);
 
 			if (type === 'cascading') { // Covered by another page
 				label = 'Cascading protection ';
 				protectionNode.push($('<b>' + label + '</b>')[0]);
 				if (settings.source) { // Should by definition exist
-					var sourceLink = '<a target="_blank" href="' + mw.util.getUrl(settings.source) + '">' + settings.source + '</a>';
+					let sourceLink = '<a target="_blank" href="' + mw.util.getUrl(settings.source) + '">' + settings.source + '</a>';
 					protectionNode.push($('<span>from ' + sourceLink + '</span>')[0]);
 				}
 			} else {
-				var level = settings.level;
+				let level = settings.level;
 				// Make cascading protection more prominent
 				if (settings.cascade) {
 					level += ' (cascading)';
@@ -306,7 +306,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 				protectionNode.push(' (expires ' + new Morebits.date(settings.expiry).calendar('utc') + ') ');
 			}
 			if (settings.admin) {
-				var adminLink = '<a target="_blank" href="' + mw.util.getUrl('User talk:' + settings.admin) + '">' + settings.admin + '</a>';
+				let adminLink = '<a target="_blank" href="' + mw.util.getUrl('User talk:' + settings.admin) + '">' + settings.admin + '</a>';
 				protectionNode.push($('<span>by ' + adminLink + '</span>')[0]);
 			}
 			protectionNode.push($('<span> \u2022 </span>')[0]);
@@ -321,9 +321,9 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 };
 
 Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAction(e) {
-	var field_preset;
-	var field1;
-	var field2;
+	let field_preset;
+	let field1;
+	let field2;
 
 	switch (e.target.values) {
 		case 'protect':
@@ -574,7 +574,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 			break;
 	}
 
-	var oldfield;
+	let oldfield;
 
 	if (field_preset) {
 		oldfield = $(e.target.form).find('fieldset[name="field_preset"]')[0];
@@ -597,7 +597,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 
 	if (e.target.values === 'protect') {
 		// fake a change event on the preset dropdown
-		var evt = document.createEvent('Event');
+		let evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 		e.target.form.category.dispatchEvent(evt);
 
@@ -653,9 +653,9 @@ Twinkle.protect.formevents = {
 };
 
 Twinkle.protect.doCustomExpiry = function twinkleprotectDoCustomExpiry(target) {
-	var custom = prompt('Enter a custom expiry time.  \nYou can use relative times, like "1 minute" or "19 days", or absolute timestamps, "yyyymmddhhmm" (e.g. "200602011405" is Feb 1, 2006, at 14:05 UTC).', '');
+	let custom = prompt('Enter a custom expiry time.  \nYou can use relative times, like "1 minute" or "19 days", or absolute timestamps, "yyyymmddhhmm" (e.g. "200602011405" is Feb 1, 2006, at 14:05 UTC).', '');
 	if (custom) {
-		var option = document.createElement('option');
+		let option = document.createElement('option');
 		option.setAttribute('value', custom);
 		option.textContent = custom;
 		target.appendChild(option);
@@ -1007,11 +1007,11 @@ Twinkle.protect.protectionTags = [
 });
 
 Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePreset(e) {
-	var form = e.target.form;
+	let form = e.target.form;
 
-	var actiontypes = form.actiontype;
-	var actiontype;
-	for (var i = 0; i < actiontypes.length; i++) {
+	let actiontypes = form.actiontype;
+	let actiontype;
+	for (let i = 0; i < actiontypes.length; i++) {
 		if (!actiontypes[i].checked) {
 			continue;
 		}
@@ -1020,7 +1020,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 	}
 
 	if (actiontype === 'protect') {  // actually protecting the page
-		var item = Twinkle.protect.protectionPresetsInfo[form.category.value];
+		let item = Twinkle.protect.protectionPresetsInfo[form.category.value];
 
 		if (mw.config.get('wgArticleId')) {
 			if (item.edit) {
@@ -1066,7 +1066,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			form.createexpiry.value = item.expiry || 'infinity';
 		}
 
-		var reasonField = actiontype === 'protect' ? form.protectReason : form.reason;
+		let reasonField = actiontype === 'protect' ? form.protectReason : form.reason;
 		if (item.reason) {
 			reasonField.value = item.reason;
 		} else {
@@ -1085,10 +1085,10 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			Twinkle.protect.formevents.tagtype({ target: form.tagtype });
 
 			// Default settings for adding <noinclude> tags to protection templates
-			var isTemplateEditorProtection = form.category.value === 'pp-template';
-			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
-			var isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
-			var isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
+			let isTemplateEditorProtection = form.category.value === 'pp-template';
+			let isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
+			let isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
+			let isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
 			if ((isTemplateEditorProtection || isAFD) && !isCode) {
 				form.noinclude.checked = true;
 			} else if (isCode || isNotTemplateNamespace) {
@@ -1108,10 +1108,10 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 };
 
 Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
-	var form = e.target;
-	var input = Morebits.quickForm.getInputData(form);
+	let form = e.target;
+	let input = Morebits.quickForm.getInputData(form);
 
-	var tagparams;
+	let tagparams;
 	if (input.actiontype === 'tag' || (input.actiontype === 'protect' && mw.config.get('wgArticleId') && mw.config.get('wgPageContentModel') !== 'Scribunto' && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */)) {
 		tagparams = {
 			tag: input.tagtype,
@@ -1402,8 +1402,8 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 
 Twinkle.protect.protectReasonAnnotations = [];
 Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallbackAnnotateProtectReason(e) {
-	var form = e.target.form;
-	var protectReason = form.protectReason.value.replace(new RegExp('(?:; )?' + mw.util.escapeRegExp(Twinkle.protect.protectReasonAnnotations.join(': '))), '');
+	let form = e.target.form;
+	let protectReason = form.protectReason.value.replace(new RegExp('(?:; )?' + mw.util.escapeRegExp(Twinkle.protect.protectReasonAnnotations.join(': '))), '');
 
 	if (this.name === 'protectReason_notes_rfpp') {
 		if (this.checked) {
@@ -1419,7 +1419,7 @@ Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallback
 			return el.indexOf('[[Special:Permalink') === -1;
 		});
 		if (e.target.value.length) {
-			var permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
+			let permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
 			Twinkle.protect.protectReasonAnnotations.push(permalink);
 		}
 	}
@@ -1438,17 +1438,17 @@ Twinkle.protect.callbacks = {
 			return;
 		}
 
-		var protectedPage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+		let protectedPage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 		protectedPage.setCallbackParameters(tagparams);
 		protectedPage.load(Twinkle.protect.callbacks.taggingPage);
 	},
 	taggingPage: function(protectedPage) {
-		var params = protectedPage.getCallbackParameters();
-		var text = protectedPage.getPageText();
-		var tag, summary;
+		let params = protectedPage.getCallbackParameters();
+		let text = protectedPage.getPageText();
+		let tag, summary;
 
-		var oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?\s*/gi;
-		var re_result = oldtag_re.exec(text);
+		let oldtag_re = /(?:\/\*)?\s*(?:<noinclude>)?\s*\{\{\s*(pp-[^{}]*?|protected|(?:t|v|s|p-|usertalk-v|usertalk-s|sb|move)protected(?:2)?|protected template|privacy protection)\s*?\}\}\s*(?:<\/noinclude>)?\s*(?:\*\/)?\s*/gi;
+		let re_result = oldtag_re.exec(text);
 		if (re_result) {
 			if (params.tag === 'none' || confirm('{{' + re_result[1] + '}} was found on the page. \nClick OK to remove it, or click Cancel to leave it there.')) {
 				text = text.replace(oldtag_re, '');
@@ -1475,7 +1475,7 @@ Twinkle.protect.callbacks = {
 					return;
 				}
 			} else {
-				var needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].indexOf(protectedPage.getContentModel()) !== -1;
+				let needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].indexOf(protectedPage.getContentModel()) !== -1;
 				if (needsTagToBeCommentedOut) {
 					if (params.noinclude) {
 						tag = '/* <noinclude>{{' + tag + '}}</noinclude> */';
@@ -1497,7 +1497,7 @@ Twinkle.protect.callbacks = {
 					}
 
 					// Insert tag after short description or any hatnotes
-					var wikipage = new Morebits.wikitext.page(text);
+					let wikipage = new Morebits.wikitext.page(text);
 					text = wikipage.insertAfterTemplates(tag, Twinkle.hatnoteRegex).getText();
 				}
 			}
@@ -1515,17 +1515,17 @@ Twinkle.protect.callbacks = {
 
 	fileRequest: function(rppPage) {
 
-		var rppPage2 = new Morebits.wiki.page('Wikipedia:Requests for page protection/Decrease', 'Loading requests pages');
+		let rppPage2 = new Morebits.wiki.page('Wikipedia:Requests for page protection/Decrease', 'Loading requests pages');
 		rppPage2.load(function() {
-			var params = rppPage.getCallbackParameters();
-			var text = rppPage.getPageText();
-			var statusElement = rppPage.getStatusElement();
-			var text2 = rppPage2.getPageText();
+			let params = rppPage.getCallbackParameters();
+			let text = rppPage.getPageText();
+			let statusElement = rppPage.getStatusElement();
+			let text2 = rppPage2.getPageText();
 
-			var rppRe = new RegExp('===\\s*(\\[\\[)?\\s*:?\\s*' + Morebits.string.escapeRegExp(Morebits.pageNameNorm) + '\\s*(\\]\\])?\\s*===', 'm');
-			var tag = rppRe.exec(text) || rppRe.exec(text2);
+			let rppRe = new RegExp('===\\s*(\\[\\[)?\\s*:?\\s*' + Morebits.string.escapeRegExp(Morebits.pageNameNorm) + '\\s*(\\]\\])?\\s*===', 'm');
+			let tag = rppRe.exec(text) || rppRe.exec(text2);
 
-			var rppLink = document.createElement('a');
+			let rppLink = document.createElement('a');
 			rppLink.setAttribute('href', mw.util.getUrl('Wikipedia:Requests for page protection'));
 			rppLink.appendChild(document.createTextNode('Wikipedia:Requests for page protection'));
 
@@ -1534,14 +1534,14 @@ Twinkle.protect.callbacks = {
 				return;
 			}
 
-			var newtag = '=== [[:' + Morebits.pageNameNorm + ']] ===\n';
+			let newtag = '=== [[:' + Morebits.pageNameNorm + ']] ===\n';
 			if (new RegExp('^' + mw.util.escapeRegExp(newtag).replace(/\s+/g, '\\s*'), 'm').test(text) || new RegExp('^' + mw.util.escapeRegExp(newtag).replace(/\s+/g, '\\s*'), 'm').test(text2)) {
 				statusElement.error([ 'There is already a protection request for this page at ', rppLink, ', aborting.' ]);
 				return;
 			}
 			newtag += '* {{pagelinks|1=' + Morebits.pageNameNorm + '}}\n\n';
 
-			var words;
+			let words;
 			switch (params.expiry) {
 				case 'temporary':
 					words = 'Temporary ';
@@ -1561,12 +1561,12 @@ Twinkle.protect.callbacks = {
 
 			// If either protection type results in a increased status, then post it under increase
 			// else we post it under decrease
-			var increase = false;
-			var protInfo = Twinkle.protect.protectionPresetsInfo[params.category];
+			let increase = false;
+			let protInfo = Twinkle.protect.protectionPresetsInfo[params.category];
 
 			// function to compute protection weights (see comment at Twinkle.protect.protectionWeight)
-			var computeWeight = function(mainLevel, stabilizeLevel) {
-				var result = Twinkle.protect.protectionWeight[mainLevel || 'all'];
+			let computeWeight = function(mainLevel, stabilizeLevel) {
+				let result = Twinkle.protect.protectionWeight[mainLevel || 'all'];
 				if (stabilizeLevel) {
 					if (result) {
 						if (stabilizeLevel.level === 'autoconfirmed') {
@@ -1580,7 +1580,7 @@ Twinkle.protect.callbacks = {
 			};
 
 			// compare the page's current protection weights with the protection we are requesting
-			var editWeight = computeWeight(Twinkle.protect.currentProtectionLevels.edit &&
+			let editWeight = computeWeight(Twinkle.protect.currentProtectionLevels.edit &&
 				Twinkle.protect.currentProtectionLevels.edit.level,
 			Twinkle.protect.currentProtectionLevels.stabilize &&
 				Twinkle.protect.currentProtectionLevels.stabilize.level);
@@ -1593,10 +1593,10 @@ Twinkle.protect.callbacks = {
 			}
 
 			if (increase) {
-				var originalTextLength = text.length;
+				let originalTextLength = text.length;
 				text += '\n' + newtag;
 				if (text.length === originalTextLength) {
-					var linknode = document.createElement('a');
+					let linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode.appendChild(document.createTextNode('How to fix RPP'));
 					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode, '.' ]);
@@ -1610,13 +1610,13 @@ Twinkle.protect.callbacks = {
 				rppPage.setCreateOption('recreate');
 				rppPage.save(function() {
 					// Watch the page being requested
-					var watchPref = Twinkle.getPref('watchRequestedPages');
+					let watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.
 					// The watchdefault pref appears to reliably return '1' (string),
 					// but that's not consistent among prefs so might as well be "correct"
-					var watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
+					let watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
 					if (watch) {
-						var watch_query = {
+						let watch_query = {
 							action: 'watch',
 							titles: mw.config.get('wgPageName'),
 							token: mw.user.tokens.get('watchToken')
@@ -1629,10 +1629,10 @@ Twinkle.protect.callbacks = {
 					}
 				});
 			} else {
-				var originalTextLength2 = text2.length;
+				let originalTextLength2 = text2.length;
 				text2 += '\n' + newtag;
 				if (text2.length === originalTextLength2) {
-					var linknode2 = document.createElement('a');
+					let linknode2 = document.createElement('a');
 					linknode2.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing RPP'));
 					linknode2.appendChild(document.createTextNode('How to fix RPP'));
 					statusElement.error([ 'Could not find relevant heading on WP:RPP. To fix this problem, please see ', linknode2, '.' ]);
@@ -1646,13 +1646,13 @@ Twinkle.protect.callbacks = {
 				rppPage2.setCreateOption('recreate');
 				rppPage2.save(function() {
 					// Watch the page being requested
-					var watchPref = Twinkle.getPref('watchRequestedPages');
+					let watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.
 					// The watchdefault pref appears to reliably return '1' (string),
 					// but that's not consistent among prefs so might as well be "correct"
-					var watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
+					let watch = watchPref !== 'no' && (watchPref !== 'default' || !!parseInt(mw.user.options.get('watchdefault'), 10));
 					if (watch) {
-						var watch_query = {
+						let watch_query = {
 							action: 'watch',
 							titles: mw.config.get('wgPageName'),
 							token: mw.user.tokens.get('watchToken')

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -127,9 +127,9 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 		list: 'logevents',
 		letitle: pageName,
 		letype: protType
-	}).then(function(data) {
+	}).then((data) => {
 		// don't check log entries that have already been checked (e.g. don't go into an infinite loop!)
-		const event = data.query ? $.grep(data.query.logevents, function(le) {
+		const event = data.query ? $.grep(data.query.logevents, (le) => {
 			return $.inArray(le.logid, logIds);
 		})[0] : null;
 		if (!event) {
@@ -169,7 +169,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		earlyDecision.push(stableDeferred);
 	}
 
-	$.when.apply($, earlyDecision).done(function(protectData, stableData) {
+	$.when.apply($, earlyDecision).done((protectData, stableData) => {
 		// $.when.apply is supposed to take an unknown number of promises
 		// via an array, which it does, but the type of data returned varies.
 		// If there are two or more deferreds, it returns an array (of objects),
@@ -184,7 +184,7 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		// Save requested page's watched status for later in case needed when filing request
 		Twinkle.protect.watched = page.watchlistexpiry || page.watched === '';
 
-		$.each(page.protection, function(index, protection) {
+		$.each(page.protection, (index, protection) => {
 			// Don't overwrite actual page protection with cascading protection
 			if (!protection.source) {
 				current[protection.type] = {
@@ -222,9 +222,9 @@ Twinkle.protect.fetchProtectionLevel = function twinkleprotectFetchProtectionLev
 		Twinkle.protect.currentProtectionLevels = current;
 
 		if (adminEditDeferred) {
-			adminEditDeferred.done(function(admin) {
+			adminEditDeferred.done((admin) => {
 				if (admin) {
-					$.each(['edit', 'move', 'create', 'stabilize', 'cascading'], function(i, type) {
+					$.each(['edit', 'move', 'create', 'stabilize', 'cascading'], (i, type) => {
 						if (Twinkle.protect.currentProtectionLevels[type]) {
 							Twinkle.protect.currentProtectionLevels[type].admin = admin;
 						}
@@ -281,7 +281,7 @@ Twinkle.protect.callback.showLogAndCurrentProtectInfo = function twinkleprotectC
 	let protectionNode = [], statusLevel = 'info';
 
 	if (currentlyProtected) {
-		$.each(Twinkle.protect.currentProtectionLevels, function(type, settings) {
+		$.each(Twinkle.protect.currentProtectionLevels, (type, settings) => {
 			let label = type === 'stabilize' ? 'Pending Changes' : Morebits.string.toUpperCaseFirstChar(type);
 
 			if (type === 'cascading') { // Covered by another page
@@ -358,7 +358,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'editlevel',
 					label: 'Who can edit:',
 					event: Twinkle.protect.formevents.editlevel,
-					list: Twinkle.protect.protectionLevels.filter(function(level) {
+					list: Twinkle.protect.protectionLevels.filter((level) => {
 						// Filter TE outside of templates and modules
 						return isTemplate || level.value !== 'templateeditor';
 					})
@@ -392,7 +392,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'movelevel',
 					label: 'Who can move:',
 					event: Twinkle.protect.formevents.movelevel,
-					list: Twinkle.protect.protectionLevels.filter(function(level) {
+					list: Twinkle.protect.protectionLevels.filter((level) => {
 						// Autoconfirmed is required for a move, redundant
 						return level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor');
 					})
@@ -451,7 +451,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'createlevel',
 					label: 'Create protection:',
 					event: Twinkle.protect.formevents.createlevel,
-					list: Twinkle.protect.protectionLevels.filter(function(level) {
+					list: Twinkle.protect.protectionLevels.filter((level) => {
 						// Filter TE always, and autoconfirmed in mainspace, redundant since WP:ACPERM
 						return level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed');
 					})
@@ -758,7 +758,7 @@ Twinkle.protect.protectionTypes = [
 			{ label: 'Highly visible page (move)', value: 'pp-move-indef' }
 		]
 	}
-].filter(function(type) {
+].filter((type) => {
 	// Filter for templates and flaggedrevs
 	return (isTemplate || type.label !== 'Template protection') && (hasFlaggedRevs || type.label !== 'Pending changes');
 });
@@ -1001,7 +1001,7 @@ Twinkle.protect.protectionTags = [
 			{ label: '{{pp-move}}: other', value: 'pp-move' }
 		]
 	}
-].filter(function(type) {
+].filter((type) => {
 	// Filter FlaggedRevs
 	return hasFlaggedRevs || type.label !== 'Pending changes templates';
 });
@@ -1204,7 +1204,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				}
 
 				thispage.setWatchlist(Twinkle.getPref('watchProtectedPages'));
-				thispage.stabilize(allDone, function(error) {
+				thispage.stabilize(allDone, (error) => {
 					if (error.errorCode === 'stabilize_denied') { // [[phab:T234743]]
 						thispage.getStatusElement().error('Failed trying to modify pending changes settings, likely due to a mediawiki bug. Other actions (tagging or regular protection) may have taken place. Please reload the page and try again.');
 					}
@@ -1287,7 +1287,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 					typename = 'create protection';
 					break;
 				case 'unprotect':
-					var admins = $.map(Twinkle.protect.currentProtectionLevels, function(pl) {
+					var admins = $.map(Twinkle.protect.currentProtectionLevels, (pl) => {
 						if (!pl.admin || Twinkle.protect.trustedBots.indexOf(pl.admin) !== -1) {
 							return null;
 						}
@@ -1415,7 +1415,7 @@ Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallback
 			$(form.protectReason_notes_rfppRevid).parent().hide();
 		}
 	} else if (this.name === 'protectReason_notes_rfppRevid') {
-		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter(function(el) {
+		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter((el) => {
 			return el.indexOf('[[Special:Permalink') === -1;
 		});
 		if (e.target.value.length) {
@@ -1516,7 +1516,7 @@ Twinkle.protect.callbacks = {
 	fileRequest: function(rppPage) {
 
 		const rppPage2 = new Morebits.wiki.page('Wikipedia:Requests for page protection/Decrease', 'Loading requests pages');
-		rppPage2.load(function() {
+		rppPage2.load(() => {
 			const params = rppPage.getCallbackParameters();
 			let text = rppPage.getPageText();
 			const statusElement = rppPage.getStatusElement();
@@ -1608,7 +1608,7 @@ Twinkle.protect.callbacks = {
 				rppPage.setChangeTags(Twinkle.changeTags);
 				rppPage.setPageText(text);
 				rppPage.setCreateOption('recreate');
-				rppPage.save(function() {
+				rppPage.save(() => {
 					// Watch the page being requested
 					const watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.
@@ -1644,7 +1644,7 @@ Twinkle.protect.callbacks = {
 				rppPage2.setChangeTags(Twinkle.changeTags);
 				rppPage2.setPageText(text2);
 				rppPage2.setCreateOption('recreate');
-				rppPage2.save(function() {
+				rppPage2.save(() => {
 					// Watch the page being requested
 					const watchPref = Twinkle.getPref('watchRequestedPages');
 					// action=watch has no way to rely on user preferences (T262912), so we do it manually.

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -356,10 +356,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'editlevel',
 					label: 'Who can edit:',
 					event: Twinkle.protect.formevents.editlevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => 
-						// Filter TE outside of templates and modules
-						 isTemplate || level.value !== 'templateeditor'
-					)
+					list: Twinkle.protect.protectionLevels.filter((level) => /* Filter TE outside of templates and modules */ isTemplate || level.value !== 'templateeditor')
 				});
 				field2.append({
 					type: 'select',
@@ -390,10 +387,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'movelevel',
 					label: 'Who can move:',
 					event: Twinkle.protect.formevents.movelevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => 
-						// Autoconfirmed is required for a move, redundant
-						 level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor')
-					)
+					list: Twinkle.protect.protectionLevels.filter((level) => /* Autoconfirmed is required for a move, redundant */ level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor'))
 				});
 				field2.append({
 					type: 'select',
@@ -449,10 +443,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'createlevel',
 					label: 'Create protection:',
 					event: Twinkle.protect.formevents.createlevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => 
-						// Filter TE always, and autoconfirmed in mainspace, redundant since WP:ACPERM
-						 level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed')
-					)
+					list: Twinkle.protect.protectionLevels.filter((level) => /* Filter TE always, and autoconfirmed in mainspace, redundant since WP:ACPERM */ level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed'))
 				});
 				field2.append({
 					type: 'select',
@@ -756,10 +747,7 @@ Twinkle.protect.protectionTypes = [
 			{ label: 'Highly visible page (move)', value: 'pp-move-indef' }
 		]
 	}
-].filter((type) => 
-	// Filter for templates and flaggedrevs
-	 (isTemplate || type.label !== 'Template protection') && (hasFlaggedRevs || type.label !== 'Pending changes')
-);
+].filter((type) => /* Filter for templates and flaggedrevs */ (isTemplate || type.label !== 'Template protection') && (hasFlaggedRevs || type.label !== 'Pending changes'));
 
 Twinkle.protect.protectionTypesCreate = [
 	{ label: 'Unprotection', value: 'unprotect' },
@@ -999,10 +987,7 @@ Twinkle.protect.protectionTags = [
 			{ label: '{{pp-move}}: other', value: 'pp-move' }
 		]
 	}
-].filter((type) => 
-	// Filter FlaggedRevs
-	 hasFlaggedRevs || type.label !== 'Pending changes templates'
-);
+].filter((type) => /* Filter FlaggedRevs */ hasFlaggedRevs || type.label !== 'Pending changes templates');
 
 Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePreset(e) {
 	const form = e.target.form;

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1670,7 +1670,7 @@ Twinkle.protect.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.protect, 'protect');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -129,9 +129,7 @@ Twinkle.protect.fetchProtectingAdmin = function twinkleprotectFetchProtectingAdm
 		letype: protType
 	}).then((data) => {
 		// don't check log entries that have already been checked (e.g. don't go into an infinite loop!)
-		const event = data.query ? $.grep(data.query.logevents, (le) => {
-			return $.inArray(le.logid, logIds);
-		})[0] : null;
+		const event = data.query ? $.grep(data.query.logevents, (le) => $.inArray(le.logid, logIds))[0] : null;
 		if (!event) {
 			// fail gracefully
 			return null;
@@ -358,10 +356,10 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'editlevel',
 					label: 'Who can edit:',
 					event: Twinkle.protect.formevents.editlevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => {
+					list: Twinkle.protect.protectionLevels.filter((level) => 
 						// Filter TE outside of templates and modules
-						return isTemplate || level.value !== 'templateeditor';
-					})
+						 isTemplate || level.value !== 'templateeditor'
+					)
 				});
 				field2.append({
 					type: 'select',
@@ -392,10 +390,10 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'movelevel',
 					label: 'Who can move:',
 					event: Twinkle.protect.formevents.movelevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => {
+					list: Twinkle.protect.protectionLevels.filter((level) => 
 						// Autoconfirmed is required for a move, redundant
-						return level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor');
-					})
+						 level.value !== 'autoconfirmed' && (isTemplate || level.value !== 'templateeditor')
+					)
 				});
 				field2.append({
 					type: 'select',
@@ -451,10 +449,10 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 					name: 'createlevel',
 					label: 'Create protection:',
 					event: Twinkle.protect.formevents.createlevel,
-					list: Twinkle.protect.protectionLevels.filter((level) => {
+					list: Twinkle.protect.protectionLevels.filter((level) => 
 						// Filter TE always, and autoconfirmed in mainspace, redundant since WP:ACPERM
-						return level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed');
-					})
+						 level.value !== 'templateeditor' && (mw.config.get('wgNamespaceNumber') !== 0 || level.value !== 'autoconfirmed')
+					)
 				});
 				field2.append({
 					type: 'select',
@@ -758,10 +756,10 @@ Twinkle.protect.protectionTypes = [
 			{ label: 'Highly visible page (move)', value: 'pp-move-indef' }
 		]
 	}
-].filter((type) => {
+].filter((type) => 
 	// Filter for templates and flaggedrevs
-	return (isTemplate || type.label !== 'Template protection') && (hasFlaggedRevs || type.label !== 'Pending changes');
-});
+	 (isTemplate || type.label !== 'Template protection') && (hasFlaggedRevs || type.label !== 'Pending changes')
+);
 
 Twinkle.protect.protectionTypesCreate = [
 	{ label: 'Unprotection', value: 'unprotect' },
@@ -1001,10 +999,10 @@ Twinkle.protect.protectionTags = [
 			{ label: '{{pp-move}}: other', value: 'pp-move' }
 		]
 	}
-].filter((type) => {
+].filter((type) => 
 	// Filter FlaggedRevs
-	return hasFlaggedRevs || type.label !== 'Pending changes templates';
-});
+	 hasFlaggedRevs || type.label !== 'Pending changes templates'
+);
 
 Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePreset(e) {
 	const form = e.target.form;
@@ -1415,9 +1413,7 @@ Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallback
 			$(form.protectReason_notes_rfppRevid).parent().hide();
 		}
 	} else if (this.name === 'protectReason_notes_rfppRevid') {
-		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter((el) => {
-			return el.indexOf('[[Special:Permalink') === -1;
-		});
+		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter((el) => el.indexOf('[[Special:Permalink') === -1);
 		if (e.target.value.length) {
 			const permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
 			Twinkle.protect.protectReasonAnnotations.push(permalink);

--- a/modules/twinkleshared.js
+++ b/modules/twinkleshared.js
@@ -14,7 +14,7 @@
 
 Twinkle.shared = function twinkleshared() {
 	if (mw.config.get('wgNamespaceNumber') === 3 && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
-		var username = mw.config.get('wgRelevantUserName');
+		let username = mw.config.get('wgRelevantUserName');
 		Twinkle.addPortletLink(function() {
 			Twinkle.shared.callback(username);
 		}, 'Shared IP', 'twinkle-shared', 'Shared IP tagging');
@@ -22,16 +22,16 @@ Twinkle.shared = function twinkleshared() {
 };
 
 Twinkle.shared.callback = function twinklesharedCallback() {
-	var Window = new Morebits.simpleWindow(600, 450);
+	let Window = new Morebits.simpleWindow(600, 450);
 	Window.setTitle('Shared IP address tagging');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Shared prefs', 'WP:TW/PREF#shared');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#shared');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.shared.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.shared.callback.evaluate);
 
-	var div = form.append({
+	let div = form.append({
 		type: 'div',
 		id: 'sharedip-templatelist',
 		className: 'morebits-scrollbox'
@@ -45,7 +45,7 @@ Twinkle.shared.callback = function twinklesharedCallback() {
 		}
 	});
 
-	var org = form.append({ type: 'field', label: 'Fill in other details (optional) and click "Submit"' });
+	let org = form.append({ type: 'field', label: 'Fill in other details (optional) and click "Submit"' });
 	org.append({
 		type: 'input',
 		name: 'organization',
@@ -71,7 +71,7 @@ Twinkle.shared.callback = function twinklesharedCallback() {
 	}
 	);
 
-	var previewlink = document.createElement('a');
+	let previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.shared.preview(result);
 	});
@@ -137,12 +137,12 @@ Twinkle.shared.callback.change_shared = function twinklesharedCallbackChangeShar
 
 Twinkle.shared.callbacks = {
 	main: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
-		var pageText = pageobj.getPageText();
-		var found = false;
+		let params = pageobj.getCallbackParameters();
+		let pageText = pageobj.getPageText();
+		let found = false;
 
-		for (var i = 0; i < Twinkle.shared.standardList.length; i++) {
-			var tagRe = new RegExp('(\\{\\{' + Twinkle.shared.standardList[i].value + '(\\||\\}\\}))', 'im');
+		for (let i = 0; i < Twinkle.shared.standardList.length; i++) {
+			let tagRe = new RegExp('(\\{\\{' + Twinkle.shared.standardList[i].value + '(\\||\\}\\}))', 'im');
 			if (tagRe.exec(pageText)) {
 				Morebits.status.warn('Info', 'Found {{' + Twinkle.shared.standardList[i].value + '}} on the user\'s talk page already...aborting');
 				found = true;
@@ -154,9 +154,9 @@ Twinkle.shared.callbacks = {
 		}
 
 		Morebits.status.info('Info', 'Will add the shared IP address template to the top of the user\'s talk page.');
-		var text = Twinkle.shared.getTemplateWikitext(params);
+		let text = Twinkle.shared.getTemplateWikitext(params);
 
-		var summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
+		let summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
 		pageobj.setPageText(text + pageText);
 		pageobj.setEditSummary(summaryText);
 		pageobj.setChangeTags(Twinkle.changeTags);
@@ -167,22 +167,22 @@ Twinkle.shared.callbacks = {
 };
 
 Twinkle.shared.preview = function(form) {
-	var input = Morebits.quickForm.getInputData(form);
+	let input = Morebits.quickForm.getInputData(form);
 	if (input.template) {
-		var previewDialog = new Morebits.simpleWindow(700, 500);
+		let previewDialog = new Morebits.simpleWindow(700, 500);
 		previewDialog.setTitle('Shared IP template preview');
 		previewDialog.setScriptName('Add Shared IP template');
 		previewDialog.setModality(true);
 
-		var previewdiv = document.createElement('div');
+		let previewdiv = document.createElement('div');
 		previewdiv.style.marginLeft = previewdiv.style.marginRight = '0.5em';
 		previewdiv.style.fontSize = 'small';
 		previewDialog.setContent(previewdiv);
 
-		var previewer = new Morebits.wiki.preview(previewdiv);
+		let previewer = new Morebits.wiki.preview(previewdiv);
 		previewer.beginRender(Twinkle.shared.getTemplateWikitext(input), mw.config.get('wgPageName'));
 
-		var submit = document.createElement('input');
+		let submit = document.createElement('input');
 		submit.setAttribute('type', 'submit');
 		submit.setAttribute('value', 'Close');
 		previewDialog.addContent(submit);
@@ -196,7 +196,7 @@ Twinkle.shared.preview = function(form) {
 };
 
 Twinkle.shared.getTemplateWikitext = function(input) {
-	var text = '{{' + input.template + '|' + input.organization;
+	let text = '{{' + input.template + '|' + input.organization;
 	if (input.contact) {
 		text += '|' + input.contact;
 	}
@@ -208,7 +208,7 @@ Twinkle.shared.getTemplateWikitext = function(input) {
 };
 
 Twinkle.shared.callback.evaluate = function twinklesharedCallbackEvaluate(e) {
-	var params = Morebits.quickForm.getInputData(e.target);
+	let params = Morebits.quickForm.getInputData(e.target);
 	if (!params.template) {
 		alert('You must select a shared IP address template to use!');
 		return;
@@ -224,7 +224,7 @@ Twinkle.shared.callback.evaluate = function twinklesharedCallbackEvaluate(e) {
 	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete, reloading talk page in a few seconds';
 
-	var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'User talk page modification');
+	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.shared.callbacks.main);

--- a/modules/twinkleshared.js
+++ b/modules/twinkleshared.js
@@ -15,7 +15,7 @@
 Twinkle.shared = function twinkleshared() {
 	if (mw.config.get('wgNamespaceNumber') === 3 && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
 		const username = mw.config.get('wgRelevantUserName');
-		Twinkle.addPortletLink(function() {
+		Twinkle.addPortletLink(() => {
 			Twinkle.shared.callback(username);
 		}, 'Shared IP', 'twinkle-shared', 'Shared IP tagging');
 	}
@@ -72,7 +72,7 @@ Twinkle.shared.callback = function twinklesharedCallback() {
 	);
 
 	const previewlink = document.createElement('a');
-	$(previewlink).click(function() {
+	$(previewlink).click(() => {
 		Twinkle.shared.preview(result);
 	});
 	previewlink.style.cursor = 'pointer';
@@ -189,7 +189,7 @@ Twinkle.shared.preview = function(form) {
 
 		previewDialog.display();
 
-		$(submit).click(function() {
+		$(submit).click(() => {
 			previewDialog.close();
 		});
 	}

--- a/modules/twinkleshared.js
+++ b/modules/twinkleshared.js
@@ -231,7 +231,7 @@ Twinkle.shared.callback.evaluate = function twinklesharedCallbackEvaluate(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.shared, 'shared');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkleshared.js
+++ b/modules/twinkleshared.js
@@ -14,7 +14,7 @@
 
 Twinkle.shared = function twinkleshared() {
 	if (mw.config.get('wgNamespaceNumber') === 3 && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
-		let username = mw.config.get('wgRelevantUserName');
+		const username = mw.config.get('wgRelevantUserName');
 		Twinkle.addPortletLink(function() {
 			Twinkle.shared.callback(username);
 		}, 'Shared IP', 'twinkle-shared', 'Shared IP tagging');
@@ -22,16 +22,16 @@ Twinkle.shared = function twinkleshared() {
 };
 
 Twinkle.shared.callback = function twinklesharedCallback() {
-	let Window = new Morebits.simpleWindow(600, 450);
+	const Window = new Morebits.simpleWindow(600, 450);
 	Window.setTitle('Shared IP address tagging');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Shared prefs', 'WP:TW/PREF#shared');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#shared');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.shared.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.shared.callback.evaluate);
 
-	let div = form.append({
+	const div = form.append({
 		type: 'div',
 		id: 'sharedip-templatelist',
 		className: 'morebits-scrollbox'
@@ -45,7 +45,7 @@ Twinkle.shared.callback = function twinklesharedCallback() {
 		}
 	});
 
-	let org = form.append({ type: 'field', label: 'Fill in other details (optional) and click "Submit"' });
+	const org = form.append({ type: 'field', label: 'Fill in other details (optional) and click "Submit"' });
 	org.append({
 		type: 'input',
 		name: 'organization',
@@ -71,7 +71,7 @@ Twinkle.shared.callback = function twinklesharedCallback() {
 	}
 	);
 
-	let previewlink = document.createElement('a');
+	const previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.shared.preview(result);
 	});
@@ -137,12 +137,12 @@ Twinkle.shared.callback.change_shared = function twinklesharedCallbackChangeShar
 
 Twinkle.shared.callbacks = {
 	main: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
-		let pageText = pageobj.getPageText();
+		const params = pageobj.getCallbackParameters();
+		const pageText = pageobj.getPageText();
 		let found = false;
 
 		for (let i = 0; i < Twinkle.shared.standardList.length; i++) {
-			let tagRe = new RegExp('(\\{\\{' + Twinkle.shared.standardList[i].value + '(\\||\\}\\}))', 'im');
+			const tagRe = new RegExp('(\\{\\{' + Twinkle.shared.standardList[i].value + '(\\||\\}\\}))', 'im');
 			if (tagRe.exec(pageText)) {
 				Morebits.status.warn('Info', 'Found {{' + Twinkle.shared.standardList[i].value + '}} on the user\'s talk page already...aborting');
 				found = true;
@@ -154,9 +154,9 @@ Twinkle.shared.callbacks = {
 		}
 
 		Morebits.status.info('Info', 'Will add the shared IP address template to the top of the user\'s talk page.');
-		let text = Twinkle.shared.getTemplateWikitext(params);
+		const text = Twinkle.shared.getTemplateWikitext(params);
 
-		let summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
+		const summaryText = 'Added {{[[Template:' + params.template + '|' + params.template + ']]}} template.';
 		pageobj.setPageText(text + pageText);
 		pageobj.setEditSummary(summaryText);
 		pageobj.setChangeTags(Twinkle.changeTags);
@@ -167,22 +167,22 @@ Twinkle.shared.callbacks = {
 };
 
 Twinkle.shared.preview = function(form) {
-	let input = Morebits.quickForm.getInputData(form);
+	const input = Morebits.quickForm.getInputData(form);
 	if (input.template) {
-		let previewDialog = new Morebits.simpleWindow(700, 500);
+		const previewDialog = new Morebits.simpleWindow(700, 500);
 		previewDialog.setTitle('Shared IP template preview');
 		previewDialog.setScriptName('Add Shared IP template');
 		previewDialog.setModality(true);
 
-		let previewdiv = document.createElement('div');
+		const previewdiv = document.createElement('div');
 		previewdiv.style.marginLeft = previewdiv.style.marginRight = '0.5em';
 		previewdiv.style.fontSize = 'small';
 		previewDialog.setContent(previewdiv);
 
-		let previewer = new Morebits.wiki.preview(previewdiv);
+		const previewer = new Morebits.wiki.preview(previewdiv);
 		previewer.beginRender(Twinkle.shared.getTemplateWikitext(input), mw.config.get('wgPageName'));
 
-		let submit = document.createElement('input');
+		const submit = document.createElement('input');
 		submit.setAttribute('type', 'submit');
 		submit.setAttribute('value', 'Close');
 		previewDialog.addContent(submit);
@@ -208,7 +208,7 @@ Twinkle.shared.getTemplateWikitext = function(input) {
 };
 
 Twinkle.shared.callback.evaluate = function twinklesharedCallbackEvaluate(e) {
-	let params = Morebits.quickForm.getInputData(e.target);
+	const params = Morebits.quickForm.getInputData(e.target);
 	if (!params.template) {
 		alert('You must select a shared IP address template to use!');
 		return;
@@ -224,7 +224,7 @@ Twinkle.shared.callback.evaluate = function twinklesharedCallbackEvaluate(e) {
 	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete, reloading talk page in a few seconds';
 
-	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'User talk page modification');
+	const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.shared.callbacks.main);

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -41,7 +41,7 @@ Twinkle.speedy.hasCSD = !!$('#delete-reason').length;
 
 // Prepares the speedy deletion dialog and displays it
 Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
-	var dialog;
+	let dialog;
 	Twinkle.speedy.dialog = new Morebits.simpleWindow(Twinkle.getPref('speedyWindowWidth'), Twinkle.getPref('speedyWindowHeight'));
 	dialog = Twinkle.speedy.dialog;
 	dialog.setTitle('Choose criteria for speedy deletion');
@@ -51,7 +51,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	dialog.addFooterLink('Twinkle help', 'WP:TW/DOC#speedy');
 	dialog.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(callbackfunc, Twinkle.getPref('speedySelectionStyle') === 'radioClick' ? 'change' : null);
+	let form = new Morebits.quickForm(callbackfunc, Twinkle.getPref('speedySelectionStyle') === 'radioClick' ? 'change' : null);
 	if (Morebits.userIsSysop) {
 		form.append({
 			type: 'checkbox',
@@ -63,8 +63,8 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					tooltip: 'If you just want to tag the page, instead of deleting it now',
 					checked: !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
 					event: function(event) {
-						var cForm = event.target.form;
-						var cChecked = event.target.checked;
+						let cForm = event.target.form;
+						let cChecked = event.target.checked;
 						// enable talk page checkbox
 						if (cForm.talkpage) {
 							cForm.talkpage.checked = !cChecked && Twinkle.getPref('deleteTalkPageOnDelete');
@@ -90,7 +90,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 			]
 		});
 
-		var deleteOptions = form.append({
+		let deleteOptions = form.append({
 			type: 'div',
 			name: 'delete_options'
 		});
@@ -153,7 +153,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 		});
 	}
 
-	var tagOptions = form.append({
+	let tagOptions = form.append({
 		type: 'div',
 		name: 'tag_options'
 	});
@@ -217,7 +217,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 		form.append({ type: 'submit', className: 'tw-speedy-submit' }); // Renamed in modeChanged
 	}
 
-	var result = form.render();
+	let result = form.render();
 	dialog.setContent(result);
 	dialog.display();
 
@@ -228,10 +228,10 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 };
 
 Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(form) {
-	var namespace = mw.config.get('wgNamespaceNumber');
+	let namespace = mw.config.get('wgNamespaceNumber');
 
 	// first figure out what mode we're in
-	var mode = {
+	let mode = {
 		isSysop: !!form.tag_only && !form.tag_only.checked,
 		isMultiple: form.tag_only && !form.tag_only.checked ? form.delmultiple.checked : form.multiple.checked,
 		isRadioClick: Twinkle.getPref('speedySelectionStyle') === 'radioClick'
@@ -247,13 +247,13 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		$('button.tw-speedy-submit').text('Tag page');
 	}
 
-	var work_area = new Morebits.quickForm.element({
+	let work_area = new Morebits.quickForm.element({
 		type: 'div',
 		name: 'work_area'
 	});
 
 	if (mode.isMultiple && mode.isRadioClick) {
-		var evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
+		let evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
 
 		work_area.append({
 			type: 'div',
@@ -270,7 +270,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		});
 	}
 
-	var appendList = function(headerLabel, csdList) {
+	let appendList = function(headerLabel, csdList) {
 		work_area.append({ type: 'header', label: headerLabel });
 		work_area.append({ type: mode.isMultiple ? 'checkbox' : 'radio', name: 'csd', list: Twinkle.speedy.generateCsdList(csdList, mode) });
 	};
@@ -319,7 +319,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		appendList('Redirects', Twinkle.speedy.redirectList);
 	}
 
-	var generalCriteria = Twinkle.speedy.generalList;
+	let generalCriteria = Twinkle.speedy.generalList;
 
 	// custom rationale lives under general criteria when tagging
 	if (!mode.isSysop) {
@@ -327,12 +327,12 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	}
 	appendList('General criteria', generalCriteria);
 
-	var old_area = Morebits.quickForm.getElements(form, 'work_area')[0];
+	let old_area = Morebits.quickForm.getElements(form, 'work_area')[0];
 	form.replaceChild(work_area.render(), old_area);
 
 	// if sysop, check if CSD is already on the page and fill in custom rationale
 	if (mode.isSysop && Twinkle.speedy.hasCSD) {
-		var customOption = $('input[name=csd][value=reason]')[0];
+		let customOption = $('input[name=csd][value=reason]')[0];
 		if (customOption) {
 			if (Twinkle.getPref('speedySelectionStyle') !== 'radioClick') {
 				// force listeners to re-init
@@ -345,7 +345,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 };
 
 Twinkle.speedy.callback.priorDeletionCount = function () {
-	var query = {
+	let query = {
 		action: 'query',
 		format: 'json',
 		list: 'logevents',
@@ -357,10 +357,10 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 	};
 
 	new Morebits.wiki.api('Checking for past deletions', query, function(apiobj) {
-		var response = apiobj.getResponse();
-		var delCount = response.query.logevents.length;
+		let response = apiobj.getResponse();
+		let delCount = response.query.logevents.length;
 		if (delCount) {
-			var message = delCount + ' previous deletion';
+			let message = delCount + ' previous deletion';
 			if (delCount > 1) {
 				message += 's';
 				if (response.continue) {
@@ -374,7 +374,7 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 			}
 
 			// Provide a link to page logs (CSD templates have one for sysops)
-			var link = Morebits.htmlNode('a', '(logs)');
+			let link = Morebits.htmlNode('a', '(logs)');
 			link.setAttribute('href', mw.util.getUrl('Special:Log', {page: mw.config.get('wgPageName')}));
 			link.setAttribute('target', '_blank');
 
@@ -387,23 +387,23 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 
 Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mode) {
 
-	var pageNamespace = mw.config.get('wgNamespaceNumber');
+	let pageNamespace = mw.config.get('wgNamespaceNumber');
 
-	var openSubgroupHandler = function(e) {
+	let openSubgroupHandler = function(e) {
 		$(e.target.form).find('input').prop('disabled', true);
 		$(e.target.form).children().css('color', 'gray');
 		$(e.target).parent().css('color', 'black').find('input').prop('disabled', false);
 		$(e.target).parent().find('input:text')[0].focus();
 		e.stopPropagation();
 	};
-	var submitSubgroupHandler = function(e) {
-		var evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
+	let submitSubgroupHandler = function(e) {
+		let evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
 		Twinkle.speedy.callback[evaluateType](e);
 		e.stopPropagation();
 	};
 
 	return $.map(list, function(critElement) {
-		var criterion = $.extend({}, critElement);
+		let criterion = $.extend({}, critElement);
 
 		if (mode.isMultiple) {
 			if (criterion.hideWhenMultiple) {
@@ -1059,14 +1059,14 @@ Twinkle.speedy.normalizeHash = {
 
 Twinkle.speedy.callbacks = {
 	getTemplateCodeAndParams: function(params) {
-		var code, parameters, i;
+		let code, parameters, i;
 		if (params.normalizeds.length > 1) {
 			code = '{{db-multiple';
 			params.utparams = {};
 			$.each(params.normalizeds, function(index, norm) {
 				code += '|' + norm.toUpperCase();
 				parameters = params.templateParams[index] || [];
-				for (var i in parameters) {
+				for (let i in parameters) {
 					if (typeof parameters[i] === 'string' && !parseInt(i, 10)) {  // skip numeric parameters - {{db-multiple}} doesn't understand them
 						code += '|' + i + '=' + parameters[i];
 					}
@@ -1093,7 +1093,7 @@ Twinkle.speedy.callbacks = {
 	},
 
 	parseWikitext: function(wikitext, callback) {
-		var query = {
+		let query = {
 			action: 'parse',
 			prop: 'text',
 			pst: 'true',
@@ -1104,9 +1104,9 @@ Twinkle.speedy.callbacks = {
 			format: 'json'
 		};
 
-		var statusIndicator = new Morebits.status('Building deletion summary');
-		var api = new Morebits.wiki.api('Parsing deletion template', query, function(apiobj) {
-			var reason = decodeURIComponent($(apiobj.getResponse().parse.text).find('#delete-reason').text()).replace(/\+/g, ' ');
+		let statusIndicator = new Morebits.status('Building deletion summary');
+		let api = new Morebits.wiki.api('Parsing deletion template', query, function(apiobj) {
+			let reason = decodeURIComponent($(apiobj.getResponse().parse.text).find('#delete-reason').text()).replace(/\+/g, ' ');
 			if (!reason) {
 				statusIndicator.warn('Unable to generate summary from deletion template');
 			} else {
@@ -1118,8 +1118,8 @@ Twinkle.speedy.callbacks = {
 	},
 
 	noteToCreator: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
-		var initialContrib = pageobj.getCreator();
+		let params = pageobj.getCallbackParameters();
+		let initialContrib = pageobj.getCreator();
 
 		// disallow notifying yourself
 		if (initialContrib === mw.config.get('wgUserName')) {
@@ -1143,13 +1143,13 @@ Twinkle.speedy.callbacks = {
 		}
 
 		if (initialContrib) {
-			var usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')'),
+			let usertalkpage = new Morebits.wiki.page('User talk:' + initialContrib, 'Notifying initial contributor (' + initialContrib + ')'),
 				notifytext, i, editsummary;
 
 			// special cases: "db" and "db-multiple"
 			if (params.normalizeds.length > 1) {
 				notifytext = '\n{{subst:db-' + (params.warnUser ? 'deleted' : 'notice') + '-multiple|1=' + Morebits.pageNameNorm;
-				var count = 2;
+				let count = 2;
 				$.each(params.normalizeds, function(index, norm) {
 					notifytext += '|' + count++ + '=' + norm.toUpperCase();
 				});
@@ -1204,12 +1204,12 @@ Twinkle.speedy.callbacks = {
 
 	sysop: {
 		main: function(params) {
-			var reason;
+			let reason;
 			if (!params.normalizeds.length && params.normalizeds[0] === 'db') {
 				reason = prompt('Enter the deletion summary to use, which will be entered into the deletion log:', '');
 				Twinkle.speedy.callbacks.sysop.deletePage(reason, params);
 			} else {
-				var code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
+				let code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
 				Twinkle.speedy.callbacks.parseWikitext(code, function(reason) {
 					if (params.promptForSummary) {
 						reason = prompt('Enter the deletion summary to use, or press OK to accept the automatically generated one.', reason);
@@ -1219,7 +1219,7 @@ Twinkle.speedy.callbacks = {
 			}
 		},
 		deletePage: function(reason, params) {
-			var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Deleting page');
+			let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Deleting page');
 
 			if (reason === null) {
 				return Morebits.status.error('Asking for reason', 'User cancelled');
@@ -1227,7 +1227,7 @@ Twinkle.speedy.callbacks = {
 				return Morebits.status.error('Asking for reason', "you didn't give one.  I don't know... what with admins and their apathetic antics... I give up...");
 			}
 
-			var deleteMain = function(callback) {
+			let deleteMain = function(callback) {
 				thispage.setEditSummary(reason);
 				thispage.setChangeTags(Twinkle.changeTags);
 				thispage.setWatchlist(params.watch);
@@ -1256,7 +1256,7 @@ Twinkle.speedy.callbacks = {
 			if (params.deleteTalkPage &&
 					params.normalized !== 'f8' &&
 					!document.getElementById('ca-talk').classList.contains('new')) {
-				var talkpage = new Morebits.wiki.page(mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceNumber') + 1] + ':' + mw.config.get('wgTitle'), 'Deleting talk page');
+				let talkpage = new Morebits.wiki.page(mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceNumber') + 1] + ':' + mw.config.get('wgTitle'), 'Deleting talk page');
 				talkpage.setEditSummary('[[WP:CSD#G8|G8]]: Talk page of deleted page "' + Morebits.pageNameNorm + '"');
 				talkpage.setChangeTags(Twinkle.changeTags);
 				talkpage.deletePage();
@@ -1272,21 +1272,21 @@ Twinkle.speedy.callbacks = {
 		deleteRedirects: function(params) {
 			// delete redirects
 			if (params.deleteRedirects) {
-				var query = {
+				let query = {
 					action: 'query',
 					titles: mw.config.get('wgPageName'),
 					prop: 'redirects',
 					rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 					format: 'json'
 				};
-				var wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
+				let wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
 					new Morebits.status('Deleting redirects'));
 				wikipedia_api.params = params;
 				wikipedia_api.post();
 			}
 
 			// promote Unlink tool
-			var $link, $bigtext;
+			let $link, $bigtext;
 			if (mw.config.get('wgNamespaceNumber') === 6 && params.normalized !== 'f8') {
 				$link = $('<a/>', {
 					href: '#',
@@ -1322,10 +1322,10 @@ Twinkle.speedy.callbacks = {
 			}
 		},
 		deleteRedirectsMain: function(apiobj) {
-			var response = apiobj.getResponse();
-			var snapshot = response.query.pages[0].redirects || [];
-			var total = snapshot.length;
-			var statusIndicator = apiobj.statelem;
+			let response = apiobj.getResponse();
+			let snapshot = response.query.pages[0].redirects || [];
+			let total = snapshot.length;
+			let statusIndicator = apiobj.statelem;
 
 			if (!total) {
 				statusIndicator.status('no redirects found');
@@ -1334,9 +1334,9 @@ Twinkle.speedy.callbacks = {
 
 			statusIndicator.status('0%');
 
-			var current = 0;
-			var onsuccess = function(apiobjInner) {
-				var now = parseInt(100 * ++current / total, 10) + '%';
+			let current = 0;
+			let onsuccess = function(apiobjInner) {
+				let now = parseInt(100 * ++current / total, 10) + '%';
 				statusIndicator.update(now);
 				apiobjInner.statelem.unlink();
 				if (current >= total) {
@@ -1348,8 +1348,8 @@ Twinkle.speedy.callbacks = {
 			Morebits.wiki.addCheckpoint();
 
 			snapshot.forEach(function(value) {
-				var title = value.title;
-				var page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
+				let title = value.title;
+				let page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
 				page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + Morebits.pageNameNorm + '"');
 				page.setChangeTags(Twinkle.changeTags);
 				page.deletePage(onsuccess);
@@ -1359,18 +1359,18 @@ Twinkle.speedy.callbacks = {
 
 	user: {
 		main: function(pageobj) {
-			var statelem = pageobj.getStatusElement();
+			let statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist; perhaps it has already been deleted");
 				return;
 			}
 
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
 			// given the params, builds the template and also adds the user talk page parameters to the params that were passed in
 			// returns => [<string> wikitext, <object> utparams]
-			var buildData = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params),
+			let buildData = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params),
 				code = buildData[0];
 			params.utparams = buildData[1];
 
@@ -1381,18 +1381,18 @@ Twinkle.speedy.callbacks = {
 
 			// Tag if possible, post on talk if not
 			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1 && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */) {
-				var text = pageobj.getPageText();
+				let text = pageobj.getPageText();
 
 				statelem.status('Checking for tags on the page...');
 
 				// check for existing deletion tags
-				var tag = /(?:\{\{\s*(db|delete|db-.*?|speedy deletion-.*?)(?:\s*\||\s*\}\}))/.exec(text);
+				let tag = /(?:\{\{\s*(db|delete|db-.*?|speedy deletion-.*?)(?:\s*\||\s*\}\}))/.exec(text);
 				// This won't make use of the db-multiple template but it probably should
 				if (tag && !confirm('The page already has the CSD-related template {{' + tag[1] + '}} on it.  Do you want to add another CSD template?')) {
 					return;
 				}
 
-				var xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
+				let xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
 				if (xfd && !confirm('The deletion-related template {{' + xfd[1] + '}} was found on the page. Do you still want to add a CSD template?')) {
 					return;
 				}
@@ -1425,7 +1425,7 @@ Twinkle.speedy.callbacks = {
 
 				if (mw.config.get('wgPageContentModel') === 'Scribunto') {
 					// Scribunto isn't parsed like wikitext, so CSD templates on modules need special handling to work
-					var equals = '';
+					let equals = '';
 					while (code.indexOf(']' + equals + ']') !== -1) {
 						equals += '=';
 					}
@@ -1436,7 +1436,7 @@ Twinkle.speedy.callbacks = {
 				}
 
 				// Generate edit summary for edit
-				var editsummary;
+				let editsummary;
 				if (params.normalizeds.length > 1) {
 					editsummary = 'Requesting speedy deletion (';
 					$.each(params.normalizeds, function(index, norm) {
@@ -1455,7 +1455,7 @@ Twinkle.speedy.callbacks = {
 					text = code;
 				} else {
 					// Insert tag after short description or any hatnotes
-					var wikipage = new Morebits.wikitext.page(text);
+					let wikipage = new Morebits.wikitext.page(text);
 					text = wikipage.insertAfterTemplates(code + '\n', Twinkle.hatnoteRegex).getText();
 				}
 
@@ -1465,7 +1465,7 @@ Twinkle.speedy.callbacks = {
 				pageobj.setWatchlist(params.watch);
 				pageobj.save(Twinkle.speedy.callbacks.user.tagComplete);
 			} else { // Attempt to place on talk page
-				var talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
+				let talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
 				if (talkName !== pageobj.getPageName()) {
 					if (params.requestsalt) {
 						code += '\n{{salt}}';
@@ -1473,7 +1473,7 @@ Twinkle.speedy.callbacks = {
 
 					pageobj.getStatusElement().warn('Unable to edit page, placing tag on talk page');
 
-					var talk_page = new Morebits.wiki.page(talkName, 'Automatically placing tag on talk page');
+					let talk_page = new Morebits.wiki.page(talkName, 'Automatically placing tag on talk page');
 					talk_page.setNewSectionTitle(pageobj.getPageName() + ' nominated for CSD, request deletion');
 					talk_page.setNewSectionText(code + '\n\nI was unable to tag ' + pageobj.getPageName() + ' so please delete it. ~~~~');
 					talk_page.setCreateOption('recreate');
@@ -1489,11 +1489,11 @@ Twinkle.speedy.callbacks = {
 		},
 
 		tagComplete: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
 			// Notification to first contributor, will also log nomination to the user's userspace log
 			if (params.usertalk) {
-				var thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
+				let thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
 				thispage.setCallbackParameters(params);
 				thispage.lookupCreation(Twinkle.speedy.callbacks.noteToCreator);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1503,14 +1503,14 @@ Twinkle.speedy.callbacks = {
 		},
 
 		addToLog: function(params, initialContrib) {
-			var usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
+			let usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
 			usl.initialText =
 				"This is a log of all [[WP:CSD|speedy deletion]] nominations made by this user using [[WP:TW|Twinkle]]'s CSD module.\n\n" +
 				'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 				'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 				(Morebits.userIsSysop ? '\n\nThis log does not track outright speedy deletions made using Twinkle.' : '');
 
-			var formatParamLog = function(normalize, csdparam, input) {
+			let formatParamLog = function(normalize, csdparam, input) {
 				if ((normalize === 'G4' && csdparam === 'xfd') ||
 					(normalize === 'G6' && csdparam === 'page') ||
 					(normalize === 'G6' && csdparam === 'fullvotepage') ||
@@ -1529,13 +1529,13 @@ Twinkle.speedy.callbacks = {
 				return ' {' + normalize + ' ' + csdparam + ': ' + input + '}';
 			};
 
-			var extraInfo = '';
+			let extraInfo = '';
 
 			// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-			var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
+			let fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
 
-			var editsummary = 'Logging speedy deletion nomination';
-			var appendText = '# [[:' + Morebits.pageNameNorm;
+			let editsummary = 'Logging speedy deletion nomination';
+			let appendText = '# [[:' + Morebits.pageNameNorm;
 
 			if (params.normalizeds.indexOf('g10') === -1) {  // no article name in log for G10 taggings
 				appendText += ']]' + fileLogLink + ': ';
@@ -1564,7 +1564,7 @@ Twinkle.speedy.callbacks = {
 					extraInfo += formatParamLog('Custom', 'rationale', params.templateParams[0]['1']);
 				} else {
 					params.templateParams.forEach(function(item, index) {
-						var keys = Object.keys(item);
+						let keys = Object.keys(item);
 						if (keys[0] !== undefined && keys[0].length > 0) {
 							// Second loop required since some items (G12, F9) may have multiple keys
 							keys.forEach(function(key, keyIndex) {
@@ -1597,14 +1597,14 @@ Twinkle.speedy.callbacks = {
 
 // validate subgroups in the form passed into the speedy deletion tag
 Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values) {
-	var parameters = [];
+	let parameters = [];
 
 	$.each(values, function(index, value) {
-		var currentParams = [];
+		let currentParams = [];
 		switch (value) {
 			case 'reason':
 				if (form['csd.reason_1']) {
-					var dbrationale = form['csd.reason_1'].value;
+					let dbrationale = form['csd.reason_1'].value;
 					if (!dbrationale || !dbrationale.trim()) {
 						alert('Custom rationale:  Please specify a rationale.');
 						parameters = null;
@@ -1616,7 +1616,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'userreq':  // U1
 				if (form['csd.userreq_rationale']) {
-					var u1rationale = form['csd.userreq_rationale'].value;
+					let u1rationale = form['csd.userreq_rationale'].value;
 					if (mw.config.get('wgNamespaceNumber') === 3 && !(/\//).test(mw.config.get('wgTitle')) &&
 							(!u1rationale || !u1rationale.trim())) {
 						alert('CSD U1:  Please specify a rationale when nominating user talk pages.');
@@ -1629,7 +1629,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'repost':  // G4
 				if (form['csd.repost_xfd']) {
-					var deldisc = form['csd.repost_xfd'].value;
+					let deldisc = form['csd.repost_xfd'].value;
 					if (deldisc) {
 						currentParams.xfd = deldisc;
 					}
@@ -1644,7 +1644,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'move':  // G6
 				if (form['csd.move_page'] && form['csd.move_reason']) {
-					var movepage = form['csd.move_page'].value,
+					let movepage = form['csd.move_page'].value,
 						movereason = form['csd.move_reason'].value;
 					if (!movepage || !movepage.trim()) {
 						alert('CSD G6 (move):  Please specify the page to be moved here.');
@@ -1663,7 +1663,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'xfd':  // G6
 				if (form['csd.xfd_fullvotepage']) {
-					var xfd = form['csd.xfd_fullvotepage'].value;
+					let xfd = form['csd.xfd_fullvotepage'].value;
 					if (xfd) {
 						currentParams.fullvotepage = xfd;
 					}
@@ -1672,7 +1672,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'afc-move':  // G6
 				if (form['csd.draft_page']) {
-					var draftpage = form['csd.draft_page'].value;
+					let draftpage = form['csd.draft_page'].value;
 					if (!draftpage || !draftpage.trim()) {
 						alert('CSD G6 (AfC move):  Please specify the draft to be moved here.');
 						parameters = null;
@@ -1684,7 +1684,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'copypaste':  // G6
 				if (form['csd.copypaste_sourcepage']) {
-					var copypaste = form['csd.copypaste_sourcepage'].value;
+					let copypaste = form['csd.copypaste_sourcepage'].value;
 					if (!copypaste || !copypaste.trim()) {
 						alert('CSD G6 (copypaste):  Please specify the source page name.');
 						parameters = null;
@@ -1735,7 +1735,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'redundantimage':  // F1
 				if (form['csd.redundantimage_filename']) {
-					var redimage = form['csd.redundantimage_filename'].value;
+					let redimage = form['csd.redundantimage_filename'].value;
 					if (!redimage || !redimage.trim()) {
 						alert('CSD F1:  Please specify the filename of the other file.');
 						parameters = null;
@@ -1753,7 +1753,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'commons':  // F8
 				if (form['csd.commons_filename']) {
-					var filename = form['csd.commons_filename'].value;
+					let filename = form['csd.commons_filename'].value;
 					if (filename && filename.trim() && filename !== Morebits.pageNameNorm) {
 						currentParams.filename = new RegExp('^\\s*' + Morebits.namespaceRegex(6) + ':', 'i').test(filename) ? filename : 'File:' + filename;
 					}
@@ -1762,8 +1762,8 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'imgcopyvio':  // F9
 				if (form['csd.imgcopyvio_url'] && form['csd.imgcopyvio_rationale']) {
-					var f9url = form['csd.imgcopyvio_url'].value;
-					var f9rationale = form['csd.imgcopyvio_rationale'].value;
+					let f9url = form['csd.imgcopyvio_url'].value;
+					let f9rationale = form['csd.imgcopyvio_rationale'].value;
 					if ((!f9url || !f9url.trim()) && (!f9rationale || !f9rationale.trim())) {
 						alert('CSD F9: You must enter a url or reason (or both) when nominating a file under F9.');
 						parameters = null;
@@ -1780,7 +1780,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'foreign':  // A2
 				if (form['csd.foreign_source']) {
-					var foreignlink = form['csd.foreign_source'].value;
+					let foreignlink = form['csd.foreign_source'].value;
 					if (!foreignlink || !foreignlink.trim()) {
 						alert('CSD A2:  Please specify an interwiki link to the article of which this is a copy.');
 						parameters = null;
@@ -1792,7 +1792,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'a10':  // A10
 				if (form['csd.a10_article']) {
-					var duptitle = form['csd.a10_article'].value;
+					let duptitle = form['csd.a10_article'].value;
 					if (!duptitle || !duptitle.trim()) {
 						alert('CSD A10:  Please specify the name of the article which is duplicated.');
 						parameters = null;
@@ -1820,7 +1820,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 // key1/value1: for {{db-criterion-[notice|deleted]}} (via {{db-csd-[notice|deleted]-custom}})
 // utparams.param: for {{db-[notice|deleted]-multiple}}
 Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParameters(normalized, parameters) {
-	var utparams = [];
+	let utparams = [];
 
 	// Special cases
 	if (normalized === 'db') {
@@ -1838,7 +1838,7 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
 		});
 	} else {
 		// Handle the rest
-		var param;
+		let param;
 		switch (normalized) {
 			case 'g4':
 				param = 'xfd';
@@ -1869,7 +1869,7 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
  * @returns {Array}
  */
 Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
-	var values = (e.target.form ? e.target.form : e.target).getChecked('csd');
+	let values = (e.target.form ? e.target.form : e.target).getChecked('csd');
 	if (values.length === 0) {
 		alert('Please select a criterion!');
 		return null;
@@ -1878,34 +1878,34 @@ Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
 };
 
 Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSysop(e) {
-	var form = e.target.form ? e.target.form : e.target;
+	let form = e.target.form ? e.target.form : e.target;
 
 	if (e.target.type === 'checkbox' || e.target.type === 'text' ||
 			e.target.type === 'select') {
 		return;
 	}
 
-	var tag_only = form.tag_only;
+	let tag_only = form.tag_only;
 	if (tag_only && tag_only.checked) {
 		Twinkle.speedy.callback.evaluateUser(e);
 		return;
 	}
 
-	var values = Twinkle.speedy.resolveCsdValues(e);
+	let values = Twinkle.speedy.resolveCsdValues(e);
 	if (!values) {
 		return;
 	}
-	var templateParams = Twinkle.speedy.getParameters(form, values);
+	let templateParams = Twinkle.speedy.getParameters(form, values);
 	if (!templateParams) {
 		return;
 	}
 
-	var normalizeds = values.map(function(value) {
+	let normalizeds = values.map(function(value) {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
 	// analyse each criterion to determine whether to watch the page, prompt for summary, or notify the creator
-	var watchPage, promptForSummary;
+	let watchPage, promptForSummary;
 	normalizeds.forEach(function(norm) {
 		if (Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1) {
 			watchPage = Twinkle.getPref('watchSpeedyExpiry');
@@ -1915,16 +1915,16 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		}
 	});
 
-	var warnusertalk = form.warnusertalk.checked && normalizeds.some(function (norm, index) {
+	let warnusertalk = form.warnusertalk.checked && normalizeds.some(function (norm, index) {
 		return Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
 
-	var welcomeuser = warnusertalk && normalizeds.some(function (norm) {
+	let welcomeuser = warnusertalk && normalizeds.some(function (norm) {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
 
-	var params = {
+	let params = {
 		values: values,
 		normalizeds: normalizeds,
 		watch: watchPage,
@@ -1943,45 +1943,45 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 };
 
 Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUser(e) {
-	var form = e.target.form ? e.target.form : e.target;
+	let form = e.target.form ? e.target.form : e.target;
 
 	if (e.target.type === 'checkbox' || e.target.type === 'text' ||
 			e.target.type === 'select') {
 		return;
 	}
 
-	var values = Twinkle.speedy.resolveCsdValues(e);
+	let values = Twinkle.speedy.resolveCsdValues(e);
 	if (!values) {
 		return;
 	}
-	var templateParams = Twinkle.speedy.getParameters(form, values);
+	let templateParams = Twinkle.speedy.getParameters(form, values);
 	if (!templateParams) {
 		return;
 	}
 
 	// var multiple = form.multiple.checked;
 
-	var normalizeds = values.map(function(value) {
+	let normalizeds = values.map(function(value) {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	var watchPage = normalizeds.some(function(csdCriteria) {
+	let watchPage = normalizeds.some(function(csdCriteria) {
 		return Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
 	}) && Twinkle.getPref('watchSpeedyExpiry');
 
-	var notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
+	let notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
-	var welcomeuser = notifyuser && normalizeds.some(function(norm) {
+	let welcomeuser = notifyuser && normalizeds.some(function(norm) {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
-	var csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some(function(norm) {
+	let csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some(function(norm) {
 		return Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1;
 	});
 
-	var params = {
+	let params = {
 		values: values,
 		normalizeds: normalizeds,
 		watch: watchPage,
@@ -1998,7 +1998,7 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete';
 
-	var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -1900,9 +1900,7 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		return;
 	}
 
-	const normalizeds = values.map((value) => {
-		return Twinkle.speedy.normalizeHash[value];
-	});
+	const normalizeds = values.map((value) => Twinkle.speedy.normalizeHash[value]);
 
 	// analyse each criterion to determine whether to watch the page, prompt for summary, or notify the creator
 	let watchPage, promptForSummary;
@@ -1915,14 +1913,10 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		}
 	});
 
-	const warnusertalk = form.warnusertalk.checked && normalizeds.some((norm, index) => {
-		return Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
-			!(norm === 'g6' && values[index] !== 'copypaste');
-	});
+	const warnusertalk = form.warnusertalk.checked && normalizeds.some((norm, index) => Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
+			!(norm === 'g6' && values[index] !== 'copypaste'));
 
-	const welcomeuser = warnusertalk && normalizeds.some((norm) => {
-		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
-	});
+	const welcomeuser = warnusertalk && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1);
 
 	const params = {
 		values: values,
@@ -1961,25 +1955,15 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 
 	// var multiple = form.multiple.checked;
 
-	const normalizeds = values.map((value) => {
-		return Twinkle.speedy.normalizeHash[value];
-	});
+	const normalizeds = values.map((value) => Twinkle.speedy.normalizeHash[value]);
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	const watchPage = normalizeds.some((csdCriteria) => {
-		return Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
-	}) && Twinkle.getPref('watchSpeedyExpiry');
+	const watchPage = normalizeds.some((csdCriteria) => Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1) && Twinkle.getPref('watchSpeedyExpiry');
 
-	const notifyuser = form.notify.checked && normalizeds.some((norm, index) => {
-		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
-			!(norm === 'g6' && values[index] !== 'copypaste');
-	});
-	const welcomeuser = notifyuser && normalizeds.some((norm) => {
-		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
-	});
-	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some((norm) => {
-		return Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1;
-	});
+	const notifyuser = form.notify.checked && normalizeds.some((norm, index) => Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
+			!(norm === 'g6' && values[index] !== 'copypaste'));
+	const welcomeuser = notifyuser && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1);
+	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some((norm) => Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1);
 
 	const params = {
 		values: values,

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -51,7 +51,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 	dialog.addFooterLink('Twinkle help', 'WP:TW/DOC#speedy');
 	dialog.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(callbackfunc, Twinkle.getPref('speedySelectionStyle') === 'radioClick' ? 'change' : null);
+	const form = new Morebits.quickForm(callbackfunc, Twinkle.getPref('speedySelectionStyle') === 'radioClick' ? 'change' : null);
 	if (Morebits.userIsSysop) {
 		form.append({
 			type: 'checkbox',
@@ -63,8 +63,8 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 					tooltip: 'If you just want to tag the page, instead of deleting it now',
 					checked: !(Twinkle.speedy.hasCSD || Twinkle.getPref('deleteSysopDefaultToDelete')),
 					event: function(event) {
-						let cForm = event.target.form;
-						let cChecked = event.target.checked;
+						const cForm = event.target.form;
+						const cChecked = event.target.checked;
 						// enable talk page checkbox
 						if (cForm.talkpage) {
 							cForm.talkpage.checked = !cChecked && Twinkle.getPref('deleteTalkPageOnDelete');
@@ -90,7 +90,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 			]
 		});
 
-		let deleteOptions = form.append({
+		const deleteOptions = form.append({
 			type: 'div',
 			name: 'delete_options'
 		});
@@ -153,7 +153,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 		});
 	}
 
-	let tagOptions = form.append({
+	const tagOptions = form.append({
 		type: 'div',
 		name: 'tag_options'
 	});
@@ -217,7 +217,7 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 		form.append({ type: 'submit', className: 'tw-speedy-submit' }); // Renamed in modeChanged
 	}
 
-	let result = form.render();
+	const result = form.render();
 	dialog.setContent(result);
 	dialog.display();
 
@@ -228,10 +228,10 @@ Twinkle.speedy.initDialog = function twinklespeedyInitDialog(callbackfunc) {
 };
 
 Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(form) {
-	let namespace = mw.config.get('wgNamespaceNumber');
+	const namespace = mw.config.get('wgNamespaceNumber');
 
 	// first figure out what mode we're in
-	let mode = {
+	const mode = {
 		isSysop: !!form.tag_only && !form.tag_only.checked,
 		isMultiple: form.tag_only && !form.tag_only.checked ? form.delmultiple.checked : form.multiple.checked,
 		isRadioClick: Twinkle.getPref('speedySelectionStyle') === 'radioClick'
@@ -247,13 +247,13 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		$('button.tw-speedy-submit').text('Tag page');
 	}
 
-	let work_area = new Morebits.quickForm.element({
+	const work_area = new Morebits.quickForm.element({
 		type: 'div',
 		name: 'work_area'
 	});
 
 	if (mode.isMultiple && mode.isRadioClick) {
-		let evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
+		const evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
 
 		work_area.append({
 			type: 'div',
@@ -270,7 +270,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 		});
 	}
 
-	let appendList = function(headerLabel, csdList) {
+	const appendList = function(headerLabel, csdList) {
 		work_area.append({ type: 'header', label: headerLabel });
 		work_area.append({ type: mode.isMultiple ? 'checkbox' : 'radio', name: 'csd', list: Twinkle.speedy.generateCsdList(csdList, mode) });
 	};
@@ -327,12 +327,12 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 	}
 	appendList('General criteria', generalCriteria);
 
-	let old_area = Morebits.quickForm.getElements(form, 'work_area')[0];
+	const old_area = Morebits.quickForm.getElements(form, 'work_area')[0];
 	form.replaceChild(work_area.render(), old_area);
 
 	// if sysop, check if CSD is already on the page and fill in custom rationale
 	if (mode.isSysop && Twinkle.speedy.hasCSD) {
-		let customOption = $('input[name=csd][value=reason]')[0];
+		const customOption = $('input[name=csd][value=reason]')[0];
 		if (customOption) {
 			if (Twinkle.getPref('speedySelectionStyle') !== 'radioClick') {
 				// force listeners to re-init
@@ -345,7 +345,7 @@ Twinkle.speedy.callback.modeChanged = function twinklespeedyCallbackModeChanged(
 };
 
 Twinkle.speedy.callback.priorDeletionCount = function () {
-	let query = {
+	const query = {
 		action: 'query',
 		format: 'json',
 		list: 'logevents',
@@ -357,8 +357,8 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 	};
 
 	new Morebits.wiki.api('Checking for past deletions', query, function(apiobj) {
-		let response = apiobj.getResponse();
-		let delCount = response.query.logevents.length;
+		const response = apiobj.getResponse();
+		const delCount = response.query.logevents.length;
 		if (delCount) {
 			let message = delCount + ' previous deletion';
 			if (delCount > 1) {
@@ -374,7 +374,7 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 			}
 
 			// Provide a link to page logs (CSD templates have one for sysops)
-			let link = Morebits.htmlNode('a', '(logs)');
+			const link = Morebits.htmlNode('a', '(logs)');
 			link.setAttribute('href', mw.util.getUrl('Special:Log', {page: mw.config.get('wgPageName')}));
 			link.setAttribute('target', '_blank');
 
@@ -387,23 +387,23 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 
 Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mode) {
 
-	let pageNamespace = mw.config.get('wgNamespaceNumber');
+	const pageNamespace = mw.config.get('wgNamespaceNumber');
 
-	let openSubgroupHandler = function(e) {
+	const openSubgroupHandler = function(e) {
 		$(e.target.form).find('input').prop('disabled', true);
 		$(e.target.form).children().css('color', 'gray');
 		$(e.target).parent().css('color', 'black').find('input').prop('disabled', false);
 		$(e.target).parent().find('input:text')[0].focus();
 		e.stopPropagation();
 	};
-	let submitSubgroupHandler = function(e) {
-		let evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
+	const submitSubgroupHandler = function(e) {
+		const evaluateType = mode.isSysop ? 'evaluateSysop' : 'evaluateUser';
 		Twinkle.speedy.callback[evaluateType](e);
 		e.stopPropagation();
 	};
 
 	return $.map(list, function(critElement) {
-		let criterion = $.extend({}, critElement);
+		const criterion = $.extend({}, critElement);
 
 		if (mode.isMultiple) {
 			if (criterion.hideWhenMultiple) {
@@ -1066,7 +1066,7 @@ Twinkle.speedy.callbacks = {
 			$.each(params.normalizeds, function(index, norm) {
 				code += '|' + norm.toUpperCase();
 				parameters = params.templateParams[index] || [];
-				for (let i in parameters) {
+				for (const i in parameters) {
 					if (typeof parameters[i] === 'string' && !parseInt(i, 10)) {  // skip numeric parameters - {{db-multiple}} doesn't understand them
 						code += '|' + i + '=' + parameters[i];
 					}
@@ -1093,7 +1093,7 @@ Twinkle.speedy.callbacks = {
 	},
 
 	parseWikitext: function(wikitext, callback) {
-		let query = {
+		const query = {
 			action: 'parse',
 			prop: 'text',
 			pst: 'true',
@@ -1104,9 +1104,9 @@ Twinkle.speedy.callbacks = {
 			format: 'json'
 		};
 
-		let statusIndicator = new Morebits.status('Building deletion summary');
-		let api = new Morebits.wiki.api('Parsing deletion template', query, function(apiobj) {
-			let reason = decodeURIComponent($(apiobj.getResponse().parse.text).find('#delete-reason').text()).replace(/\+/g, ' ');
+		const statusIndicator = new Morebits.status('Building deletion summary');
+		const api = new Morebits.wiki.api('Parsing deletion template', query, function(apiobj) {
+			const reason = decodeURIComponent($(apiobj.getResponse().parse.text).find('#delete-reason').text()).replace(/\+/g, ' ');
 			if (!reason) {
 				statusIndicator.warn('Unable to generate summary from deletion template');
 			} else {
@@ -1118,7 +1118,7 @@ Twinkle.speedy.callbacks = {
 	},
 
 	noteToCreator: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 		let initialContrib = pageobj.getCreator();
 
 		// disallow notifying yourself
@@ -1209,7 +1209,7 @@ Twinkle.speedy.callbacks = {
 				reason = prompt('Enter the deletion summary to use, which will be entered into the deletion log:', '');
 				Twinkle.speedy.callbacks.sysop.deletePage(reason, params);
 			} else {
-				let code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
+				const code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
 				Twinkle.speedy.callbacks.parseWikitext(code, function(reason) {
 					if (params.promptForSummary) {
 						reason = prompt('Enter the deletion summary to use, or press OK to accept the automatically generated one.', reason);
@@ -1219,7 +1219,7 @@ Twinkle.speedy.callbacks = {
 			}
 		},
 		deletePage: function(reason, params) {
-			let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Deleting page');
+			const thispage = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Deleting page');
 
 			if (reason === null) {
 				return Morebits.status.error('Asking for reason', 'User cancelled');
@@ -1227,7 +1227,7 @@ Twinkle.speedy.callbacks = {
 				return Morebits.status.error('Asking for reason', "you didn't give one.  I don't know... what with admins and their apathetic antics... I give up...");
 			}
 
-			let deleteMain = function(callback) {
+			const deleteMain = function(callback) {
 				thispage.setEditSummary(reason);
 				thispage.setChangeTags(Twinkle.changeTags);
 				thispage.setWatchlist(params.watch);
@@ -1256,7 +1256,7 @@ Twinkle.speedy.callbacks = {
 			if (params.deleteTalkPage &&
 					params.normalized !== 'f8' &&
 					!document.getElementById('ca-talk').classList.contains('new')) {
-				let talkpage = new Morebits.wiki.page(mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceNumber') + 1] + ':' + mw.config.get('wgTitle'), 'Deleting talk page');
+				const talkpage = new Morebits.wiki.page(mw.config.get('wgFormattedNamespaces')[mw.config.get('wgNamespaceNumber') + 1] + ':' + mw.config.get('wgTitle'), 'Deleting talk page');
 				talkpage.setEditSummary('[[WP:CSD#G8|G8]]: Talk page of deleted page "' + Morebits.pageNameNorm + '"');
 				talkpage.setChangeTags(Twinkle.changeTags);
 				talkpage.deletePage();
@@ -1272,14 +1272,14 @@ Twinkle.speedy.callbacks = {
 		deleteRedirects: function(params) {
 			// delete redirects
 			if (params.deleteRedirects) {
-				let query = {
+				const query = {
 					action: 'query',
 					titles: mw.config.get('wgPageName'),
 					prop: 'redirects',
 					rdlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 					format: 'json'
 				};
-				let wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
+				const wikipedia_api = new Morebits.wiki.api('getting list of redirects...', query, Twinkle.speedy.callbacks.sysop.deleteRedirectsMain,
 					new Morebits.status('Deleting redirects'));
 				wikipedia_api.params = params;
 				wikipedia_api.post();
@@ -1322,10 +1322,10 @@ Twinkle.speedy.callbacks = {
 			}
 		},
 		deleteRedirectsMain: function(apiobj) {
-			let response = apiobj.getResponse();
-			let snapshot = response.query.pages[0].redirects || [];
-			let total = snapshot.length;
-			let statusIndicator = apiobj.statelem;
+			const response = apiobj.getResponse();
+			const snapshot = response.query.pages[0].redirects || [];
+			const total = snapshot.length;
+			const statusIndicator = apiobj.statelem;
 
 			if (!total) {
 				statusIndicator.status('no redirects found');
@@ -1335,8 +1335,8 @@ Twinkle.speedy.callbacks = {
 			statusIndicator.status('0%');
 
 			let current = 0;
-			let onsuccess = function(apiobjInner) {
-				let now = parseInt(100 * ++current / total, 10) + '%';
+			const onsuccess = function(apiobjInner) {
+				const now = parseInt(100 * ++current / total, 10) + '%';
 				statusIndicator.update(now);
 				apiobjInner.statelem.unlink();
 				if (current >= total) {
@@ -1348,8 +1348,8 @@ Twinkle.speedy.callbacks = {
 			Morebits.wiki.addCheckpoint();
 
 			snapshot.forEach(function(value) {
-				let title = value.title;
-				let page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
+				const title = value.title;
+				const page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
 				page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + Morebits.pageNameNorm + '"');
 				page.setChangeTags(Twinkle.changeTags);
 				page.deletePage(onsuccess);
@@ -1359,14 +1359,14 @@ Twinkle.speedy.callbacks = {
 
 	user: {
 		main: function(pageobj) {
-			let statelem = pageobj.getStatusElement();
+			const statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist; perhaps it has already been deleted");
 				return;
 			}
 
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			// given the params, builds the template and also adds the user talk page parameters to the params that were passed in
 			// returns => [<string> wikitext, <object> utparams]
@@ -1386,13 +1386,13 @@ Twinkle.speedy.callbacks = {
 				statelem.status('Checking for tags on the page...');
 
 				// check for existing deletion tags
-				let tag = /(?:\{\{\s*(db|delete|db-.*?|speedy deletion-.*?)(?:\s*\||\s*\}\}))/.exec(text);
+				const tag = /(?:\{\{\s*(db|delete|db-.*?|speedy deletion-.*?)(?:\s*\||\s*\}\}))/.exec(text);
 				// This won't make use of the db-multiple template but it probably should
 				if (tag && !confirm('The page already has the CSD-related template {{' + tag[1] + '}} on it.  Do you want to add another CSD template?')) {
 					return;
 				}
 
-				let xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
+				const xfd = /\{\{((?:article for deletion|proposed deletion|prod blp|template for discussion)\/dated|[cfm]fd\b)/i.exec(text) || /#invoke:(RfD)/.exec(text);
 				if (xfd && !confirm('The deletion-related template {{' + xfd[1] + '}} was found on the page. Do you still want to add a CSD template?')) {
 					return;
 				}
@@ -1455,7 +1455,7 @@ Twinkle.speedy.callbacks = {
 					text = code;
 				} else {
 					// Insert tag after short description or any hatnotes
-					let wikipage = new Morebits.wikitext.page(text);
+					const wikipage = new Morebits.wikitext.page(text);
 					text = wikipage.insertAfterTemplates(code + '\n', Twinkle.hatnoteRegex).getText();
 				}
 
@@ -1465,7 +1465,7 @@ Twinkle.speedy.callbacks = {
 				pageobj.setWatchlist(params.watch);
 				pageobj.save(Twinkle.speedy.callbacks.user.tagComplete);
 			} else { // Attempt to place on talk page
-				let talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
+				const talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
 				if (talkName !== pageobj.getPageName()) {
 					if (params.requestsalt) {
 						code += '\n{{salt}}';
@@ -1473,7 +1473,7 @@ Twinkle.speedy.callbacks = {
 
 					pageobj.getStatusElement().warn('Unable to edit page, placing tag on talk page');
 
-					let talk_page = new Morebits.wiki.page(talkName, 'Automatically placing tag on talk page');
+					const talk_page = new Morebits.wiki.page(talkName, 'Automatically placing tag on talk page');
 					talk_page.setNewSectionTitle(pageobj.getPageName() + ' nominated for CSD, request deletion');
 					talk_page.setNewSectionText(code + '\n\nI was unable to tag ' + pageobj.getPageName() + ' so please delete it. ~~~~');
 					talk_page.setCreateOption('recreate');
@@ -1489,11 +1489,11 @@ Twinkle.speedy.callbacks = {
 		},
 
 		tagComplete: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			// Notification to first contributor, will also log nomination to the user's userspace log
 			if (params.usertalk) {
-				let thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
+				const thispage = new Morebits.wiki.page(Morebits.pageNameNorm);
 				thispage.setCallbackParameters(params);
 				thispage.lookupCreation(Twinkle.speedy.callbacks.noteToCreator);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1503,14 +1503,14 @@ Twinkle.speedy.callbacks = {
 		},
 
 		addToLog: function(params, initialContrib) {
-			let usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
+			const usl = new Morebits.userspaceLogger(Twinkle.getPref('speedyLogPageName'));
 			usl.initialText =
 				"This is a log of all [[WP:CSD|speedy deletion]] nominations made by this user using [[WP:TW|Twinkle]]'s CSD module.\n\n" +
 				'If you no longer wish to keep this log, you can turn it off using the [[Wikipedia:Twinkle/Preferences|preferences panel]], and ' +
 				'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 				(Morebits.userIsSysop ? '\n\nThis log does not track outright speedy deletions made using Twinkle.' : '');
 
-			let formatParamLog = function(normalize, csdparam, input) {
+			const formatParamLog = function(normalize, csdparam, input) {
 				if ((normalize === 'G4' && csdparam === 'xfd') ||
 					(normalize === 'G6' && csdparam === 'page') ||
 					(normalize === 'G6' && csdparam === 'fullvotepage') ||
@@ -1532,7 +1532,7 @@ Twinkle.speedy.callbacks = {
 			let extraInfo = '';
 
 			// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-			let fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
+			const fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
 
 			let editsummary = 'Logging speedy deletion nomination';
 			let appendText = '# [[:' + Morebits.pageNameNorm;
@@ -1564,7 +1564,7 @@ Twinkle.speedy.callbacks = {
 					extraInfo += formatParamLog('Custom', 'rationale', params.templateParams[0]['1']);
 				} else {
 					params.templateParams.forEach(function(item, index) {
-						let keys = Object.keys(item);
+						const keys = Object.keys(item);
 						if (keys[0] !== undefined && keys[0].length > 0) {
 							// Second loop required since some items (G12, F9) may have multiple keys
 							keys.forEach(function(key, keyIndex) {
@@ -1600,11 +1600,11 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 	let parameters = [];
 
 	$.each(values, function(index, value) {
-		let currentParams = [];
+		const currentParams = [];
 		switch (value) {
 			case 'reason':
 				if (form['csd.reason_1']) {
-					let dbrationale = form['csd.reason_1'].value;
+					const dbrationale = form['csd.reason_1'].value;
 					if (!dbrationale || !dbrationale.trim()) {
 						alert('Custom rationale:  Please specify a rationale.');
 						parameters = null;
@@ -1616,7 +1616,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'userreq':  // U1
 				if (form['csd.userreq_rationale']) {
-					let u1rationale = form['csd.userreq_rationale'].value;
+					const u1rationale = form['csd.userreq_rationale'].value;
 					if (mw.config.get('wgNamespaceNumber') === 3 && !(/\//).test(mw.config.get('wgTitle')) &&
 							(!u1rationale || !u1rationale.trim())) {
 						alert('CSD U1:  Please specify a rationale when nominating user talk pages.');
@@ -1629,7 +1629,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'repost':  // G4
 				if (form['csd.repost_xfd']) {
-					let deldisc = form['csd.repost_xfd'].value;
+					const deldisc = form['csd.repost_xfd'].value;
 					if (deldisc) {
 						currentParams.xfd = deldisc;
 					}
@@ -1644,7 +1644,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'move':  // G6
 				if (form['csd.move_page'] && form['csd.move_reason']) {
-					let movepage = form['csd.move_page'].value,
+					const movepage = form['csd.move_page'].value,
 						movereason = form['csd.move_reason'].value;
 					if (!movepage || !movepage.trim()) {
 						alert('CSD G6 (move):  Please specify the page to be moved here.');
@@ -1663,7 +1663,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'xfd':  // G6
 				if (form['csd.xfd_fullvotepage']) {
-					let xfd = form['csd.xfd_fullvotepage'].value;
+					const xfd = form['csd.xfd_fullvotepage'].value;
 					if (xfd) {
 						currentParams.fullvotepage = xfd;
 					}
@@ -1672,7 +1672,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'afc-move':  // G6
 				if (form['csd.draft_page']) {
-					let draftpage = form['csd.draft_page'].value;
+					const draftpage = form['csd.draft_page'].value;
 					if (!draftpage || !draftpage.trim()) {
 						alert('CSD G6 (AfC move):  Please specify the draft to be moved here.');
 						parameters = null;
@@ -1684,7 +1684,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'copypaste':  // G6
 				if (form['csd.copypaste_sourcepage']) {
-					let copypaste = form['csd.copypaste_sourcepage'].value;
+					const copypaste = form['csd.copypaste_sourcepage'].value;
 					if (!copypaste || !copypaste.trim()) {
 						alert('CSD G6 (copypaste):  Please specify the source page name.');
 						parameters = null;
@@ -1735,7 +1735,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'redundantimage':  // F1
 				if (form['csd.redundantimage_filename']) {
-					let redimage = form['csd.redundantimage_filename'].value;
+					const redimage = form['csd.redundantimage_filename'].value;
 					if (!redimage || !redimage.trim()) {
 						alert('CSD F1:  Please specify the filename of the other file.');
 						parameters = null;
@@ -1753,7 +1753,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'commons':  // F8
 				if (form['csd.commons_filename']) {
-					let filename = form['csd.commons_filename'].value;
+					const filename = form['csd.commons_filename'].value;
 					if (filename && filename.trim() && filename !== Morebits.pageNameNorm) {
 						currentParams.filename = new RegExp('^\\s*' + Morebits.namespaceRegex(6) + ':', 'i').test(filename) ? filename : 'File:' + filename;
 					}
@@ -1762,8 +1762,8 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'imgcopyvio':  // F9
 				if (form['csd.imgcopyvio_url'] && form['csd.imgcopyvio_rationale']) {
-					let f9url = form['csd.imgcopyvio_url'].value;
-					let f9rationale = form['csd.imgcopyvio_rationale'].value;
+					const f9url = form['csd.imgcopyvio_url'].value;
+					const f9rationale = form['csd.imgcopyvio_rationale'].value;
 					if ((!f9url || !f9url.trim()) && (!f9rationale || !f9rationale.trim())) {
 						alert('CSD F9: You must enter a url or reason (or both) when nominating a file under F9.');
 						parameters = null;
@@ -1780,7 +1780,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'foreign':  // A2
 				if (form['csd.foreign_source']) {
-					let foreignlink = form['csd.foreign_source'].value;
+					const foreignlink = form['csd.foreign_source'].value;
 					if (!foreignlink || !foreignlink.trim()) {
 						alert('CSD A2:  Please specify an interwiki link to the article of which this is a copy.');
 						parameters = null;
@@ -1792,7 +1792,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 
 			case 'a10':  // A10
 				if (form['csd.a10_article']) {
-					let duptitle = form['csd.a10_article'].value;
+					const duptitle = form['csd.a10_article'].value;
 					if (!duptitle || !duptitle.trim()) {
 						alert('CSD A10:  Please specify the name of the article which is duplicated.');
 						parameters = null;
@@ -1820,7 +1820,7 @@ Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values)
 // key1/value1: for {{db-criterion-[notice|deleted]}} (via {{db-csd-[notice|deleted]-custom}})
 // utparams.param: for {{db-[notice|deleted]-multiple}}
 Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParameters(normalized, parameters) {
-	let utparams = [];
+	const utparams = [];
 
 	// Special cases
 	if (normalized === 'db') {
@@ -1869,7 +1869,7 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
  * @returns {Array}
  */
 Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
-	let values = (e.target.form ? e.target.form : e.target).getChecked('csd');
+	const values = (e.target.form ? e.target.form : e.target).getChecked('csd');
 	if (values.length === 0) {
 		alert('Please select a criterion!');
 		return null;
@@ -1878,29 +1878,29 @@ Twinkle.speedy.resolveCsdValues = function twinklespeedyResolveCsdValues(e) {
 };
 
 Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSysop(e) {
-	let form = e.target.form ? e.target.form : e.target;
+	const form = e.target.form ? e.target.form : e.target;
 
 	if (e.target.type === 'checkbox' || e.target.type === 'text' ||
 			e.target.type === 'select') {
 		return;
 	}
 
-	let tag_only = form.tag_only;
+	const tag_only = form.tag_only;
 	if (tag_only && tag_only.checked) {
 		Twinkle.speedy.callback.evaluateUser(e);
 		return;
 	}
 
-	let values = Twinkle.speedy.resolveCsdValues(e);
+	const values = Twinkle.speedy.resolveCsdValues(e);
 	if (!values) {
 		return;
 	}
-	let templateParams = Twinkle.speedy.getParameters(form, values);
+	const templateParams = Twinkle.speedy.getParameters(form, values);
 	if (!templateParams) {
 		return;
 	}
 
-	let normalizeds = values.map(function(value) {
+	const normalizeds = values.map(function(value) {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
@@ -1915,16 +1915,16 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		}
 	});
 
-	let warnusertalk = form.warnusertalk.checked && normalizeds.some(function (norm, index) {
+	const warnusertalk = form.warnusertalk.checked && normalizeds.some(function (norm, index) {
 		return Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
 
-	let welcomeuser = warnusertalk && normalizeds.some(function (norm) {
+	const welcomeuser = warnusertalk && normalizeds.some(function (norm) {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
 
-	let params = {
+	const params = {
 		values: values,
 		normalizeds: normalizeds,
 		watch: watchPage,
@@ -1943,45 +1943,45 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 };
 
 Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUser(e) {
-	let form = e.target.form ? e.target.form : e.target;
+	const form = e.target.form ? e.target.form : e.target;
 
 	if (e.target.type === 'checkbox' || e.target.type === 'text' ||
 			e.target.type === 'select') {
 		return;
 	}
 
-	let values = Twinkle.speedy.resolveCsdValues(e);
+	const values = Twinkle.speedy.resolveCsdValues(e);
 	if (!values) {
 		return;
 	}
-	let templateParams = Twinkle.speedy.getParameters(form, values);
+	const templateParams = Twinkle.speedy.getParameters(form, values);
 	if (!templateParams) {
 		return;
 	}
 
 	// var multiple = form.multiple.checked;
 
-	let normalizeds = values.map(function(value) {
+	const normalizeds = values.map(function(value) {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	let watchPage = normalizeds.some(function(csdCriteria) {
+	const watchPage = normalizeds.some(function(csdCriteria) {
 		return Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
 	}) && Twinkle.getPref('watchSpeedyExpiry');
 
-	let notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
+	const notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
-	let welcomeuser = notifyuser && normalizeds.some(function(norm) {
+	const welcomeuser = notifyuser && normalizeds.some(function(norm) {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
-	let csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some(function(norm) {
+	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some(function(norm) {
 		return Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1;
 	});
 
-	let params = {
+	const params = {
 		values: values,
 		normalizeds: normalizeds,
 		watch: watchPage,
@@ -1998,7 +1998,7 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	Morebits.wiki.actionCompleted.redirect = mw.config.get('wgPageName');
 	Morebits.wiki.actionCompleted.notice = 'Tagging complete';
 
-	let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
+	const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Tagging page');
 	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.speedy.callbacks.user.main);

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -356,7 +356,7 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 		lelimit: 5  // A little bit goes a long way
 	};
 
-	new Morebits.wiki.api('Checking for past deletions', query, function(apiobj) {
+	new Morebits.wiki.api('Checking for past deletions', query, ((apiobj) => {
 		const response = apiobj.getResponse();
 		const delCount = response.query.logevents.length;
 		if (delCount) {
@@ -381,7 +381,7 @@ Twinkle.speedy.callback.priorDeletionCount = function () {
 			$('#prior-deletion-count').text(message + ' '); // Space before log link
 			$('#prior-deletion-count').append(link);
 		}
-	}).post();
+	})).post();
 };
 
 
@@ -402,7 +402,7 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 		e.stopPropagation();
 	};
 
-	return $.map(list, function(critElement) {
+	return $.map(list, (critElement) => {
 		const criterion = $.extend({}, critElement);
 
 		if (mode.isMultiple) {
@@ -1063,7 +1063,7 @@ Twinkle.speedy.callbacks = {
 		if (params.normalizeds.length > 1) {
 			code = '{{db-multiple';
 			params.utparams = {};
-			$.each(params.normalizeds, function(index, norm) {
+			$.each(params.normalizeds, (index, norm) => {
 				code += '|' + norm.toUpperCase();
 				parameters = params.templateParams[index] || [];
 				for (const i in parameters) {
@@ -1105,7 +1105,7 @@ Twinkle.speedy.callbacks = {
 		};
 
 		const statusIndicator = new Morebits.status('Building deletion summary');
-		const api = new Morebits.wiki.api('Parsing deletion template', query, function(apiobj) {
+		const api = new Morebits.wiki.api('Parsing deletion template', query, ((apiobj) => {
 			const reason = decodeURIComponent($(apiobj.getResponse().parse.text).find('#delete-reason').text()).replace(/\+/g, ' ');
 			if (!reason) {
 				statusIndicator.warn('Unable to generate summary from deletion template');
@@ -1113,7 +1113,7 @@ Twinkle.speedy.callbacks = {
 				statusIndicator.info('complete');
 			}
 			callback(reason);
-		}, statusIndicator);
+		}), statusIndicator);
 		api.post();
 	},
 
@@ -1150,7 +1150,7 @@ Twinkle.speedy.callbacks = {
 			if (params.normalizeds.length > 1) {
 				notifytext = '\n{{subst:db-' + (params.warnUser ? 'deleted' : 'notice') + '-multiple|1=' + Morebits.pageNameNorm;
 				let count = 2;
-				$.each(params.normalizeds, function(index, norm) {
+				$.each(params.normalizeds, (index, norm) => {
 					notifytext += '|' + count++ + '=' + norm.toUpperCase();
 				});
 			} else if (params.normalizeds[0] === 'db') {
@@ -1185,12 +1185,12 @@ Twinkle.speedy.callbacks = {
 			usertalkpage.setCreateOption('recreate');
 			usertalkpage.setWatchlist(Twinkle.getPref('watchSpeedyUser'));
 			usertalkpage.setFollowRedirect(true, false);
-			usertalkpage.append(function onNotifySuccess() {
+			usertalkpage.append(() => {
 				// add this nomination to the user's userspace log, if the user has enabled it
 				if (params.lognomination) {
 					Twinkle.speedy.callbacks.user.addToLog(params, initialContrib);
 				}
-			}, function onNotifyError() {
+			}, () => {
 				// if user could not be notified, log nomination without mentioning that notification was sent
 				if (params.lognomination) {
 					Twinkle.speedy.callbacks.user.addToLog(params, null);
@@ -1210,7 +1210,7 @@ Twinkle.speedy.callbacks = {
 				Twinkle.speedy.callbacks.sysop.deletePage(reason, params);
 			} else {
 				const code = Twinkle.speedy.callbacks.getTemplateCodeAndParams(params)[0];
-				Twinkle.speedy.callbacks.parseWikitext(code, function(reason) {
+				Twinkle.speedy.callbacks.parseWikitext(code, (reason) => {
 					if (params.promptForSummary) {
 						reason = prompt('Enter the deletion summary to use, or press OK to accept the automatically generated one.', reason);
 					}
@@ -1231,7 +1231,7 @@ Twinkle.speedy.callbacks = {
 				thispage.setEditSummary(reason);
 				thispage.setChangeTags(Twinkle.changeTags);
 				thispage.setWatchlist(params.watch);
-				thispage.deletePage(function() {
+				thispage.deletePage(() => {
 					thispage.getStatusElement().info('done');
 					typeof callback === 'function' && callback();
 					Twinkle.speedy.callbacks.sysop.deleteTalk(params);
@@ -1242,8 +1242,8 @@ Twinkle.speedy.callbacks = {
 			// Otherwise open the talk page directly
 			if (params.warnUser) {
 				thispage.setCallbackParameters(params);
-				thispage.lookupCreation(function(pageobj) {
-					deleteMain(function() {
+				thispage.lookupCreation((pageobj) => {
+					deleteMain(() => {
 						Twinkle.speedy.callbacks.noteToCreator(pageobj);
 					});
 				});
@@ -1262,7 +1262,7 @@ Twinkle.speedy.callbacks = {
 				talkpage.deletePage();
 				// this is ugly, but because of the architecture of wiki.api, it is needed
 				// (otherwise success/failure messages for the previous action would be suppressed)
-				window.setTimeout(function() {
+				window.setTimeout(() => {
 					Twinkle.speedy.callbacks.sysop.deleteRedirects(params);
 				}, 1800);
 			} else {
@@ -1347,7 +1347,7 @@ Twinkle.speedy.callbacks = {
 
 			Morebits.wiki.addCheckpoint();
 
-			snapshot.forEach(function(value) {
+			snapshot.forEach((value) => {
 				const title = value.title;
 				const page = new Morebits.wiki.page(title, 'Deleting redirect "' + title + '"');
 				page.setEditSummary('[[WP:CSD#G8|G8]]: Redirect to deleted page "' + Morebits.pageNameNorm + '"');
@@ -1439,7 +1439,7 @@ Twinkle.speedy.callbacks = {
 				let editsummary;
 				if (params.normalizeds.length > 1) {
 					editsummary = 'Requesting speedy deletion (';
-					$.each(params.normalizeds, function(index, norm) {
+					$.each(params.normalizeds, (index, norm) => {
 						editsummary += '[[WP:CSD#' + norm.toUpperCase() + '|CSD ' + norm.toUpperCase() + ']], ';
 					});
 					editsummary = editsummary.substr(0, editsummary.length - 2); // remove trailing comma
@@ -1546,7 +1546,7 @@ Twinkle.speedy.callbacks = {
 			}
 			if (params.normalizeds.length > 1) {
 				appendText += 'multiple criteria (';
-				$.each(params.normalizeds, function(index, norm) {
+				$.each(params.normalizeds, (index, norm) => {
 					appendText += '[[WP:CSD#' + norm.toUpperCase() + '|' + norm.toUpperCase() + ']], ';
 				});
 				appendText = appendText.substr(0, appendText.length - 2);  // remove trailing comma
@@ -1563,11 +1563,11 @@ Twinkle.speedy.callbacks = {
 				if (params.normalizeds[0] && params.normalizeds[0] === 'db') {
 					extraInfo += formatParamLog('Custom', 'rationale', params.templateParams[0]['1']);
 				} else {
-					params.templateParams.forEach(function(item, index) {
+					params.templateParams.forEach((item, index) => {
 						const keys = Object.keys(item);
 						if (keys[0] !== undefined && keys[0].length > 0) {
 							// Second loop required since some items (G12, F9) may have multiple keys
-							keys.forEach(function(key, keyIndex) {
+							keys.forEach((key, keyIndex) => {
 								if (keys[keyIndex] === 'blanked' || keys[keyIndex] === 'ts') {
 									return true; // Not worth logging
 								}
@@ -1599,7 +1599,7 @@ Twinkle.speedy.callbacks = {
 Twinkle.speedy.getParameters = function twinklespeedyGetParameters(form, values) {
 	let parameters = [];
 
-	$.each(values, function(index, value) {
+	$.each(values, (index, value) => {
 		const currentParams = [];
 		switch (value) {
 			case 'reason':
@@ -1829,7 +1829,7 @@ Twinkle.speedy.getUserTalkParameters = function twinklespeedyGetUserTalkParamete
 		utparams.key1 = 'to';
 		utparams.value1 = Morebits.pageNameNorm;
 	} else if (normalized === 'g12') {
-		['url', 'url2', 'url3'].forEach(function(item, idx) {
+		['url', 'url2', 'url3'].forEach((item, idx) => {
 			if (parameters[item]) {
 				idx++;
 				utparams['key' + idx] = item;
@@ -1900,13 +1900,13 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		return;
 	}
 
-	const normalizeds = values.map(function(value) {
+	const normalizeds = values.map((value) => {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
 	// analyse each criterion to determine whether to watch the page, prompt for summary, or notify the creator
 	let watchPage, promptForSummary;
-	normalizeds.forEach(function(norm) {
+	normalizeds.forEach((norm) => {
 		if (Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1) {
 			watchPage = Twinkle.getPref('watchSpeedyExpiry');
 		}
@@ -1915,12 +1915,12 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 		}
 	});
 
-	const warnusertalk = form.warnusertalk.checked && normalizeds.some(function (norm, index) {
+	const warnusertalk = form.warnusertalk.checked && normalizeds.some((norm, index) => {
 		return Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
 
-	const welcomeuser = warnusertalk && normalizeds.some(function (norm) {
+	const welcomeuser = warnusertalk && normalizeds.some((norm) => {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
 
@@ -1961,23 +1961,23 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 
 	// var multiple = form.multiple.checked;
 
-	const normalizeds = values.map(function(value) {
+	const normalizeds = values.map((value) => {
 		return Twinkle.speedy.normalizeHash[value];
 	});
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	const watchPage = normalizeds.some(function(csdCriteria) {
+	const watchPage = normalizeds.some((csdCriteria) => {
 		return Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1;
 	}) && Twinkle.getPref('watchSpeedyExpiry');
 
-	const notifyuser = form.notify.checked && normalizeds.some(function(norm, index) {
+	const notifyuser = form.notify.checked && normalizeds.some((norm, index) => {
 		return Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
 			!(norm === 'g6' && values[index] !== 'copypaste');
 	});
-	const welcomeuser = notifyuser && normalizeds.some(function(norm) {
+	const welcomeuser = notifyuser && normalizeds.some((norm) => {
 		return Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1;
 	});
-	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some(function(norm) {
+	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some((norm) => {
 		return Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1;
 	});
 

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -2005,7 +2005,7 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 };
 
 Twinkle.addInitCallback(Twinkle.speedy, 'speedy');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -46,7 +46,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 	const form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
 	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
-	const isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));
+	const isPatroller = mw.config.get('wgUserGroups').some((r) => ['patroller', 'sysop'].includes(r));
 	if (isPatroller) {
 		new mw.Api().get({
 			action: 'pagetriagelist',

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -36,17 +36,17 @@ Twinkle.tag = function twinkletag() {
 Twinkle.tag.checkedTags = [];
 
 Twinkle.tag.callback = function twinkletagCallback() {
-	let Window = new Morebits.simpleWindow(630, Twinkle.tag.mode === 'article' ? 500 : 400);
+	const Window = new Morebits.simpleWindow(630, Twinkle.tag.mode === 'article' ? 500 : 400);
 	Window.setScriptName('Twinkle');
 	// anyone got a good policy/guideline/info page/instructional page link??
 	Window.addFooterLink('Tag prefs', 'WP:TW/PREF#tag');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
 	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
-	let isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));
+	const isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));
 	if (isPatroller) {
 		new mw.Api().get({
 			action: 'pagetriagelist',
@@ -56,14 +56,14 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			// Figure out whether the article is marked as reviewed in PageTriage.
 			// Recent articles will have a patrol_status that we can read.
 			// For articles that have been out of the new pages feed for awhile, pages[0] will be undefined.
-			let isReviewed = response.pagetriagelist.pages[0] ?
+			const isReviewed = response.pagetriagelist.pages[0] ?
 				response.pagetriagelist.pages[0].patrol_status > 0 :
 				true;
 
 			// if article is not marked as reviewed, show the "mark as reviewed" check box
 			if (!isReviewed) {
 				// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
-				let checkbox = new Morebits.quickForm.element({
+				const checkbox = new Morebits.quickForm.element({
 					type: 'checkbox',
 					list: [
 						{
@@ -74,7 +74,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 						}
 					]
 				});
-				let html = checkbox.render();
+				const html = checkbox.render();
 				$('.quickform').prepend(html);
 			}
 		});
@@ -88,7 +88,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		event: function twinkletagquickfilter() {
 			// flush the DOM of all existing underline spans
 			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
-				let label_element = e.parentElement;
+				const label_element = e.parentElement;
 				// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
 				// to <label>Hello world</label>
 				label_element.innerHTML = label_element.textContent;
@@ -97,19 +97,19 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			if (this.value) {
 				$allCheckboxDivs.hide();
 				$allHeaders.hide();
-				let searchString = this.value;
-				let searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
+				const searchString = this.value;
+				const searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
 
 				$allCheckboxDivs.find('label').each(function () {
-					let label_text = this.textContent;
-					let searchHit = searchRegex.exec(label_text);
+					const label_text = this.textContent;
+					const searchHit = searchRegex.exec(label_text);
 					if (searchHit) {
-						let range = document.createRange();
-						let textnode = this.childNodes[0];
+						const range = document.createRange();
+						const textnode = this.childNodes[0];
 						range.selectNodeContents(textnode);
 						range.setStart(textnode, searchHit.index);
 						range.setEnd(textnode, searchHit.index + searchString.length);
-						let underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+						const underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
 						range.surroundContents(underline_span);
 						this.parentElement.style.display = 'block'; // show
 					}
@@ -155,7 +155,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 
 			if (!Twinkle.tag.canRemove) {
-				let divElement = document.createElement('div');
+				const divElement = document.createElement('div');
 				divElement.innerHTML = 'For removal of existing tags, please open Tag menu from the current version of article';
 				form.append({
 					type: 'div',
@@ -216,7 +216,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 				if (typeof item.restriction === 'undefined') {
 					return false;
 				}
-				let namespace = mw.config.get('wgNamespaceNumber');
+				const namespace = mw.config.get('wgNamespaceNumber');
 				switch (item.restriction) {
 					case 'insideMainspaceOnly':
 						if (namespace !== 0) {
@@ -249,7 +249,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			var i = 1;
 			$.each(Twinkle.tag.redirectList, function(groupName, group) {
 				form.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
-				let subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
+				const subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
 				$.each(group, function(subgroupName, subgroup) {
 					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
 					subdiv.append({
@@ -279,7 +279,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 	form.append({ type: 'submit', className: 'tw-tag-submit' });
 
-	let result = form.render();
+	const result = form.render();
 	Window.setContent(result);
 	Window.display();
 
@@ -321,14 +321,14 @@ Twinkle.tag.callback = function twinkletagCallback() {
 					if (e.classList[0] === 'box-Multiple_issues') {
 						$(e).find('.ambox').each(function(idx, e) {
 							if (e.classList[0].indexOf('box-') === 0) {
-								let tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
+								const tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 								Twinkle.tag.alreadyPresentTags.push(tag);
 							}
 						});
 						return true; // continue
 					}
 
-					let tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
+					const tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 					Twinkle.tag.alreadyPresentTags.push(tag);
 				}
 			});
@@ -344,7 +344,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		}
 
 		// Add status text node after Submit button
-		let statusNode = document.createElement('small');
+		const statusNode = document.createElement('small');
 		statusNode.id = 'tw-tag-status';
 		Twinkle.tag.status = {
 			// initial state; defined like this because these need to be available for reference
@@ -355,7 +355,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		$('button.tw-tag-submit').after(statusNode);
 
 		// fake a change event on the sort dropdown, to initialize the tag list
-		let evt = document.createEvent('Event');
+		const evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 		result.sortorder.dispatchEvent(evt);
 
@@ -371,16 +371,16 @@ Twinkle.tag.callback = function twinkletagCallback() {
 let $allCheckboxDivs, $allHeaders;
 
 Twinkle.tag.updateSortOrder = function(e) {
-	let form = e.target.form;
-	let sortorder = e.target.value;
+	const form = e.target.form;
+	const sortorder = e.target.value;
 	Twinkle.tag.checkedTags = form.getChecked('tags');
 
-	let container = new Morebits.quickForm.element({ type: 'fragment' });
+	const container = new Morebits.quickForm.element({ type: 'fragment' });
 
 	// function to generate a checkbox, with appropriate subgroup if needed
-	let makeCheckbox = function (item) {
-		let tag = item.tag, description = item.description;
-		let checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
+	const makeCheckbox = function (item) {
+		const tag = item.tag, description = item.description;
+		const checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
 		if (Twinkle.tag.checkedTags.indexOf(tag) !== -1) {
 			checkbox.checked = true;
 		}
@@ -388,13 +388,13 @@ Twinkle.tag.updateSortOrder = function(e) {
 		return checkbox;
 	};
 
-	let makeCheckboxesForAlreadyPresentTags = function() {
+	const makeCheckboxesForAlreadyPresentTags = function() {
 		container.append({ type: 'header', id: 'tagHeader0', label: 'Tags already present' });
-		let subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
-		let checkboxes = [];
-		let unCheckedTags = e.target.form.getUnchecked('existingTags');
+		const subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
+		const checkboxes = [];
+		const unCheckedTags = e.target.form.getUnchecked('existingTags');
 		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
-			let checkbox =
+			const checkbox =
 				{
 					value: tag,
 					label: '{{' + tag + '}}' + (Twinkle.tag.article.flatObject[tag] ? ': ' + Twinkle.tag.article.flatObject[tag].description : ''),
@@ -414,8 +414,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 
 	if (sortorder === 'cat') { // categorical sort order
 		// function to iterate through the tags and create a checkbox for each one
-		let doCategoryCheckboxes = function(subdiv, subgroup) {
-			let checkboxes = [];
+		const doCategoryCheckboxes = function(subdiv, subgroup) {
+			const checkboxes = [];
 			$.each(subgroup, function(k, item) {
 				if (Twinkle.tag.alreadyPresentTags.indexOf(item.tag) === -1) {
 					checkboxes.push(makeCheckbox(item));
@@ -435,7 +435,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		// go through each category and sub-category and append lists of checkboxes
 		$.each(Twinkle.tag.article.tagList, function(groupName, group) {
 			container.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
-			let subdiv = container.append({ type: 'div', id: 'tagSubdiv' + i++ });
+			const subdiv = container.append({ type: 'div', id: 'tagSubdiv' + i++ });
 			if (Array.isArray(group)) {
 				doCategoryCheckboxes(subdiv, group);
 			} else {
@@ -453,7 +453,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 
 		// Avoid repeatedly resorting
 		Twinkle.tag.article.alphabeticalList = Twinkle.tag.article.alphabeticalList || Object.keys(Twinkle.tag.article.flatObject).sort();
-		let checkboxes = [];
+		const checkboxes = [];
 		Twinkle.tag.article.alphabeticalList.forEach(function(tag) {
 			if (Twinkle.tag.alreadyPresentTags.indexOf(tag) === -1) {
 				checkboxes.push(makeCheckbox(Twinkle.tag.article.flatObject[tag]));
@@ -477,8 +477,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 		});
 	}
 
-	let $workarea = $(form).find('#tagWorkArea');
-	let rendered = container.render();
+	const $workarea = $(form).find('#tagWorkArea');
+	const rendered = container.render();
 	$workarea.empty().append(rendered);
 
 	// for quick filter:
@@ -496,7 +496,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	Morebits.quickForm.getElements(form, 'tags').forEach(generateLinks);
 
 	// tally tags added/removed, update statusNode text
-	let statusNode = document.getElementById('tw-tag-status');
+	const statusNode = document.getElementById('tw-tag-status');
 	$('[name=tags], [name=existingTags]').click(function() {
 		if (this.name === 'tags') {
 			Twinkle.tag.status.numAdded += this.checked ? 1 : -1;
@@ -504,8 +504,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 			Twinkle.tag.status.numRemoved += this.checked ? -1 : 1;
 		}
 
-		let firstPart = 'Adding ' + Twinkle.tag.status.numAdded + ' tag' + (Twinkle.tag.status.numAdded > 1 ? 's' : '');
-		let secondPart = 'Removing ' + Twinkle.tag.status.numRemoved + ' tag' + (Twinkle.tag.status.numRemoved > 1 ? 's' : '');
+		const firstPart = 'Adding ' + Twinkle.tag.status.numAdded + ' tag' + (Twinkle.tag.status.numAdded > 1 ? 's' : '');
+		const secondPart = 'Removing ' + Twinkle.tag.status.numRemoved + ' tag' + (Twinkle.tag.status.numRemoved > 1 ? 's' : '');
 		statusNode.textContent =
 			(Twinkle.tag.status.numAdded ? '  ' + firstPart : '') +
 			(Twinkle.tag.status.numRemoved ? (Twinkle.tag.status.numAdded ? '; ' : '  ') + secondPart : '');
@@ -517,9 +517,9 @@ Twinkle.tag.updateSortOrder = function(e) {
  * @param {Morebits.quickForm.element} checkbox  associated with the template
  */
 var generateLinks = function(checkbox) {
-	let link = Morebits.htmlNode('a', '>');
+	const link = Morebits.htmlNode('a', '>');
 	link.setAttribute('class', 'tag-template-link');
-	let tagname = checkbox.values;
+	const tagname = checkbox.values;
 	link.setAttribute('href', mw.util.getUrl(
 		(tagname.indexOf(':') === -1 ? 'Template:' : '') +
 		(tagname.indexOf('|') === -1 ? tagname : tagname.slice(0, tagname.indexOf('|')))
@@ -533,7 +533,7 @@ var generateLinks = function(checkbox) {
 Twinkle.tag.article = {};
 
 // Shared across {{Rough translation}} and {{Not English}}
-let translationSubgroups = [
+const translationSubgroups = [
 	{
 		name: 'translationLanguage',
 		parameter: '1',
@@ -559,7 +559,7 @@ let translationSubgroups = [
 ] : []);
 
 // Subgroups for {{merge}}, {{merge-to}} and {{merge-from}}
-let getMergeSubgroups = function(tag) {
+const getMergeSubgroups = function(tag) {
 	let otherTagName = 'Merge';
 	switch (tag) {
 		case 'Merge from':
@@ -1349,13 +1349,13 @@ Twinkle.tag.callbacks = {
 
 		// Remove tags that become superfluous with this action
 		let pageText = pageobj.getPageText().replace(/\{\{\s*([Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, '');
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 
 		/**
 		 * Saves the page following the removal of tags if any. The last step.
 		 * Called from removeTags()
 		 */
-		let postRemoval = function() {
+		const postRemoval = function() {
 			if (params.tagsToRemove.length) {
 				// Remove empty {{multiple issues}} if found
 				pageText = pageText.replace(/\{\{(multiple ?issues|article ?issues|mi)\s*\|\s*\}\}\n?/im, '');
@@ -1364,14 +1364,14 @@ Twinkle.tag.callbacks = {
 			}
 
 			// Build edit summary
-			let makeSentence = function(array) {
+			const makeSentence = function(array) {
 				if (array.length < 3) {
 					return array.join(' and ');
 				}
-				let last = array.pop();
+				const last = array.pop();
 				return array.join(', ') + ', and ' + last;
 			};
-			let makeTemplateLink = function(tag) {
+			const makeTemplateLink = function(tag) {
 				let text = '{{[[';
 				// if it is a custom tag with a parameter
 				if (tag.indexOf('|') !== -1) {
@@ -1382,8 +1382,8 @@ Twinkle.tag.callbacks = {
 			};
 
 			let summaryText;
-			let addedTags = params.tags.map(makeTemplateLink);
-			let removedTags = params.tagsToRemove.map(makeTemplateLink);
+			const addedTags = params.tags.map(makeTemplateLink);
+			const removedTags = params.tagsToRemove.map(makeTemplateLink);
 			if (addedTags.length) {
 				summaryText = 'Added ' + makeSentence(addedTags);
 				summaryText += removedTags.length ? '; and removed ' + makeSentence(removedTags) : '';
@@ -1410,7 +1410,7 @@ Twinkle.tag.callbacks = {
 			pageobj.save(function() {
 				// COI: Start the discussion on the talk page (mainspace only)
 				if (params.coiReason) {
-					let coiTalkPage = new Morebits.wiki.page('Talk:' + Morebits.pageNameNorm, 'Starting discussion on talk page');
+					const coiTalkPage = new Morebits.wiki.page('Talk:' + Morebits.pageNameNorm, 'Starting discussion on talk page');
 					coiTalkPage.setNewSectionText(params.coiReason + ' ~~~~');
 					coiTalkPage.setNewSectionTitle('COI tag (' + new Morebits.date(pageobj.getLoadTime()).format('MMMM Y', 'utc') + ')');
 					coiTalkPage.setChangeTags(Twinkle.changeTags);
@@ -1421,7 +1421,7 @@ Twinkle.tag.callbacks = {
 				// Special functions for merge tags
 				// Post a rationale on the talk page (mainspace only)
 				if (params.mergeReason) {
-					let mergeTalkPage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
+					const mergeTalkPage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					mergeTalkPage.setNewSectionText(params.mergeReason.trim() + ' ~~~~');
 					mergeTalkPage.setNewSectionTitle(params.talkDiscussionTitleLinked);
 					mergeTalkPage.setChangeTags(Twinkle.changeTags);
@@ -1437,7 +1437,7 @@ Twinkle.tag.callbacks = {
 					} else if (params.mergeTag === 'Merge to') {
 						otherTagName = 'Merge from';
 					}
-					let newParams = {
+					const newParams = {
 						tags: [otherTagName],
 						tagsToRemove: [],
 						tagsToRemain: [],
@@ -1446,7 +1446,7 @@ Twinkle.tag.callbacks = {
 						talkDiscussionTitle: params.talkDiscussionTitle,
 						talkDiscussionTitleLinked: params.talkDiscussionTitleLinked
 					};
-					let otherpage = new Morebits.wiki.page(params.mergeTarget, 'Tagging other page (' +
+					const otherpage = new Morebits.wiki.page(params.mergeTarget, 'Tagging other page (' +
 						params.mergeTarget + ')');
 					otherpage.setChangeTags(Twinkle.changeTags);
 					otherpage.setCallbackParameters(newParams);
@@ -1456,14 +1456,14 @@ Twinkle.tag.callbacks = {
 				// Special functions for {{not English}} and {{rough translation}}
 				// Post at WP:PNT (mainspace only)
 				if (params.translationPostAtPNT) {
-					let pntPage = new Morebits.wiki.page('Wikipedia:Pages needing translation into English',
+					const pntPage = new Morebits.wiki.page('Wikipedia:Pages needing translation into English',
 						'Listing article at Wikipedia:Pages needing translation into English');
 					pntPage.setFollowRedirect(true);
 					pntPage.load(function twinkletagCallbacksTranslationListPage(pageobj) {
-						let old_text = pageobj.getPageText();
+						const old_text = pageobj.getPageText();
 
-						let lang = params.translationLanguage;
-						let reason = params.translationComments;
+						const lang = params.translationLanguage;
+						const reason = params.translationComments;
 
 						let templateText;
 
@@ -1497,7 +1497,7 @@ Twinkle.tag.callbacks = {
 				// Notify the user ({{Not English}} only)
 				if (params.translationNotify) {
 					new Morebits.wiki.page(Morebits.pageNameNorm).lookupCreation(function(innerPageobj) {
-						let initialContrib = innerPageobj.getCreator();
+						const initialContrib = innerPageobj.getCreator();
 
 						// Disallow warning yourself
 						if (initialContrib === mw.config.get('wgUserName')) {
@@ -1505,7 +1505,7 @@ Twinkle.tag.callbacks = {
 							return;
 						}
 
-						let userTalkPage = new Morebits.wiki.page('User talk:' + initialContrib,
+						const userTalkPage = new Morebits.wiki.page('User talk:' + initialContrib,
 							'Notifying initial contributor (' + initialContrib + ')');
 						userTalkPage.setNewSectionTitle('Your article [[' + Morebits.pageNameNorm + ']]');
 						userTalkPage.setNewSectionText('{{subst:uw-notenglish|1=' + Morebits.pageNameNorm +
@@ -1528,7 +1528,7 @@ Twinkle.tag.callbacks = {
 		 * Removes the existing tags that were deselected (if any)
 		 * Calls postRemoval() when done
 		 */
-		let removeTags = function removeTags() {
+		const removeTags = function removeTags() {
 
 			if (params.tagsToRemove.length === 0) {
 				postRemoval();
@@ -1537,13 +1537,13 @@ Twinkle.tag.callbacks = {
 
 			Morebits.status.info('Info', 'Removing deselected tags that were already present');
 
-			let getRedirectsFor = [];
+			const getRedirectsFor = [];
 
 			// Remove the tags from the page text, if found in its proper name,
 			// otherwise moves it to `getRedirectsFor` array earmarking it for
 			// later removal
 			params.tagsToRemove.forEach(function removeTag(tag) {
-				let tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?');
+				const tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?');
 
 				if (tag_re.test(pageText)) {
 					pageText = pageText.replace(tag_re, '');
@@ -1558,7 +1558,7 @@ Twinkle.tag.callbacks = {
 			}
 
 			// Remove tags which appear in page text as redirects
-			let api = new Morebits.wiki.api('Getting template redirects', {
+			const api = new Morebits.wiki.api('Getting template redirects', {
 				action: 'query',
 				prop: 'linkshere',
 				titles: getRedirectsFor.join('|'),
@@ -1568,14 +1568,14 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function removeRedirectTag(apiobj) {
-				let pages = apiobj.getResponse().query.pages.filter(function(p) {
+				const pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;
 				});
 				pages.forEach(function(page) {
 					let removed = false;
 					page.linkshere.concat({title: page.title}).forEach(function(el) {
-						let tag = el.title.slice(9);
-						let tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
+						const tag = el.title.slice(9);
+						const tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
 						if (tag_re.test(pageText)) {
 							pageText = pageText.replace(tag_re, '');
 							removed = true;
@@ -1609,7 +1609,7 @@ Twinkle.tag.callbacks = {
 		 * @param {number} tagIndex
 		 * @param {string} tagName
 		 */
-		let addTag = function articleAddTag(tagIndex, tagName) {
+		const addTag = function articleAddTag(tagIndex, tagName) {
 			let currentTag = '';
 			if (tagName === 'Uncategorized' || tagName === 'Improve categories') {
 				pageText += '\n\n{{' + tagName + '|date={{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}}}';
@@ -1617,10 +1617,10 @@ Twinkle.tag.callbacks = {
 				currentTag += '{{' + tagName;
 				// fill in other parameters, based on the tag
 
-				let subgroupObj = Twinkle.tag.article.flatObject[tagName] &&
+				const subgroupObj = Twinkle.tag.article.flatObject[tagName] &&
 					Twinkle.tag.article.flatObject[tagName].subgroup;
 				if (subgroupObj) {
-					let subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
+					const subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
 					subgroups.forEach(function(gr) {
 						if (gr.parameter && (params[gr.name] || gr.required)) {
 							currentTag += '|' + gr.parameter + '=' + (params[gr.name] || '');
@@ -1651,11 +1651,11 @@ Twinkle.tag.callbacks = {
 								params.discussArticle = tagName === 'Merge to' ? params.mergeTarget : mw.config.get('wgTitle');
 								// nonDiscussArticle is the article which won't have the discussion
 								params.nonDiscussArticle = tagName === 'Merge to' ? mw.config.get('wgTitle') : params.mergeTarget;
-								let direction = '[[' + params.nonDiscussArticle + ']]' + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + '[[' + params.discussArticle + ']]';
+								const direction = '[[' + params.nonDiscussArticle + ']]' + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + '[[' + params.discussArticle + ']]';
 								params.talkDiscussionTitleLinked = 'Proposed merge of ' + direction;
 								params.talkDiscussionTitle = params.talkDiscussionTitleLinked.replace(/\[\[(.*?)\]\]/g, '$1');
 							}
-							let titleWithSectionRemoved = params.discussArticle.replace(/^([^#]*)#.*$/, '$1'); // If article name is Test#Section, delete #Section
+							const titleWithSectionRemoved = params.discussArticle.replace(/^([^#]*)#.*$/, '$1'); // If article name is Test#Section, delete #Section
 							currentTag += '|discuss=Talk:' + titleWithSectionRemoved + '#' + params.talkDiscussionTitle;
 						}
 						break;
@@ -1673,13 +1673,13 @@ Twinkle.tag.callbacks = {
 		 * these tags aren't supported in {{multiple issues}} or because
 		 * {{multiple issues}} is not being added to the page at all
 		 */
-		let addUngroupedTags = function() {
+		const addUngroupedTags = function() {
 			$.each(tags, addTag);
 
 			// Insert tag after short description or any hatnotes,
 			// as well as deletion/protection-related templates
-			let wikipage = new Morebits.wikitext.page(pageText);
-			let templatesAfter = Twinkle.hatnoteRegex +
+			const wikipage = new Morebits.wikitext.page(pageText);
+			const templatesAfter = Twinkle.hatnoteRegex +
 				// Protection templates
 				'pp|pp-.*?|' +
 				// CSD
@@ -1690,7 +1690,7 @@ Twinkle.tag.callbacks = {
 				'salt|proposed deletion endorsed';
 			// AfD is special, as the tag includes html comments before and after the actual template
 			// trailing whitespace/newline needed since this subst's a newline
-			let afdRegex = '(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?';
+			const afdRegex = '(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?';
 			pageText = wikipage.insertAfterTemplates(tagText, templatesAfter, null, afdRegex).getText();
 
 			removeTags();
@@ -1730,7 +1730,7 @@ Twinkle.tag.callbacks = {
 			}
 		});
 
-		let miTest = /\{\{(multiple ?issues|article ?issues|mi)(?!\s*\|\s*section\s*=)[^}]+\{/im.exec(pageText);
+		const miTest = /\{\{(multiple ?issues|article ?issues|mi)(?!\s*\|\s*section\s*=)[^}]+\{/im.exec(pageText);
 
 		if (miTest && groupableTags.length > 0) {
 			Morebits.status.info('Info', 'Adding supported tags inside existing {{multiple issues}} tag');
@@ -1738,7 +1738,7 @@ Twinkle.tag.callbacks = {
 			tagText = '';
 			$.each(groupableTags, addTag);
 
-			let miRegex = new RegExp('(\\{\\{\\s*' + miTest[1] + '\\s*(?:\\|(?:\\{\\{[^{}]*\\}\\}|[^{}])*)?)\\}\\}\\s*', 'im');
+			const miRegex = new RegExp('(\\{\\{\\s*' + miTest[1] + '\\s*(?:\\|(?:\\{\\{[^{}]*\\}\\}|[^{}])*)?)\\}\\}\\s*', 'im');
 			pageText = pageText.replace(miRegex, '$1' + tagText + '}}\n');
 			tagText = '';
 
@@ -1752,7 +1752,7 @@ Twinkle.tag.callbacks = {
 			/**
 			 * Adds newly added tags to MI
 			 */
-			let addNewTagsToMI = function() {
+			const addNewTagsToMI = function() {
 				$.each(groupableTags, addTag);
 				tagText += '}}\n';
 
@@ -1760,12 +1760,12 @@ Twinkle.tag.callbacks = {
 			};
 
 
-			let getRedirectsFor = [];
+			const getRedirectsFor = [];
 
 			// Reposition the tags on the page into {{multiple issues}}, if found with its
 			// proper name, else moves it to `getRedirectsFor` array to be handled later
 			groupableExistingTags.forEach(function repositionTagIntoMI(tag) {
-				let tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?)');
+				const tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?)');
 				if (tag_re.test(pageText)) {
 					tagText += tag_re.exec(pageText)[1];
 					pageText = pageText.replace(tag_re, '');
@@ -1779,7 +1779,7 @@ Twinkle.tag.callbacks = {
 				return;
 			}
 
-			let api = new Morebits.wiki.api('Getting template redirects', {
+			const api = new Morebits.wiki.api('Getting template redirects', {
 				action: 'query',
 				prop: 'linkshere',
 				titles: getRedirectsFor.join('|'),
@@ -1789,14 +1789,14 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function replaceRedirectTag(apiobj) {
-				let pages = apiobj.getResponse().query.pages.filter(function(p) {
+				const pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;
 				});
 				pages.forEach(function(page) {
 					let found = false;
 					page.linkshere.forEach(function(el) {
-						let tag = el.title.slice(9);
-						let tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
+						const tag = el.title.slice(9);
+						const tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
 						if (tag_re.test(pageText)) {
 							tagText += tag_re.exec(pageText)[1];
 							pageText = pageText.replace(tag_re, '');
@@ -1835,7 +1835,7 @@ Twinkle.tag.callbacks = {
 			}
 		}
 
-		let addTag = function redirectAddTag(tagIndex, tagName) {
+		const addTag = function redirectAddTag(tagIndex, tagName) {
 			tagText += '\n{{' + tagName;
 			if (tagName === 'R from alternative language') {
 				if (params.altLangFrom) {
@@ -1870,15 +1870,15 @@ Twinkle.tag.callbacks = {
 		// Check for all Rcat shell redirects (from #433)
 		if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
 			// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
-			let oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]|{{[^}]+}})+)(}})\s*/i);
+			const oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]|{{[^}]+}})+)(}})\s*/i);
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell
-			let pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
+			const pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
 			let oldPageTags = '';
 			if (pageTags) {
 				pageTags.forEach(function(pageTag) {
-					let pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
+					const pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
 					pageText = pageText.replace(pageRe, '');
 					pageTag = pageTag.trim();
 					oldPageTags += '\n' + pageTag;
@@ -1911,7 +1911,7 @@ Twinkle.tag.callbacks = {
 
 	file: function twinkletagCallbacksFile(pageobj) {
 		let text = pageobj.getPageText();
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 		let summary = 'Adding ';
 
 		// Add maintenance tags
@@ -2029,15 +2029,15 @@ Twinkle.tag.callbacks = {
 };
 
 Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
-	let form = e.target;
-	let params = Morebits.quickForm.getInputData(form);
+	const form = e.target;
+	const params = Morebits.quickForm.getInputData(form);
 
 
 	// Validation
 
 	// Given an array of incompatible tags, check if we have two or more selected
-	let checkIncompatible = function(conflicts, extra) {
-		let count = conflicts.reduce(function(sum, tag) {
+	const checkIncompatible = function(conflicts, extra) {
+		const count = conflicts.reduce(function(sum, tag) {
 			return sum += params.tags.indexOf(tag) !== -1;
 		}, 0);
 		if (count > 1) {
@@ -2092,7 +2092,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 			// Get extension from either mime-type or title, if not present (e.g., SVGs)
 			var extension = ((extension = $('.mime-type').text()) && extension.split(/\//)[1]) || mw.Title.newFromText(Morebits.pageNameNorm).getExtension();
 			if (extension) {
-				let extensionUpper = extension.toUpperCase();
+				const extensionUpper = extension.toUpperCase();
 
 				// What self-respecting file format has *two* extensions?!
 				if (extensionUpper === 'JPG') {
@@ -2195,7 +2195,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 		Morebits.wiki.actionCompleted.followRedirect = false;
 	}
 
-	let wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + Twinkle.tag.mode);
+	const wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + Twinkle.tag.mode);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.load(Twinkle.tag.callbacks[Twinkle.tag.mode]);

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -2203,5 +2203,5 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.tag, 'tag');
-})(jQuery);
+}(jQuery));
 // </nowiki>

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -36,14 +36,14 @@ Twinkle.tag = function twinkletag() {
 Twinkle.tag.checkedTags = [];
 
 Twinkle.tag.callback = function twinkletagCallback() {
-	var Window = new Morebits.simpleWindow(630, Twinkle.tag.mode === 'article' ? 500 : 400);
+	let Window = new Morebits.simpleWindow(630, Twinkle.tag.mode === 'article' ? 500 : 400);
 	Window.setScriptName('Twinkle');
 	// anyone got a good policy/guideline/info page/instructional page link??
 	Window.addFooterLink('Tag prefs', 'WP:TW/PREF#tag');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#tag');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.tag.callback.evaluate);
 
 	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
 	let isPatroller = mw.config.get('wgUserGroups').some(r => ['patroller', 'sysop'].includes(r));
@@ -56,14 +56,14 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			// Figure out whether the article is marked as reviewed in PageTriage.
 			// Recent articles will have a patrol_status that we can read.
 			// For articles that have been out of the new pages feed for awhile, pages[0] will be undefined.
-			var isReviewed = response.pagetriagelist.pages[0] ?
+			let isReviewed = response.pagetriagelist.pages[0] ?
 				response.pagetriagelist.pages[0].patrol_status > 0 :
 				true;
 
 			// if article is not marked as reviewed, show the "mark as reviewed" check box
 			if (!isReviewed) {
 				// Quickform is probably already rendered. Instead of using form.append(), we need to make an element and then append it using JQuery.
-				var checkbox = new Morebits.quickForm.element({
+				let checkbox = new Morebits.quickForm.element({
 					type: 'checkbox',
 					list: [
 						{
@@ -74,7 +74,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 						}
 					]
 				});
-				var html = checkbox.render();
+				let html = checkbox.render();
 				$('.quickform').prepend(html);
 			}
 		});
@@ -88,7 +88,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		event: function twinkletagquickfilter() {
 			// flush the DOM of all existing underline spans
 			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
-				var label_element = e.parentElement;
+				let label_element = e.parentElement;
 				// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
 				// to <label>Hello world</label>
 				label_element.innerHTML = label_element.textContent;
@@ -97,19 +97,19 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			if (this.value) {
 				$allCheckboxDivs.hide();
 				$allHeaders.hide();
-				var searchString = this.value;
-				var searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
+				let searchString = this.value;
+				let searchRegex = new RegExp(mw.util.escapeRegExp(searchString), 'i');
 
 				$allCheckboxDivs.find('label').each(function () {
-					var label_text = this.textContent;
-					var searchHit = searchRegex.exec(label_text);
+					let label_text = this.textContent;
+					let searchHit = searchRegex.exec(label_text);
 					if (searchHit) {
-						var range = document.createRange();
-						var textnode = this.childNodes[0];
+						let range = document.createRange();
+						let textnode = this.childNodes[0];
 						range.selectNodeContents(textnode);
 						range.setStart(textnode, searchHit.index);
 						range.setEnd(textnode, searchHit.index + searchString.length);
-						var underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
+						let underline_span = $('<span>').addClass('search-hit').css('text-decoration', 'underline')[0];
 						range.surroundContents(underline_span);
 						this.parentElement.style.display = 'block'; // show
 					}
@@ -155,7 +155,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 
 			if (!Twinkle.tag.canRemove) {
-				var divElement = document.createElement('div');
+				let divElement = document.createElement('div');
 				divElement.innerHTML = 'For removal of existing tags, please open Tag menu from the current version of article';
 				form.append({
 					type: 'div',
@@ -216,7 +216,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 				if (typeof item.restriction === 'undefined') {
 					return false;
 				}
-				var namespace = mw.config.get('wgNamespaceNumber');
+				let namespace = mw.config.get('wgNamespaceNumber');
 				switch (item.restriction) {
 					case 'insideMainspaceOnly':
 						if (namespace !== 0) {
@@ -249,7 +249,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			var i = 1;
 			$.each(Twinkle.tag.redirectList, function(groupName, group) {
 				form.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
-				var subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
+				let subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
 				$.each(group, function(subgroupName, subgroup) {
 					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
 					subdiv.append({
@@ -279,7 +279,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 	form.append({ type: 'submit', className: 'tw-tag-submit' });
 
-	var result = form.render();
+	let result = form.render();
 	Window.setContent(result);
 	Window.display();
 
@@ -321,14 +321,14 @@ Twinkle.tag.callback = function twinkletagCallback() {
 					if (e.classList[0] === 'box-Multiple_issues') {
 						$(e).find('.ambox').each(function(idx, e) {
 							if (e.classList[0].indexOf('box-') === 0) {
-								var tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
+								let tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 								Twinkle.tag.alreadyPresentTags.push(tag);
 							}
 						});
 						return true; // continue
 					}
 
-					var tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
+					let tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 					Twinkle.tag.alreadyPresentTags.push(tag);
 				}
 			});
@@ -344,7 +344,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		}
 
 		// Add status text node after Submit button
-		var statusNode = document.createElement('small');
+		let statusNode = document.createElement('small');
 		statusNode.id = 'tw-tag-status';
 		Twinkle.tag.status = {
 			// initial state; defined like this because these need to be available for reference
@@ -355,7 +355,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		$('button.tw-tag-submit').after(statusNode);
 
 		// fake a change event on the sort dropdown, to initialize the tag list
-		var evt = document.createEvent('Event');
+		let evt = document.createEvent('Event');
 		evt.initEvent('change', true, true);
 		result.sortorder.dispatchEvent(evt);
 
@@ -368,19 +368,19 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 // $allCheckboxDivs and $allHeaders are defined globally, rather than in the
 // quickfilter event function, to avoid having to recompute them on every keydown
-var $allCheckboxDivs, $allHeaders;
+let $allCheckboxDivs, $allHeaders;
 
 Twinkle.tag.updateSortOrder = function(e) {
-	var form = e.target.form;
-	var sortorder = e.target.value;
+	let form = e.target.form;
+	let sortorder = e.target.value;
 	Twinkle.tag.checkedTags = form.getChecked('tags');
 
-	var container = new Morebits.quickForm.element({ type: 'fragment' });
+	let container = new Morebits.quickForm.element({ type: 'fragment' });
 
 	// function to generate a checkbox, with appropriate subgroup if needed
-	var makeCheckbox = function (item) {
-		var tag = item.tag, description = item.description;
-		var checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
+	let makeCheckbox = function (item) {
+		let tag = item.tag, description = item.description;
+		let checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
 		if (Twinkle.tag.checkedTags.indexOf(tag) !== -1) {
 			checkbox.checked = true;
 		}
@@ -388,13 +388,13 @@ Twinkle.tag.updateSortOrder = function(e) {
 		return checkbox;
 	};
 
-	var makeCheckboxesForAlreadyPresentTags = function() {
+	let makeCheckboxesForAlreadyPresentTags = function() {
 		container.append({ type: 'header', id: 'tagHeader0', label: 'Tags already present' });
-		var subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
-		var checkboxes = [];
-		var unCheckedTags = e.target.form.getUnchecked('existingTags');
+		let subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
+		let checkboxes = [];
+		let unCheckedTags = e.target.form.getUnchecked('existingTags');
 		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
-			var checkbox =
+			let checkbox =
 				{
 					value: tag,
 					label: '{{' + tag + '}}' + (Twinkle.tag.article.flatObject[tag] ? ': ' + Twinkle.tag.article.flatObject[tag].description : ''),
@@ -414,8 +414,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 
 	if (sortorder === 'cat') { // categorical sort order
 		// function to iterate through the tags and create a checkbox for each one
-		var doCategoryCheckboxes = function(subdiv, subgroup) {
-			var checkboxes = [];
+		let doCategoryCheckboxes = function(subdiv, subgroup) {
+			let checkboxes = [];
 			$.each(subgroup, function(k, item) {
 				if (Twinkle.tag.alreadyPresentTags.indexOf(item.tag) === -1) {
 					checkboxes.push(makeCheckbox(item));
@@ -431,11 +431,11 @@ Twinkle.tag.updateSortOrder = function(e) {
 		if (Twinkle.tag.alreadyPresentTags.length > 0) {
 			makeCheckboxesForAlreadyPresentTags();
 		}
-		var i = 1;
+		let i = 1;
 		// go through each category and sub-category and append lists of checkboxes
 		$.each(Twinkle.tag.article.tagList, function(groupName, group) {
 			container.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
-			var subdiv = container.append({ type: 'div', id: 'tagSubdiv' + i++ });
+			let subdiv = container.append({ type: 'div', id: 'tagSubdiv' + i++ });
 			if (Array.isArray(group)) {
 				doCategoryCheckboxes(subdiv, group);
 			} else {
@@ -453,7 +453,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 
 		// Avoid repeatedly resorting
 		Twinkle.tag.article.alphabeticalList = Twinkle.tag.article.alphabeticalList || Object.keys(Twinkle.tag.article.flatObject).sort();
-		var checkboxes = [];
+		let checkboxes = [];
 		Twinkle.tag.article.alphabeticalList.forEach(function(tag) {
 			if (Twinkle.tag.alreadyPresentTags.indexOf(tag) === -1) {
 				checkboxes.push(makeCheckbox(Twinkle.tag.article.flatObject[tag]));
@@ -477,8 +477,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 		});
 	}
 
-	var $workarea = $(form).find('#tagWorkArea');
-	var rendered = container.render();
+	let $workarea = $(form).find('#tagWorkArea');
+	let rendered = container.render();
 	$workarea.empty().append(rendered);
 
 	// for quick filter:
@@ -496,7 +496,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	Morebits.quickForm.getElements(form, 'tags').forEach(generateLinks);
 
 	// tally tags added/removed, update statusNode text
-	var statusNode = document.getElementById('tw-tag-status');
+	let statusNode = document.getElementById('tw-tag-status');
 	$('[name=tags], [name=existingTags]').click(function() {
 		if (this.name === 'tags') {
 			Twinkle.tag.status.numAdded += this.checked ? 1 : -1;
@@ -504,8 +504,8 @@ Twinkle.tag.updateSortOrder = function(e) {
 			Twinkle.tag.status.numRemoved += this.checked ? -1 : 1;
 		}
 
-		var firstPart = 'Adding ' + Twinkle.tag.status.numAdded + ' tag' + (Twinkle.tag.status.numAdded > 1 ? 's' : '');
-		var secondPart = 'Removing ' + Twinkle.tag.status.numRemoved + ' tag' + (Twinkle.tag.status.numRemoved > 1 ? 's' : '');
+		let firstPart = 'Adding ' + Twinkle.tag.status.numAdded + ' tag' + (Twinkle.tag.status.numAdded > 1 ? 's' : '');
+		let secondPart = 'Removing ' + Twinkle.tag.status.numRemoved + ' tag' + (Twinkle.tag.status.numRemoved > 1 ? 's' : '');
 		statusNode.textContent =
 			(Twinkle.tag.status.numAdded ? '  ' + firstPart : '') +
 			(Twinkle.tag.status.numRemoved ? (Twinkle.tag.status.numAdded ? '; ' : '  ') + secondPart : '');
@@ -517,9 +517,9 @@ Twinkle.tag.updateSortOrder = function(e) {
  * @param {Morebits.quickForm.element} checkbox  associated with the template
  */
 var generateLinks = function(checkbox) {
-	var link = Morebits.htmlNode('a', '>');
+	let link = Morebits.htmlNode('a', '>');
 	link.setAttribute('class', 'tag-template-link');
-	var tagname = checkbox.values;
+	let tagname = checkbox.values;
 	link.setAttribute('href', mw.util.getUrl(
 		(tagname.indexOf(':') === -1 ? 'Template:' : '') +
 		(tagname.indexOf('|') === -1 ? tagname : tagname.slice(0, tagname.indexOf('|')))
@@ -533,7 +533,7 @@ var generateLinks = function(checkbox) {
 Twinkle.tag.article = {};
 
 // Shared across {{Rough translation}} and {{Not English}}
-var translationSubgroups = [
+let translationSubgroups = [
 	{
 		name: 'translationLanguage',
 		parameter: '1',
@@ -559,8 +559,8 @@ var translationSubgroups = [
 ] : []);
 
 // Subgroups for {{merge}}, {{merge-to}} and {{merge-from}}
-var getMergeSubgroups = function(tag) {
-	var otherTagName = 'Merge';
+let getMergeSubgroups = function(tag) {
+	let otherTagName = 'Merge';
 	switch (tag) {
 		case 'Merge from':
 			otherTagName = 'Merge to';
@@ -1348,14 +1348,14 @@ Twinkle.tag.callbacks = {
 	article: function articleCallback(pageobj) {
 
 		// Remove tags that become superfluous with this action
-		var pageText = pageobj.getPageText().replace(/\{\{\s*([Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, '');
-		var params = pageobj.getCallbackParameters();
+		let pageText = pageobj.getPageText().replace(/\{\{\s*([Uu]serspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/g, '');
+		let params = pageobj.getCallbackParameters();
 
 		/**
 		 * Saves the page following the removal of tags if any. The last step.
 		 * Called from removeTags()
 		 */
-		var postRemoval = function() {
+		let postRemoval = function() {
 			if (params.tagsToRemove.length) {
 				// Remove empty {{multiple issues}} if found
 				pageText = pageText.replace(/\{\{(multiple ?issues|article ?issues|mi)\s*\|\s*\}\}\n?/im, '');
@@ -1364,15 +1364,15 @@ Twinkle.tag.callbacks = {
 			}
 
 			// Build edit summary
-			var makeSentence = function(array) {
+			let makeSentence = function(array) {
 				if (array.length < 3) {
 					return array.join(' and ');
 				}
-				var last = array.pop();
+				let last = array.pop();
 				return array.join(', ') + ', and ' + last;
 			};
-			var makeTemplateLink = function(tag) {
-				var text = '{{[[';
+			let makeTemplateLink = function(tag) {
+				let text = '{{[[';
 				// if it is a custom tag with a parameter
 				if (tag.indexOf('|') !== -1) {
 					tag = tag.slice(0, tag.indexOf('|'));
@@ -1381,9 +1381,9 @@ Twinkle.tag.callbacks = {
 				return text + ']]}}';
 			};
 
-			var summaryText;
-			var addedTags = params.tags.map(makeTemplateLink);
-			var removedTags = params.tagsToRemove.map(makeTemplateLink);
+			let summaryText;
+			let addedTags = params.tags.map(makeTemplateLink);
+			let removedTags = params.tagsToRemove.map(makeTemplateLink);
 			if (addedTags.length) {
 				summaryText = 'Added ' + makeSentence(addedTags);
 				summaryText += removedTags.length ? '; and removed ' + makeSentence(removedTags) : '';
@@ -1410,7 +1410,7 @@ Twinkle.tag.callbacks = {
 			pageobj.save(function() {
 				// COI: Start the discussion on the talk page (mainspace only)
 				if (params.coiReason) {
-					var coiTalkPage = new Morebits.wiki.page('Talk:' + Morebits.pageNameNorm, 'Starting discussion on talk page');
+					let coiTalkPage = new Morebits.wiki.page('Talk:' + Morebits.pageNameNorm, 'Starting discussion on talk page');
 					coiTalkPage.setNewSectionText(params.coiReason + ' ~~~~');
 					coiTalkPage.setNewSectionTitle('COI tag (' + new Morebits.date(pageobj.getLoadTime()).format('MMMM Y', 'utc') + ')');
 					coiTalkPage.setChangeTags(Twinkle.changeTags);
@@ -1421,7 +1421,7 @@ Twinkle.tag.callbacks = {
 				// Special functions for merge tags
 				// Post a rationale on the talk page (mainspace only)
 				if (params.mergeReason) {
-					var mergeTalkPage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
+					let mergeTalkPage = new Morebits.wiki.page('Talk:' + params.discussArticle, 'Posting rationale on talk page');
 					mergeTalkPage.setNewSectionText(params.mergeReason.trim() + ' ~~~~');
 					mergeTalkPage.setNewSectionTitle(params.talkDiscussionTitleLinked);
 					mergeTalkPage.setChangeTags(Twinkle.changeTags);
@@ -1431,13 +1431,13 @@ Twinkle.tag.callbacks = {
 				}
 				// Tag the target page (if requested)
 				if (params.mergeTagOther) {
-					var otherTagName = 'Merge';
+					let otherTagName = 'Merge';
 					if (params.mergeTag === 'Merge from') {
 						otherTagName = 'Merge to';
 					} else if (params.mergeTag === 'Merge to') {
 						otherTagName = 'Merge from';
 					}
-					var newParams = {
+					let newParams = {
 						tags: [otherTagName],
 						tagsToRemove: [],
 						tagsToRemain: [],
@@ -1446,7 +1446,7 @@ Twinkle.tag.callbacks = {
 						talkDiscussionTitle: params.talkDiscussionTitle,
 						talkDiscussionTitleLinked: params.talkDiscussionTitleLinked
 					};
-					var otherpage = new Morebits.wiki.page(params.mergeTarget, 'Tagging other page (' +
+					let otherpage = new Morebits.wiki.page(params.mergeTarget, 'Tagging other page (' +
 						params.mergeTarget + ')');
 					otherpage.setChangeTags(Twinkle.changeTags);
 					otherpage.setCallbackParameters(newParams);
@@ -1456,18 +1456,18 @@ Twinkle.tag.callbacks = {
 				// Special functions for {{not English}} and {{rough translation}}
 				// Post at WP:PNT (mainspace only)
 				if (params.translationPostAtPNT) {
-					var pntPage = new Morebits.wiki.page('Wikipedia:Pages needing translation into English',
+					let pntPage = new Morebits.wiki.page('Wikipedia:Pages needing translation into English',
 						'Listing article at Wikipedia:Pages needing translation into English');
 					pntPage.setFollowRedirect(true);
 					pntPage.load(function twinkletagCallbacksTranslationListPage(pageobj) {
-						var old_text = pageobj.getPageText();
+						let old_text = pageobj.getPageText();
 
-						var lang = params.translationLanguage;
-						var reason = params.translationComments;
+						let lang = params.translationLanguage;
+						let reason = params.translationComments;
 
-						var templateText;
+						let templateText;
 
-						var text, summary;
+						let text, summary;
 						if (params.tags.indexOf('Rough translation') !== -1) {
 							templateText = '{{subst:Dual fluency request|pg=' + Morebits.pageNameNorm + '|Language=' +
 							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
@@ -1497,7 +1497,7 @@ Twinkle.tag.callbacks = {
 				// Notify the user ({{Not English}} only)
 				if (params.translationNotify) {
 					new Morebits.wiki.page(Morebits.pageNameNorm).lookupCreation(function(innerPageobj) {
-						var initialContrib = innerPageobj.getCreator();
+						let initialContrib = innerPageobj.getCreator();
 
 						// Disallow warning yourself
 						if (initialContrib === mw.config.get('wgUserName')) {
@@ -1505,7 +1505,7 @@ Twinkle.tag.callbacks = {
 							return;
 						}
 
-						var userTalkPage = new Morebits.wiki.page('User talk:' + initialContrib,
+						let userTalkPage = new Morebits.wiki.page('User talk:' + initialContrib,
 							'Notifying initial contributor (' + initialContrib + ')');
 						userTalkPage.setNewSectionTitle('Your article [[' + Morebits.pageNameNorm + ']]');
 						userTalkPage.setNewSectionText('{{subst:uw-notenglish|1=' + Morebits.pageNameNorm +
@@ -1528,7 +1528,7 @@ Twinkle.tag.callbacks = {
 		 * Removes the existing tags that were deselected (if any)
 		 * Calls postRemoval() when done
 		 */
-		var removeTags = function removeTags() {
+		let removeTags = function removeTags() {
 
 			if (params.tagsToRemove.length === 0) {
 				postRemoval();
@@ -1537,13 +1537,13 @@ Twinkle.tag.callbacks = {
 
 			Morebits.status.info('Info', 'Removing deselected tags that were already present');
 
-			var getRedirectsFor = [];
+			let getRedirectsFor = [];
 
 			// Remove the tags from the page text, if found in its proper name,
 			// otherwise moves it to `getRedirectsFor` array earmarking it for
 			// later removal
 			params.tagsToRemove.forEach(function removeTag(tag) {
-				var tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?');
+				let tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?');
 
 				if (tag_re.test(pageText)) {
 					pageText = pageText.replace(tag_re, '');
@@ -1558,7 +1558,7 @@ Twinkle.tag.callbacks = {
 			}
 
 			// Remove tags which appear in page text as redirects
-			var api = new Morebits.wiki.api('Getting template redirects', {
+			let api = new Morebits.wiki.api('Getting template redirects', {
 				action: 'query',
 				prop: 'linkshere',
 				titles: getRedirectsFor.join('|'),
@@ -1568,14 +1568,14 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function removeRedirectTag(apiobj) {
-				var pages = apiobj.getResponse().query.pages.filter(function(p) {
+				let pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;
 				});
 				pages.forEach(function(page) {
-					var removed = false;
+					let removed = false;
 					page.linkshere.concat({title: page.title}).forEach(function(el) {
-						var tag = el.title.slice(9);
-						var tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
+						let tag = el.title.slice(9);
+						let tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
 						if (tag_re.test(pageText)) {
 							pageText = pageText.replace(tag_re, '');
 							removed = true;
@@ -1601,7 +1601,7 @@ Twinkle.tag.callbacks = {
 			return;
 		}
 
-		var tagRe, tagText = '', tags = [], groupableTags = [], groupableExistingTags = [];
+		let tagRe, tagText = '', tags = [], groupableTags = [], groupableExistingTags = [];
 		// Executes first: addition of selected tags
 
 		/**
@@ -1609,18 +1609,18 @@ Twinkle.tag.callbacks = {
 		 * @param {number} tagIndex
 		 * @param {string} tagName
 		 */
-		var addTag = function articleAddTag(tagIndex, tagName) {
-			var currentTag = '';
+		let addTag = function articleAddTag(tagIndex, tagName) {
+			let currentTag = '';
 			if (tagName === 'Uncategorized' || tagName === 'Improve categories') {
 				pageText += '\n\n{{' + tagName + '|date={{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}}}';
 			} else {
 				currentTag += '{{' + tagName;
 				// fill in other parameters, based on the tag
 
-				var subgroupObj = Twinkle.tag.article.flatObject[tagName] &&
+				let subgroupObj = Twinkle.tag.article.flatObject[tagName] &&
 					Twinkle.tag.article.flatObject[tagName].subgroup;
 				if (subgroupObj) {
-					var subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
+					let subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
 					subgroups.forEach(function(gr) {
 						if (gr.parameter && (params[gr.name] || gr.required)) {
 							currentTag += '|' + gr.parameter + '=' + (params[gr.name] || '');
@@ -1651,11 +1651,11 @@ Twinkle.tag.callbacks = {
 								params.discussArticle = tagName === 'Merge to' ? params.mergeTarget : mw.config.get('wgTitle');
 								// nonDiscussArticle is the article which won't have the discussion
 								params.nonDiscussArticle = tagName === 'Merge to' ? mw.config.get('wgTitle') : params.mergeTarget;
-								var direction = '[[' + params.nonDiscussArticle + ']]' + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + '[[' + params.discussArticle + ']]';
+								let direction = '[[' + params.nonDiscussArticle + ']]' + (params.mergeTag === 'Merge' ? ' with ' : ' into ') + '[[' + params.discussArticle + ']]';
 								params.talkDiscussionTitleLinked = 'Proposed merge of ' + direction;
 								params.talkDiscussionTitle = params.talkDiscussionTitleLinked.replace(/\[\[(.*?)\]\]/g, '$1');
 							}
-							var titleWithSectionRemoved = params.discussArticle.replace(/^([^#]*)#.*$/, '$1'); // If article name is Test#Section, delete #Section
+							let titleWithSectionRemoved = params.discussArticle.replace(/^([^#]*)#.*$/, '$1'); // If article name is Test#Section, delete #Section
 							currentTag += '|discuss=Talk:' + titleWithSectionRemoved + '#' + params.talkDiscussionTitle;
 						}
 						break;
@@ -1673,13 +1673,13 @@ Twinkle.tag.callbacks = {
 		 * these tags aren't supported in {{multiple issues}} or because
 		 * {{multiple issues}} is not being added to the page at all
 		 */
-		var addUngroupedTags = function() {
+		let addUngroupedTags = function() {
 			$.each(tags, addTag);
 
 			// Insert tag after short description or any hatnotes,
 			// as well as deletion/protection-related templates
-			var wikipage = new Morebits.wikitext.page(pageText);
-			var templatesAfter = Twinkle.hatnoteRegex +
+			let wikipage = new Morebits.wikitext.page(pageText);
+			let templatesAfter = Twinkle.hatnoteRegex +
 				// Protection templates
 				'pp|pp-.*?|' +
 				// CSD
@@ -1690,7 +1690,7 @@ Twinkle.tag.callbacks = {
 				'salt|proposed deletion endorsed';
 			// AfD is special, as the tag includes html comments before and after the actual template
 			// trailing whitespace/newline needed since this subst's a newline
-			var afdRegex = '(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?';
+			let afdRegex = '(?:<!--.*AfD.*\\n\\{\\{(?:Article for deletion\\/dated|AfDM).*\\}\\}\\n<!--.*(?:\\n<!--.*)?AfD.*(?:\\s*\\n))?';
 			pageText = wikipage.insertAfterTemplates(tagText, templatesAfter, null, afdRegex).getText();
 
 			removeTags();
@@ -1730,7 +1730,7 @@ Twinkle.tag.callbacks = {
 			}
 		});
 
-		var miTest = /\{\{(multiple ?issues|article ?issues|mi)(?!\s*\|\s*section\s*=)[^}]+\{/im.exec(pageText);
+		let miTest = /\{\{(multiple ?issues|article ?issues|mi)(?!\s*\|\s*section\s*=)[^}]+\{/im.exec(pageText);
 
 		if (miTest && groupableTags.length > 0) {
 			Morebits.status.info('Info', 'Adding supported tags inside existing {{multiple issues}} tag');
@@ -1738,7 +1738,7 @@ Twinkle.tag.callbacks = {
 			tagText = '';
 			$.each(groupableTags, addTag);
 
-			var miRegex = new RegExp('(\\{\\{\\s*' + miTest[1] + '\\s*(?:\\|(?:\\{\\{[^{}]*\\}\\}|[^{}])*)?)\\}\\}\\s*', 'im');
+			let miRegex = new RegExp('(\\{\\{\\s*' + miTest[1] + '\\s*(?:\\|(?:\\{\\{[^{}]*\\}\\}|[^{}])*)?)\\}\\}\\s*', 'im');
 			pageText = pageText.replace(miRegex, '$1' + tagText + '}}\n');
 			tagText = '';
 
@@ -1752,7 +1752,7 @@ Twinkle.tag.callbacks = {
 			/**
 			 * Adds newly added tags to MI
 			 */
-			var addNewTagsToMI = function() {
+			let addNewTagsToMI = function() {
 				$.each(groupableTags, addTag);
 				tagText += '}}\n';
 
@@ -1760,12 +1760,12 @@ Twinkle.tag.callbacks = {
 			};
 
 
-			var getRedirectsFor = [];
+			let getRedirectsFor = [];
 
 			// Reposition the tags on the page into {{multiple issues}}, if found with its
 			// proper name, else moves it to `getRedirectsFor` array to be handled later
 			groupableExistingTags.forEach(function repositionTagIntoMI(tag) {
-				var tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?)');
+				let tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?)');
 				if (tag_re.test(pageText)) {
 					tagText += tag_re.exec(pageText)[1];
 					pageText = pageText.replace(tag_re, '');
@@ -1779,7 +1779,7 @@ Twinkle.tag.callbacks = {
 				return;
 			}
 
-			var api = new Morebits.wiki.api('Getting template redirects', {
+			let api = new Morebits.wiki.api('Getting template redirects', {
 				action: 'query',
 				prop: 'linkshere',
 				titles: getRedirectsFor.join('|'),
@@ -1789,14 +1789,14 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, function replaceRedirectTag(apiobj) {
-				var pages = apiobj.getResponse().query.pages.filter(function(p) {
+				let pages = apiobj.getResponse().query.pages.filter(function(p) {
 					return !p.missing && !!p.linkshere;
 				});
 				pages.forEach(function(page) {
-					var found = false;
+					let found = false;
 					page.linkshere.forEach(function(el) {
-						var tag = el.title.slice(9);
-						var tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
+						let tag = el.title.slice(9);
+						let tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
 						if (tag_re.test(pageText)) {
 							tagText += tag_re.exec(pageText)[1];
 							pageText = pageText.replace(tag_re, '');
@@ -1820,7 +1820,7 @@ Twinkle.tag.callbacks = {
 	},
 
 	redirect: function redirect(pageobj) {
-		var params = pageobj.getCallbackParameters(),
+		let params = pageobj.getCallbackParameters(),
 			pageText = pageobj.getPageText(),
 			tagRe, tagText = '', summaryText = 'Added',
 			tags = [], i;
@@ -1835,7 +1835,7 @@ Twinkle.tag.callbacks = {
 			}
 		}
 
-		var addTag = function redirectAddTag(tagIndex, tagName) {
+		let addTag = function redirectAddTag(tagIndex, tagName) {
 			tagText += '\n{{' + tagName;
 			if (tagName === 'R from alternative language') {
 				if (params.altLangFrom) {
@@ -1870,15 +1870,15 @@ Twinkle.tag.callbacks = {
 		// Check for all Rcat shell redirects (from #433)
 		if (pageText.match(/{{(?:redr|this is a redirect|r(?:edirect)?(?:.?cat.*)?[ _]?sh)/i)) {
 			// Regex inspired by [[User:Kephir/gadgets/sagittarius.js]] ([[Special:PermaLink/831402893]])
-			var oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]|{{[^}]+}})+)(}})\s*/i);
+			let oldTags = pageText.match(/(\s*{{[A-Za-z\s]+\|(?:\s*1=)?)((?:[^|{}]|{{[^}]+}})+)(}})\s*/i);
 			pageText = pageText.replace(oldTags[0], oldTags[1] + tagText + oldTags[2] + oldTags[3]);
 		} else {
 			// Fold any pre-existing Rcats into taglist and under Rcatshell
-			var pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
-			var oldPageTags = '';
+			let pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
+			let oldPageTags = '';
 			if (pageTags) {
 				pageTags.forEach(function(pageTag) {
-					var pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
+					let pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
 					pageText = pageText.replace(pageRe, '');
 					pageTag = pageTag.trim();
 					oldPageTags += '\n' + pageTag;
@@ -1910,14 +1910,14 @@ Twinkle.tag.callbacks = {
 	},
 
 	file: function twinkletagCallbacksFile(pageobj) {
-		var text = pageobj.getPageText();
-		var params = pageobj.getCallbackParameters();
-		var summary = 'Adding ';
+		let text = pageobj.getPageText();
+		let params = pageobj.getCallbackParameters();
+		let summary = 'Adding ';
 
 		// Add maintenance tags
 		if (params.tags.length) {
 
-			var tagtext = '', currentTag;
+			let tagtext = '', currentTag;
 			$.each(params.tags, function(k, tag) {
 				// when other commons-related tags are placed, remove "move to Commons" tag
 				if (['Keep local', 'Now Commons', 'Do not move to Commons'].indexOf(tag) !== -1) {
@@ -2029,19 +2029,19 @@ Twinkle.tag.callbacks = {
 };
 
 Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
-	var form = e.target;
-	var params = Morebits.quickForm.getInputData(form);
+	let form = e.target;
+	let params = Morebits.quickForm.getInputData(form);
 
 
 	// Validation
 
 	// Given an array of incompatible tags, check if we have two or more selected
-	var checkIncompatible = function(conflicts, extra) {
-		var count = conflicts.reduce(function(sum, tag) {
+	let checkIncompatible = function(conflicts, extra) {
+		let count = conflicts.reduce(function(sum, tag) {
 			return sum += params.tags.indexOf(tag) !== -1;
 		}, 0);
 		if (count > 1) {
-			var message = 'Please select only one of: {{' + conflicts.join('}}, {{') + '}}.';
+			let message = 'Please select only one of: {{' + conflicts.join('}}, {{') + '}}.';
 			message += extra ? ' ' + extra : '';
 			alert(message);
 			return true;
@@ -2092,7 +2092,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 			// Get extension from either mime-type or title, if not present (e.g., SVGs)
 			var extension = ((extension = $('.mime-type').text()) && extension.split(/\//)[1]) || mw.Title.newFromText(Morebits.pageNameNorm).getExtension();
 			if (extension) {
-				var extensionUpper = extension.toUpperCase();
+				let extensionUpper = extension.toUpperCase();
 
 				// What self-respecting file format has *two* extensions?!
 				if (extensionUpper === 'JPG') {
@@ -2195,7 +2195,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 		Morebits.wiki.actionCompleted.followRedirect = false;
 	}
 
-	var wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + Twinkle.tag.mode);
+	let wikipedia_page = new Morebits.wiki.page(Morebits.pageNameNorm, 'Tagging ' + Twinkle.tag.mode);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 	wikipedia_page.load(Twinkle.tag.callbacks[Twinkle.tag.mode]);

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -52,7 +52,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			action: 'pagetriagelist',
 			format: 'json',
 			page_id: mw.config.get('wgArticleId')
-		}).then(function(response) {
+		}).then((response) => {
 			// Figure out whether the article is marked as reviewed in PageTriage.
 			// Recent articles will have a patrol_status that we can read.
 			// For articles that have been out of the new pages feed for awhile, pages[0] will be undefined.
@@ -87,7 +87,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		size: '30',
 		event: function twinkletagquickfilter() {
 			// flush the DOM of all existing underline spans
-			$allCheckboxDivs.find('.search-hit').each(function(i, e) {
+			$allCheckboxDivs.find('.search-hit').each((i, e) => {
 				const label_element = e.parentElement;
 				// This would convert <label>Hello <span class=search-hit>wo</span>rld</label>
 				// to <label>Hello world</label>
@@ -128,10 +128,10 @@ Twinkle.tag.callback = function twinkletagCallback() {
 			// Build sorting and lookup object flatObject, which is always
 			// needed but also used to generate the alphabetical list
 			Twinkle.tag.article.flatObject = {};
-			Object.values(Twinkle.tag.article.tagList).forEach(function (group) {
-				Object.values(group).forEach(function (subgroup) {
+			Object.values(Twinkle.tag.article.tagList).forEach((group) => {
+				Object.values(group).forEach((subgroup) => {
 					if (Array.isArray(subgroup)) {
-						subgroup.forEach(function (item) {
+						subgroup.forEach((item) => {
 							Twinkle.tag.article.flatObject[item.tag] = item;
 						});
 					} else {
@@ -197,7 +197,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 		case 'file':
 			Window.setTitle('File maintenance tagging');
 
-			$.each(Twinkle.tag.fileList, function(groupName, group) {
+			$.each(Twinkle.tag.fileList, (groupName, group) => {
 				form.append({ type: 'header', label: groupName });
 				form.append({ type: 'checkbox', name: 'tags', list: group });
 			});
@@ -247,19 +247,19 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 			// Generate the HTML form with the list of redirect tags that the user can choose to apply.
 			var i = 1;
-			$.each(Twinkle.tag.redirectList, function(groupName, group) {
+			$.each(Twinkle.tag.redirectList, (groupName, group) => {
 				form.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
 				const subdiv = form.append({ type: 'div', id: 'tagSubdiv' + i++ });
-				$.each(group, function(subgroupName, subgroup) {
+				$.each(group, (subgroupName, subgroup) => {
 					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
 					subdiv.append({
 						type: 'checkbox',
 						name: 'tags',
 						list: subgroup
-							.filter(function(item) {
+							.filter((item) => {
 								return !isRestricted(item);
 							})
-							.map(function (item) {
+							.map((item) => {
 								return { value: item.tag, label: '{{' + item.tag + '}}: ' + item.description, subgroup: item.subgroup };
 							})
 					});
@@ -288,7 +288,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 	$allHeaders = $(result).find('h5, .quickformDescription');
 	result.quickfilter.focus();  // place cursor in the quick filter field as soon as window is opened
 	result.quickfilter.autocomplete = 'off'; // disable browser suggestions
-	result.quickfilter.addEventListener('keypress', function(e) {
+	result.quickfilter.addEventListener('keypress', (e) => {
 		if (e.keyCode === 13) { // prevent enter key from accidentally submitting the form
 			e.preventDefault();
 			return false;
@@ -304,7 +304,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 
 			// All tags are HTML table elements that are direct children of .mw-parser-output,
 			// except when they are within {{multiple issues}}
-			$('.mw-parser-output').children().each(function parsehtml(i, e) {
+			$('.mw-parser-output').children().each((i, e) => {
 
 				// break out on encountering the first heading, which means we are no
 				// longer in the lead section
@@ -319,7 +319,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 				// All tags have their first class name as "box-" + template name
 				if (e.className.indexOf('box-') === 0) {
 					if (e.classList[0] === 'box-Multiple_issues') {
-						$(e).find('.ambox').each(function(idx, e) {
+						$(e).find('.ambox').each((idx, e) => {
 							if (e.classList[0].indexOf('box-') === 0) {
 								const tag = e.classList[0].slice('box-'.length).replace(/_/g, ' ');
 								Twinkle.tag.alreadyPresentTags.push(tag);
@@ -393,7 +393,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		const subdiv = container.append({ type: 'div', id: 'tagSubdiv0' });
 		const checkboxes = [];
 		const unCheckedTags = e.target.form.getUnchecked('existingTags');
-		Twinkle.tag.alreadyPresentTags.forEach(function(tag) {
+		Twinkle.tag.alreadyPresentTags.forEach((tag) => {
 			const checkbox =
 				{
 					value: tag,
@@ -416,7 +416,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		// function to iterate through the tags and create a checkbox for each one
 		const doCategoryCheckboxes = function(subdiv, subgroup) {
 			const checkboxes = [];
-			$.each(subgroup, function(k, item) {
+			$.each(subgroup, (k, item) => {
 				if (Twinkle.tag.alreadyPresentTags.indexOf(item.tag) === -1) {
 					checkboxes.push(makeCheckbox(item));
 				}
@@ -433,13 +433,13 @@ Twinkle.tag.updateSortOrder = function(e) {
 		}
 		let i = 1;
 		// go through each category and sub-category and append lists of checkboxes
-		$.each(Twinkle.tag.article.tagList, function(groupName, group) {
+		$.each(Twinkle.tag.article.tagList, (groupName, group) => {
 			container.append({ type: 'header', id: 'tagHeader' + i, label: groupName });
 			const subdiv = container.append({ type: 'div', id: 'tagSubdiv' + i++ });
 			if (Array.isArray(group)) {
 				doCategoryCheckboxes(subdiv, group);
 			} else {
-				$.each(group, function(subgroupName, subgroup) {
+				$.each(group, (subgroupName, subgroup) => {
 					subdiv.append({ type: 'div', label: [ Morebits.htmlNode('b', subgroupName) ] });
 					doCategoryCheckboxes(subdiv, subgroup);
 				});
@@ -454,7 +454,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		// Avoid repeatedly resorting
 		Twinkle.tag.article.alphabeticalList = Twinkle.tag.article.alphabeticalList || Object.keys(Twinkle.tag.article.flatObject).sort();
 		const checkboxes = [];
-		Twinkle.tag.article.alphabeticalList.forEach(function(tag) {
+		Twinkle.tag.article.alphabeticalList.forEach((tag) => {
 			if (Twinkle.tag.alreadyPresentTags.indexOf(tag) === -1) {
 				checkboxes.push(makeCheckbox(Twinkle.tag.article.flatObject[tag]));
 			}
@@ -470,7 +470,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	if (Twinkle.getPref('customTagList').length) {
 		container.append({ type: 'header', label: 'Custom tags' });
 		container.append({ type: 'checkbox', name: 'tags',
-			list: Twinkle.getPref('customTagList').map(function(el) {
+			list: Twinkle.getPref('customTagList').map((el) => {
 				el.checked = Twinkle.tag.checkedTags.indexOf(el.value) !== -1;
 				return el;
 			})
@@ -1333,7 +1333,7 @@ Twinkle.tag.fileList = {
 		{ label: '{{Vector version available}}', value: 'Vector version available' }
 	]
 };
-Twinkle.tag.fileList['Replacement tags'].forEach(function(el) {
+Twinkle.tag.fileList['Replacement tags'].forEach((el) => {
 	el.subgroup = {
 		type: 'input',
 		label: 'Replacement file:',
@@ -1407,7 +1407,7 @@ Twinkle.tag.callbacks = {
 			}
 			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
 			pageobj.setCreateOption('nocreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				// COI: Start the discussion on the talk page (mainspace only)
 				if (params.coiReason) {
 					const coiTalkPage = new Morebits.wiki.page('Talk:' + Morebits.pageNameNorm, 'Starting discussion on talk page');
@@ -1459,7 +1459,7 @@ Twinkle.tag.callbacks = {
 					const pntPage = new Morebits.wiki.page('Wikipedia:Pages needing translation into English',
 						'Listing article at Wikipedia:Pages needing translation into English');
 					pntPage.setFollowRedirect(true);
-					pntPage.load(function twinkletagCallbacksTranslationListPage(pageobj) {
+					pntPage.load((pageobj) => {
 						const old_text = pageobj.getPageText();
 
 						const lang = params.translationLanguage;
@@ -1496,7 +1496,7 @@ Twinkle.tag.callbacks = {
 				}
 				// Notify the user ({{Not English}} only)
 				if (params.translationNotify) {
-					new Morebits.wiki.page(Morebits.pageNameNorm).lookupCreation(function(innerPageobj) {
+					new Morebits.wiki.page(Morebits.pageNameNorm).lookupCreation((innerPageobj) => {
 						const initialContrib = innerPageobj.getCreator();
 
 						// Disallow warning yourself
@@ -1542,7 +1542,7 @@ Twinkle.tag.callbacks = {
 			// Remove the tags from the page text, if found in its proper name,
 			// otherwise moves it to `getRedirectsFor` array earmarking it for
 			// later removal
-			params.tagsToRemove.forEach(function removeTag(tag) {
+			params.tagsToRemove.forEach((tag) => {
 				const tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?');
 
 				if (tag_re.test(pageText)) {
@@ -1567,13 +1567,13 @@ Twinkle.tag.callbacks = {
 				lhshow: 'redirect',
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
-			}, function removeRedirectTag(apiobj) {
-				const pages = apiobj.getResponse().query.pages.filter(function(p) {
+			}, ((apiobj) => {
+				const pages = apiobj.getResponse().query.pages.filter((p) => {
 					return !p.missing && !!p.linkshere;
 				});
-				pages.forEach(function(page) {
+				pages.forEach((page) => {
 					let removed = false;
-					page.linkshere.concat({title: page.title}).forEach(function(el) {
+					page.linkshere.concat({title: page.title}).forEach((el) => {
 						const tag = el.title.slice(9);
 						const tag_re = new RegExp('\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?');
 						if (tag_re.test(pageText)) {
@@ -1591,7 +1591,7 @@ Twinkle.tag.callbacks = {
 
 				postRemoval();
 
-			});
+			}));
 			api.post();
 
 		};
@@ -1621,7 +1621,7 @@ Twinkle.tag.callbacks = {
 					Twinkle.tag.article.flatObject[tagName].subgroup;
 				if (subgroupObj) {
 					const subgroups = Array.isArray(subgroupObj) ? subgroupObj : [ subgroupObj ];
-					subgroups.forEach(function(gr) {
+					subgroups.forEach((gr) => {
 						if (gr.parameter && (params[gr.name] || gr.required)) {
 							currentTag += '|' + gr.parameter + '=' + (params[gr.name] || '');
 						}
@@ -1697,7 +1697,7 @@ Twinkle.tag.callbacks = {
 		};
 
 		// Separate tags into groupable ones (`groupableTags`) and non-groupable ones (`tags`)
-		params.tags.forEach(function(tag) {
+		params.tags.forEach((tag) => {
 			tagRe = new RegExp('\\{\\{' + tag + '(\\||\\}\\})', 'im');
 			// regex check for preexistence of tag can be skipped if in canRemove mode
 			if (Twinkle.tag.canRemove || !tagRe.exec(pageText)) {
@@ -1723,7 +1723,7 @@ Twinkle.tag.callbacks = {
 		});
 
 		// To-be-retained existing tags that are groupable
-		params.tagsToRemain.forEach(function(tag) {
+		params.tagsToRemain.forEach((tag) => {
 			// If the tag is unknown to us, we consider it non-groupable
 			if (Twinkle.tag.article.flatObject[tag] && !Twinkle.tag.article.flatObject[tag].excludeMI) {
 				groupableExistingTags.push(tag);
@@ -1764,7 +1764,7 @@ Twinkle.tag.callbacks = {
 
 			// Reposition the tags on the page into {{multiple issues}}, if found with its
 			// proper name, else moves it to `getRedirectsFor` array to be handled later
-			groupableExistingTags.forEach(function repositionTagIntoMI(tag) {
+			groupableExistingTags.forEach((tag) => {
 				const tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]+)?\\}\\}\\n?)');
 				if (tag_re.test(pageText)) {
 					tagText += tag_re.exec(pageText)[1];
@@ -1788,13 +1788,13 @@ Twinkle.tag.callbacks = {
 				lhshow: 'redirect',
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
-			}, function replaceRedirectTag(apiobj) {
-				const pages = apiobj.getResponse().query.pages.filter(function(p) {
+			}, ((apiobj) => {
+				const pages = apiobj.getResponse().query.pages.filter((p) => {
 					return !p.missing && !!p.linkshere;
 				});
-				pages.forEach(function(page) {
+				pages.forEach((page) => {
 					let found = false;
-					page.linkshere.forEach(function(el) {
+					page.linkshere.forEach((el) => {
 						const tag = el.title.slice(9);
 						const tag_re = new RegExp('(\\{\\{' + Morebits.pageNameRegex(tag) + '\\s*(\\|[^}]*)?\\}\\}\\n?)');
 						if (tag_re.test(pageText)) {
@@ -1810,7 +1810,7 @@ Twinkle.tag.callbacks = {
 					}
 				});
 				addNewTagsToMI();
-			});
+			}));
 			api.post();
 
 		} else {
@@ -1877,7 +1877,7 @@ Twinkle.tag.callbacks = {
 			const pageTags = pageText.match(/\s*{{R(?:edirect)? .*?}}/img);
 			let oldPageTags = '';
 			if (pageTags) {
-				pageTags.forEach(function(pageTag) {
+				pageTags.forEach((pageTag) => {
 					const pageRe = new RegExp(Morebits.string.escapeRegExp(pageTag), 'img');
 					pageText = pageText.replace(pageRe, '');
 					pageTag = pageTag.trim();
@@ -1918,7 +1918,7 @@ Twinkle.tag.callbacks = {
 		if (params.tags.length) {
 
 			let tagtext = '', currentTag;
-			$.each(params.tags, function(k, tag) {
+			$.each(params.tags, (k, tag) => {
 				// when other commons-related tags are placed, remove "move to Commons" tag
 				if (['Keep local', 'Now Commons', 'Do not move to Commons'].indexOf(tag) !== -1) {
 					text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
@@ -2037,7 +2037,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 
 	// Given an array of incompatible tags, check if we have two or more selected
 	const checkIncompatible = function(conflicts, extra) {
-		const count = conflicts.reduce(function(sum, tag) {
+		const count = conflicts.reduce((sum, tag) => {
 			return sum += params.tags.indexOf(tag) !== -1;
 		}, 0);
 		if (count > 1) {

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -256,12 +256,8 @@ Twinkle.tag.callback = function twinkletagCallback() {
 						type: 'checkbox',
 						name: 'tags',
 						list: subgroup
-							.filter((item) => {
-								return !isRestricted(item);
-							})
-							.map((item) => {
-								return { value: item.tag, label: '{{' + item.tag + '}}: ' + item.description, subgroup: item.subgroup };
-							})
+							.filter((item) => !isRestricted(item))
+							.map((item) => ({ value: item.tag, label: '{{' + item.tag + '}}: ' + item.description, subgroup: item.subgroup }))
 					});
 				});
 			});
@@ -1568,9 +1564,7 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, ((apiobj) => {
-				const pages = apiobj.getResponse().query.pages.filter((p) => {
-					return !p.missing && !!p.linkshere;
-				});
+				const pages = apiobj.getResponse().query.pages.filter((p) => !p.missing && !!p.linkshere);
 				pages.forEach((page) => {
 					let removed = false;
 					page.linkshere.concat({title: page.title}).forEach((el) => {
@@ -1789,9 +1783,7 @@ Twinkle.tag.callbacks = {
 				lhlimit: 'max', // 500 is max for normal users, 5000 for bots and sysops
 				format: 'json'
 			}, ((apiobj) => {
-				const pages = apiobj.getResponse().query.pages.filter((p) => {
-					return !p.missing && !!p.linkshere;
-				});
+				const pages = apiobj.getResponse().query.pages.filter((p) => !p.missing && !!p.linkshere);
 				pages.forEach((page) => {
 					let found = false;
 					page.linkshere.forEach((el) => {
@@ -2037,9 +2029,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 
 	// Given an array of incompatible tags, check if we have two or more selected
 	const checkIncompatible = function(conflicts, extra) {
-		const count = conflicts.reduce((sum, tag) => {
-			return sum += params.tags.indexOf(tag) !== -1;
-		}, 0);
+		const count = conflicts.reduce((sum, tag) => sum += params.tags.indexOf(tag) !== -1, 0);
 		if (count > 1) {
 			let message = 'Please select only one of: {{' + conflicts.join('}}, {{') + '}}.';
 			message += extra ? ' ' + extra : '';

--- a/modules/twinkletalkback.js
+++ b/modules/twinkletalkback.js
@@ -413,7 +413,7 @@ Twinkle.talkback.callbacks = {
 	}
 };
 Twinkle.addInitCallback(Twinkle.talkback, 'talkback');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinkletalkback.js
+++ b/modules/twinkletalkback.js
@@ -24,14 +24,14 @@ Twinkle.talkback.callback = function() {
 		return;
 	}
 
-	var Window = new Morebits.simpleWindow(600, 350);
+	let Window = new Morebits.simpleWindow(600, 350);
 	Window.setTitle('Talkback');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Talkback prefs', 'WP:TW/PREF#talkback');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#talkback');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.talkback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.talkback.evaluate);
 
 	form.append({ type: 'radio', name: 'tbtarget',
 		list: [
@@ -62,7 +62,7 @@ Twinkle.talkback.callback = function() {
 		name: 'work_area'
 	});
 
-	var previewlink = document.createElement('a');
+	let previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.talkback.callbacks.preview(result);  // |result| is defined below
 	});
@@ -79,12 +79,12 @@ Twinkle.talkback.callback = function() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinkletalkback-previewbox').last()[0]);
 
 	// We must init the
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.tbtarget[0].dispatchEvent(evt);
 
 	// Check whether the user has opted out from talkback
-	var query = {
+	let query = {
 		action: 'query',
 		prop: 'extlinks',
 		titles: 'User talk:' + mw.config.get('wgRelevantUserName'),
@@ -92,32 +92,32 @@ Twinkle.talkback.callback = function() {
 		ellimit: '1',
 		format: 'json'
 	};
-	var wpapi = new Morebits.wiki.api('Fetching talkback opt-out status', query, Twinkle.talkback.callback.optoutStatus);
+	let wpapi = new Morebits.wiki.api('Fetching talkback opt-out status', query, Twinkle.talkback.callback.optoutStatus);
 	wpapi.post();
 };
 
 Twinkle.talkback.optout = '';
 
 Twinkle.talkback.callback.optoutStatus = function(apiobj) {
-	var el = apiobj.getResponse().query.pages[0].extlinks;
+	let el = apiobj.getResponse().query.pages[0].extlinks;
 	if (el && el.length) {
 		Twinkle.talkback.optout = mw.config.get('wgRelevantUserName') + ' prefers not to receive talkbacks';
-		var url = el[0].url;
-		var reason = mw.util.getParamValue('reason', url);
+		let url = el[0].url;
+		let reason = mw.util.getParamValue('reason', url);
 		Twinkle.talkback.optout += reason ? ': ' + reason : '.';
 	}
 	$('#twinkle-talkback-optout-message').text(Twinkle.talkback.optout);
 };
 
-var prev_page = '';
-var prev_section = '';
-var prev_message = '';
+let prev_page = '';
+let prev_section = '';
+let prev_message = '';
 
 Twinkle.talkback.changeTarget = function(e) {
-	var value = e.target.values;
-	var root = e.target.form;
+	let value = e.target.values;
+	let root = e.target.form;
 
-	var old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
+	let old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
 
 	if (root.section) {
 		prev_section = root.section.value;
@@ -129,7 +129,7 @@ Twinkle.talkback.changeTarget = function(e) {
 		prev_page = root.page.value;
 	}
 
-	var work_area = new Morebits.quickForm.element({
+	let work_area = new Morebits.quickForm.element({
 		type: 'field',
 		label: 'Talkback information',
 		name: 'work_area'
@@ -306,10 +306,10 @@ Twinkle.talkback.noticeboards = {
 };
 
 Twinkle.talkback.evaluate = function(e) {
-	var input = Morebits.quickForm.getInputData(e.target);
+	let input = Morebits.quickForm.getInputData(e.target);
 
-	var fullUserTalkPageName = new mw.Title(mw.config.get('wgRelevantUserName'), 3).toText();
-	var talkpage = new Morebits.wiki.page(fullUserTalkPageName, 'Adding talkback');
+	let fullUserTalkPageName = new mw.Title(mw.config.get('wgRelevantUserName'), 3).toText();
+	let talkpage = new Morebits.wiki.page(fullUserTalkPageName, 'Adding talkback');
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(e.target);
@@ -354,7 +354,7 @@ Twinkle.talkback.callbacks = {
 		page = page || mw.config.get('wgUserName');
 
 		// Assume no prefix is a username, convert to user talk space
-		var normal = mw.Title.newFromText(page, 3);
+		let normal = mw.Title.newFromText(page, 3);
 		// Normalize erroneous or likely mis-entered items
 		if (normal) {
 			// Only allow talks and WPspace, as well as Template-space for DYK
@@ -367,18 +367,18 @@ Twinkle.talkback.callbacks = {
 	},
 
 	preview: function(form) {
-		var input = Morebits.quickForm.getInputData(form);
+		let input = Morebits.quickForm.getInputData(form);
 
 		if (input.tbtarget === 'talkback' || input.tbtarget === 'see') {
 			input.page = Twinkle.talkback.callbacks.normalizeTalkbackPage(input.page);
 		}
 
-		var noticetext = Twinkle.talkback.callbacks.getNoticeWikitext(input);
+		let noticetext = Twinkle.talkback.callbacks.getNoticeWikitext(input);
 		form.previewer.beginRender(noticetext, 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 	},
 
 	getNoticeWikitext: function(input) {
-		var text;
+		let text;
 
 		switch (input.tbtarget) {
 			case 'notice':

--- a/modules/twinkletalkback.js
+++ b/modules/twinkletalkback.js
@@ -24,14 +24,14 @@ Twinkle.talkback.callback = function() {
 		return;
 	}
 
-	let Window = new Morebits.simpleWindow(600, 350);
+	const Window = new Morebits.simpleWindow(600, 350);
 	Window.setTitle('Talkback');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Talkback prefs', 'WP:TW/PREF#talkback');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#talkback');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.talkback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.talkback.evaluate);
 
 	form.append({ type: 'radio', name: 'tbtarget',
 		list: [
@@ -62,7 +62,7 @@ Twinkle.talkback.callback = function() {
 		name: 'work_area'
 	});
 
-	let previewlink = document.createElement('a');
+	const previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.talkback.callbacks.preview(result);  // |result| is defined below
 	});
@@ -79,12 +79,12 @@ Twinkle.talkback.callback = function() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinkletalkback-previewbox').last()[0]);
 
 	// We must init the
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.tbtarget[0].dispatchEvent(evt);
 
 	// Check whether the user has opted out from talkback
-	let query = {
+	const query = {
 		action: 'query',
 		prop: 'extlinks',
 		titles: 'User talk:' + mw.config.get('wgRelevantUserName'),
@@ -92,18 +92,18 @@ Twinkle.talkback.callback = function() {
 		ellimit: '1',
 		format: 'json'
 	};
-	let wpapi = new Morebits.wiki.api('Fetching talkback opt-out status', query, Twinkle.talkback.callback.optoutStatus);
+	const wpapi = new Morebits.wiki.api('Fetching talkback opt-out status', query, Twinkle.talkback.callback.optoutStatus);
 	wpapi.post();
 };
 
 Twinkle.talkback.optout = '';
 
 Twinkle.talkback.callback.optoutStatus = function(apiobj) {
-	let el = apiobj.getResponse().query.pages[0].extlinks;
+	const el = apiobj.getResponse().query.pages[0].extlinks;
 	if (el && el.length) {
 		Twinkle.talkback.optout = mw.config.get('wgRelevantUserName') + ' prefers not to receive talkbacks';
-		let url = el[0].url;
-		let reason = mw.util.getParamValue('reason', url);
+		const url = el[0].url;
+		const reason = mw.util.getParamValue('reason', url);
 		Twinkle.talkback.optout += reason ? ': ' + reason : '.';
 	}
 	$('#twinkle-talkback-optout-message').text(Twinkle.talkback.optout);
@@ -114,10 +114,10 @@ let prev_section = '';
 let prev_message = '';
 
 Twinkle.talkback.changeTarget = function(e) {
-	let value = e.target.values;
-	let root = e.target.form;
+	const value = e.target.values;
+	const root = e.target.form;
 
-	let old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
+	const old_area = Morebits.quickForm.getElements(root, 'work_area')[0];
 
 	if (root.section) {
 		prev_section = root.section.value;
@@ -306,10 +306,10 @@ Twinkle.talkback.noticeboards = {
 };
 
 Twinkle.talkback.evaluate = function(e) {
-	let input = Morebits.quickForm.getInputData(e.target);
+	const input = Morebits.quickForm.getInputData(e.target);
 
-	let fullUserTalkPageName = new mw.Title(mw.config.get('wgRelevantUserName'), 3).toText();
-	let talkpage = new Morebits.wiki.page(fullUserTalkPageName, 'Adding talkback');
+	const fullUserTalkPageName = new mw.Title(mw.config.get('wgRelevantUserName'), 3).toText();
+	const talkpage = new Morebits.wiki.page(fullUserTalkPageName, 'Adding talkback');
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(e.target);
@@ -367,13 +367,13 @@ Twinkle.talkback.callbacks = {
 	},
 
 	preview: function(form) {
-		let input = Morebits.quickForm.getInputData(form);
+		const input = Morebits.quickForm.getInputData(form);
 
 		if (input.tbtarget === 'talkback' || input.tbtarget === 'see') {
 			input.page = Twinkle.talkback.callbacks.normalizeTalkbackPage(input.page);
 		}
 
-		let noticetext = Twinkle.talkback.callbacks.getNoticeWikitext(input);
+		const noticetext = Twinkle.talkback.callbacks.getNoticeWikitext(input);
 		form.previewer.beginRender(noticetext, 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 	},
 

--- a/modules/twinkletalkback.js
+++ b/modules/twinkletalkback.js
@@ -63,7 +63,7 @@ Twinkle.talkback.callback = function() {
 	});
 
 	const previewlink = document.createElement('a');
-	$(previewlink).click(function() {
+	$(previewlink).click(() => {
 		Twinkle.talkback.callbacks.preview(result);  // |result| is defined below
 	});
 	previewlink.style.cursor = 'pointer';
@@ -179,7 +179,7 @@ Twinkle.talkback.changeTarget = function(e) {
 				}
 			});
 
-			$.each(Twinkle.talkback.noticeboards, function(value, data) {
+			$.each(Twinkle.talkback.noticeboards, (value, data) => {
 				noticeboard.append({
 					type: 'option',
 					label: data.label,

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -23,22 +23,22 @@ Twinkle.unlink = function twinkleunlink() {
 
 // the parameter is used when invoking unlink from admin speedy
 Twinkle.unlink.callback = function(presetReason) {
-	let fileSpace = mw.config.get('wgNamespaceNumber') === 6;
+	const fileSpace = mw.config.get('wgNamespaceNumber') === 6;
 
-	let Window = new Morebits.simpleWindow(600, 440);
+	const Window = new Morebits.simpleWindow(600, 440);
 	Window.setTitle('Unlink backlinks' + (fileSpace ? ' and file usages' : ''));
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Unlink prefs', 'WP:TW/PREF#unlink');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#unlink');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.unlink.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.unlink.callback.evaluate);
 
 	// prepend some documentation: files are commented out, while any
 	// display text is preserved for links (otherwise the link itself is used)
-	let linkTextBefore = Morebits.htmlNode('code', '[[' + (fileSpace ? ':' : '') + Morebits.pageNameNorm + '|link text]]');
-	let linkTextAfter = Morebits.htmlNode('code', 'link text');
-	let linkPlainBefore = Morebits.htmlNode('code', '[[' + Morebits.pageNameNorm + ']]');
+	const linkTextBefore = Morebits.htmlNode('code', '[[' + (fileSpace ? ':' : '') + Morebits.pageNameNorm + '|link text]]');
+	const linkTextAfter = Morebits.htmlNode('code', 'link text');
+	const linkPlainBefore = Morebits.htmlNode('code', '[[' + Morebits.pageNameNorm + ']]');
 	let linkPlainAfter;
 	if (fileSpace) {
 		linkPlainAfter = Morebits.htmlNode('code', '<!-- [[' + Morebits.pageNameNorm + ']] -->');
@@ -66,7 +66,7 @@ Twinkle.unlink.callback = function(presetReason) {
 		size: 60
 	});
 
-	let query = {
+	const query = {
 		action: 'query',
 		list: 'backlinks',
 		bltitle: mw.config.get('wgPageName'),
@@ -83,11 +83,11 @@ Twinkle.unlink.callback = function(presetReason) {
 	} else {
 		query.blfilterredir = 'nonredirects';
 	}
-	let wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.unlink.callbacks.display.backlinks);
+	const wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.unlink.callbacks.display.backlinks);
 	wikipedia_api.params = { form: form, Window: Window, image: fileSpace };
 	wikipedia_api.post();
 
-	let root = document.createElement('div');
+	const root = document.createElement('div');
 	root.style.padding = '15px';  // just so it doesn't look broken
 	Morebits.status.init(root);
 	wikipedia_api.statelem.status('loading...');
@@ -96,8 +96,8 @@ Twinkle.unlink.callback = function(presetReason) {
 };
 
 Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event) {
-	let form = event.target;
-	let input = Morebits.quickForm.getInputData(form);
+	const form = event.target;
+	const input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert('You must specify a reason for unlinking.');
@@ -106,7 +106,7 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 
 	input.backlinks = input.backlinks || [];
 	input.imageusage = input.imageusage || [];
-	let pages = Morebits.array.uniq(input.backlinks.concat(input.imageusage));
+	const pages = Morebits.array.uniq(input.backlinks.concat(input.imageusage));
 	if (!pages.length) {
 		alert('You must select at least one item to unlink.');
 		return;
@@ -115,13 +115,13 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	let unlinker = new Morebits.batchOperation('Unlinking ' + (input.backlinks.length ? 'backlinks' +
+	const unlinker = new Morebits.batchOperation('Unlinking ' + (input.backlinks.length ? 'backlinks' +
 			(input.imageusage.length ? ' and instances of file usage' : '') : 'instances of file usage'));
 	unlinker.setOption('preserveIndividualStatusLines', true);
 	unlinker.setPageList(pages);
-	let params = { reason: input.reason, unlinker: unlinker };
+	const params = { reason: input.reason, unlinker: unlinker };
 	unlinker.run(function(pageName) {
-		let wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking in page "' + pageName + '"');
+		const wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking in page "' + pageName + '"');
 		wikipedia_page.setBotEdit(true);  // unlink considered a floody operation
 		wikipedia_page.setCallbackParameters($.extend({
 			doBacklinks: input.backlinks.indexOf(pageName) !== -1,
@@ -134,12 +134,12 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 Twinkle.unlink.callbacks = {
 	display: {
 		backlinks: function twinkleunlinkCallbackDisplayBacklinks(apiobj) {
-			let response = apiobj.getResponse();
+			const response = apiobj.getResponse();
 			let havecontent = false;
 			let list, namespaces, i;
 
 			if (apiobj.params.image) {
-				let imageusage = response.query.imageusage.sort(Twinkle.sortByNamespace);
+				const imageusage = response.query.imageusage.sort(Twinkle.sortByNamespace);
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
 					// Label made by Twinkle.generateBatchPageLinks
@@ -188,7 +188,7 @@ Twinkle.unlink.callbacks = {
 				}
 			}
 
-			let backlinks = response.query.backlinks.sort(Twinkle.sortByNamespace);
+			const backlinks = response.query.backlinks.sort(Twinkle.sortByNamespace);
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {
@@ -240,7 +240,7 @@ Twinkle.unlink.callbacks = {
 				apiobj.params.form.append({ type: 'submit' });
 			}
 
-			let result = apiobj.params.form.render();
+			const result = apiobj.params.form.render();
 			apiobj.params.Window.setContent(result);
 
 			Morebits.quickForm.getElements(result, 'backlinks').forEach(Twinkle.generateBatchPageLinks);
@@ -250,8 +250,8 @@ Twinkle.unlink.callbacks = {
 	},
 	unlinkBacklinks: function twinkleunlinkCallbackUnlinkBacklinks(pageobj) {
 		let oldtext = pageobj.getPageText();
-		let params = pageobj.getCallbackParameters();
-		let wikiPage = new Morebits.wikitext.page(oldtext);
+		const params = pageobj.getCallbackParameters();
+		const wikiPage = new Morebits.wikitext.page(oldtext);
 
 		let summaryText = '', warningString = false;
 		let text;

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -23,23 +23,23 @@ Twinkle.unlink = function twinkleunlink() {
 
 // the parameter is used when invoking unlink from admin speedy
 Twinkle.unlink.callback = function(presetReason) {
-	var fileSpace = mw.config.get('wgNamespaceNumber') === 6;
+	let fileSpace = mw.config.get('wgNamespaceNumber') === 6;
 
-	var Window = new Morebits.simpleWindow(600, 440);
+	let Window = new Morebits.simpleWindow(600, 440);
 	Window.setTitle('Unlink backlinks' + (fileSpace ? ' and file usages' : ''));
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Unlink prefs', 'WP:TW/PREF#unlink');
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#unlink');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.unlink.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.unlink.callback.evaluate);
 
 	// prepend some documentation: files are commented out, while any
 	// display text is preserved for links (otherwise the link itself is used)
-	var linkTextBefore = Morebits.htmlNode('code', '[[' + (fileSpace ? ':' : '') + Morebits.pageNameNorm + '|link text]]');
-	var linkTextAfter = Morebits.htmlNode('code', 'link text');
-	var linkPlainBefore = Morebits.htmlNode('code', '[[' + Morebits.pageNameNorm + ']]');
-	var linkPlainAfter;
+	let linkTextBefore = Morebits.htmlNode('code', '[[' + (fileSpace ? ':' : '') + Morebits.pageNameNorm + '|link text]]');
+	let linkTextAfter = Morebits.htmlNode('code', 'link text');
+	let linkPlainBefore = Morebits.htmlNode('code', '[[' + Morebits.pageNameNorm + ']]');
+	let linkPlainAfter;
 	if (fileSpace) {
 		linkPlainAfter = Morebits.htmlNode('code', '<!-- [[' + Morebits.pageNameNorm + ']] -->');
 	} else {
@@ -66,7 +66,7 @@ Twinkle.unlink.callback = function(presetReason) {
 		size: 60
 	});
 
-	var query = {
+	let query = {
 		action: 'query',
 		list: 'backlinks',
 		bltitle: mw.config.get('wgPageName'),
@@ -83,11 +83,11 @@ Twinkle.unlink.callback = function(presetReason) {
 	} else {
 		query.blfilterredir = 'nonredirects';
 	}
-	var wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.unlink.callbacks.display.backlinks);
+	let wikipedia_api = new Morebits.wiki.api('Grabbing backlinks', query, Twinkle.unlink.callbacks.display.backlinks);
 	wikipedia_api.params = { form: form, Window: Window, image: fileSpace };
 	wikipedia_api.post();
 
-	var root = document.createElement('div');
+	let root = document.createElement('div');
 	root.style.padding = '15px';  // just so it doesn't look broken
 	Morebits.status.init(root);
 	wikipedia_api.statelem.status('loading...');
@@ -96,8 +96,8 @@ Twinkle.unlink.callback = function(presetReason) {
 };
 
 Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event) {
-	var form = event.target;
-	var input = Morebits.quickForm.getInputData(form);
+	let form = event.target;
+	let input = Morebits.quickForm.getInputData(form);
 
 	if (!input.reason) {
 		alert('You must specify a reason for unlinking.');
@@ -106,7 +106,7 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 
 	input.backlinks = input.backlinks || [];
 	input.imageusage = input.imageusage || [];
-	var pages = Morebits.array.uniq(input.backlinks.concat(input.imageusage));
+	let pages = Morebits.array.uniq(input.backlinks.concat(input.imageusage));
 	if (!pages.length) {
 		alert('You must select at least one item to unlink.');
 		return;
@@ -115,13 +115,13 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	var unlinker = new Morebits.batchOperation('Unlinking ' + (input.backlinks.length ? 'backlinks' +
+	let unlinker = new Morebits.batchOperation('Unlinking ' + (input.backlinks.length ? 'backlinks' +
 			(input.imageusage.length ? ' and instances of file usage' : '') : 'instances of file usage'));
 	unlinker.setOption('preserveIndividualStatusLines', true);
 	unlinker.setPageList(pages);
-	var params = { reason: input.reason, unlinker: unlinker };
+	let params = { reason: input.reason, unlinker: unlinker };
 	unlinker.run(function(pageName) {
-		var wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking in page "' + pageName + '"');
+		let wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking in page "' + pageName + '"');
 		wikipedia_page.setBotEdit(true);  // unlink considered a floody operation
 		wikipedia_page.setCallbackParameters($.extend({
 			doBacklinks: input.backlinks.indexOf(pageName) !== -1,
@@ -134,12 +134,12 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 Twinkle.unlink.callbacks = {
 	display: {
 		backlinks: function twinkleunlinkCallbackDisplayBacklinks(apiobj) {
-			var response = apiobj.getResponse();
-			var havecontent = false;
-			var list, namespaces, i;
+			let response = apiobj.getResponse();
+			let havecontent = false;
+			let list, namespaces, i;
 
 			if (apiobj.params.image) {
-				var imageusage = response.query.imageusage.sort(Twinkle.sortByNamespace);
+				let imageusage = response.query.imageusage.sort(Twinkle.sortByNamespace);
 				list = [];
 				for (i = 0; i < imageusage.length; ++i) {
 					// Label made by Twinkle.generateBatchPageLinks
@@ -188,7 +188,7 @@ Twinkle.unlink.callbacks = {
 				}
 			}
 
-			var backlinks = response.query.backlinks.sort(Twinkle.sortByNamespace);
+			let backlinks = response.query.backlinks.sort(Twinkle.sortByNamespace);
 			if (backlinks.length > 0) {
 				list = [];
 				for (i = 0; i < backlinks.length; ++i) {
@@ -240,7 +240,7 @@ Twinkle.unlink.callbacks = {
 				apiobj.params.form.append({ type: 'submit' });
 			}
 
-			var result = apiobj.params.form.render();
+			let result = apiobj.params.form.render();
 			apiobj.params.Window.setContent(result);
 
 			Morebits.quickForm.getElements(result, 'backlinks').forEach(Twinkle.generateBatchPageLinks);
@@ -249,12 +249,12 @@ Twinkle.unlink.callbacks = {
 		}
 	},
 	unlinkBacklinks: function twinkleunlinkCallbackUnlinkBacklinks(pageobj) {
-		var oldtext = pageobj.getPageText();
-		var params = pageobj.getCallbackParameters();
-		var wikiPage = new Morebits.wikitext.page(oldtext);
+		let oldtext = pageobj.getPageText();
+		let params = pageobj.getCallbackParameters();
+		let wikiPage = new Morebits.wikitext.page(oldtext);
 
-		var summaryText = '', warningString = false;
-		var text;
+		let summaryText = '', warningString = false;
+		let text;
 
 		// remove image usages
 		if (params.doImageusage) {

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -120,7 +120,7 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 	unlinker.setOption('preserveIndividualStatusLines', true);
 	unlinker.setPageList(pages);
 	const params = { reason: input.reason, unlinker: unlinker };
-	unlinker.run(function(pageName) {
+	unlinker.run((pageName) => {
 		const wikipedia_page = new Morebits.wiki.page(pageName, 'Unlinking in page "' + pageName + '"');
 		wikipedia_page.setBotEdit(true);  // unlink considered a floody operation
 		wikipedia_page.setCallbackParameters($.extend({
@@ -150,7 +150,7 @@ Twinkle.unlink.callbacks = {
 				} else {
 					apiobj.params.form.append({ type: 'header', label: 'File usage' });
 					namespaces = [];
-					$.each(Twinkle.getPref('unlinkNamespaces'), function(k, v) {
+					$.each(Twinkle.getPref('unlinkNamespaces'), (k, v) => {
 						namespaces.push(v === '0' ? '(Article)' : mw.config.get('wgFormattedNamespaces')[v]);
 					});
 					apiobj.params.form.append({
@@ -197,7 +197,7 @@ Twinkle.unlink.callbacks = {
 				}
 				apiobj.params.form.append({ type: 'header', label: 'Backlinks' });
 				namespaces = [];
-				$.each(Twinkle.getPref('unlinkNamespaces'), function(k, v) {
+				$.each(Twinkle.getPref('unlinkNamespaces'), (k, v) => {
 					namespaces.push(v === '0' ? '(Article)' : mw.config.get('wgFormattedNamespaces')[v]);
 				});
 				apiobj.params.form.append({

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -296,7 +296,7 @@ Twinkle.unlink.callbacks = {
 };
 
 Twinkle.addInitCallback(Twinkle.unlink, 'unlink');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -30,14 +30,14 @@ Twinkle.warn = function twinklewarn() {
 	// Modify URL of talk page on rollback success pages, makes use of a
 	// custom message box in [[MediaWiki:Rollback-success]]
 	if (mw.config.get('wgAction') === 'rollback') {
-		let $vandalTalkLink = $('#mw-rollback-success').find('.mw-usertoollinks a').first();
+		const $vandalTalkLink = $('#mw-rollback-success').find('.mw-usertoollinks a').first();
 		if ($vandalTalkLink.length) {
 			$vandalTalkLink.css('font-weight', 'bold');
 			$vandalTalkLink.wrapInner($('<span/>').attr('title', 'If appropriate, you can use Twinkle to warn the user about their edits to this page.'));
 
 			// Can't provide vanarticlerevid as only wgCurRevisionId is provided
-			let extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
-			let href = $vandalTalkLink.attr('href');
+			const extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
+			const href = $vandalTalkLink.attr('href');
 			if (href.indexOf('?') === -1) {
 				$vandalTalkLink.attr('href', href + '?' + extraParam);
 			} else {
@@ -66,21 +66,21 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	dialog.addFooterLink('Twinkle help', 'WP:TW/DOC#warn');
 	dialog.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.warn.callback.evaluate);
-	let main_select = form.append({
+	const form = new Morebits.quickForm(Twinkle.warn.callback.evaluate);
+	const main_select = form.append({
 		type: 'field',
 		label: 'Choose type of warning/notice to issue',
 		tooltip: 'First choose a main warning group, then the specific warning to issue.'
 	});
 
-	let main_group = main_select.append({
+	const main_group = main_select.append({
 		type: 'select',
 		name: 'main_group',
 		tooltip: 'You can customize the default selection in your Twinkle preferences',
 		event: Twinkle.warn.callback.change_category
 	});
 
-	let defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
+	const defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
 	main_group.append({ type: 'option', label: 'Auto-select level (1-4)', value: 'autolevel', selected: defaultGroup === 11 });
 	main_group.append({ type: 'option', label: '1: General note', value: 'level1', selected: defaultGroup === 1 });
 	main_group.append({ type: 'option', label: '2: Caution', value: 'level2', selected: defaultGroup === 2 });
@@ -116,10 +116,10 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	});
 
 
-	let more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });
+	const more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });
 	more.append({ type: 'textarea', label: 'Optional message:', name: 'reason', tooltip: 'Perhaps a reason, or that a more detailed notice must be appended' });
 
-	let previewlink = document.createElement('a');
+	const previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.warn.callbacks.preview(result);  // |result| is defined below
 	});
@@ -137,7 +137,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinklewarn-previewbox').last()[0]);
 
 	// Potential notices for staleness and missed reverts
-	let vanrevid = Twinkle.getPrefill('vanarticlerevid');
+	const vanrevid = Twinkle.getPrefill('vanarticlerevid');
 	if (vanrevid) {
 		let message = '';
 		let query = {};
@@ -156,8 +156,8 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 			};
 
 			new Morebits.wiki.api('Checking if you successfully reverted the page', query, function(apiobj) {
-				let rev = apiobj.getResponse().query.pages[0].revisions;
-				let revertUser = rev && rev[1].user;
+				const rev = apiobj.getResponse().query.pages[0].revisions;
+				const revertUser = rev && rev[1].user;
 				if (revertUser && revertUser !== mw.config.get('wgUserName')) {
 					message += ' Someone else reverted the page and may have already warned the user.';
 					$('#twinkle-warn-warning-messages').text('Note:' + message);
@@ -166,8 +166,8 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		}
 
 		// Confirm edit wasn't too old for a warning
-		let checkStale = function(vantimestamp) {
-			let revDate = new Morebits.date(vantimestamp);
+		const checkStale = function(vantimestamp) {
+			const revDate = new Morebits.date(vantimestamp);
 			if (vantimestamp && revDate.isValid()) {
 				if (revDate.add(24, 'hours').isBefore(new Date())) {
 					message += ' This edit was made more than 24 hours ago so a warning may be stale.';
@@ -189,7 +189,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				format: 'json'
 			};
 			new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
-				let rev = apiobj.getResponse().query.pages[0].revisions;
+				const rev = apiobj.getResponse().query.pages[0].revisions;
 				vantimestamp = rev && rev[0].timestamp;
 				checkStale(vantimestamp);
 			}).post();
@@ -198,7 +198,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 
 
 	// We must init the first choice (General Note);
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.main_group.dispatchEvent(evt);
 };
@@ -1361,11 +1361,11 @@ Twinkle.warn.messages = {
  */
 Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyName) {
 	let result;
-	let isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);
+	const isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);
 	if (isNumberedTemplate) {
-		let unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
-		let level = isNumberedTemplate[0];
-		let numberedWarnings = {};
+		const unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
+		const level = isNumberedTemplate[0];
+		const numberedWarnings = {};
 		$.each(templates.levels, function(key, val) {
 			$.extend(numberedWarnings, val);
 		});
@@ -1377,7 +1377,7 @@ Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyNam
 	}
 
 	// Non-level templates can also end in a number. So check this for all templates.
-	let otherWarnings = {};
+	const otherWarnings = {};
 	$.each(templates, function(key, val) {
 		if (key !== 'levels') {
 			$.extend(otherWarnings, val);
@@ -1398,8 +1398,8 @@ Twinkle.warn.prev_reason = null;
 Twinkle.warn.talkpageObj = null;
 
 Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCategory(e) {
-	let value = e.target.value;
-	let sub_group = e.target.root.sub_group;
+	const value = e.target.value;
+	const sub_group = e.target.root.sub_group;
 	sub_group.main_group = value;
 	let old_subvalue = sub_group.value;
 	let old_subvalue_re;
@@ -1418,10 +1418,10 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 
 	let selected = false;
 	// worker function to create the combo box entries
-	let createEntries = function(contents, container, wrapInOptgroup, val = value) {
+	const createEntries = function(contents, container, wrapInOptgroup, val = value) {
 		// level2->2, singlewarn->''; also used to distinguish the
 		// scaled levels from singlenotice, singlewarn, and custom
-		let level = val.replace(/^\D+/g, '');
+		const level = val.replace(/^\D+/g, '');
 		// due to an apparent iOS bug, we have to add an option-group to prevent truncation of text
 		// (search WT:TW archives for "Problem selecting warnings on an iPhone")
 		if (wrapInOptgroup && $.client.profile().platform === 'iphone') {
@@ -1439,10 +1439,10 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (!!level && !itemProperties[val]) {
 				return;
 			}
-			let key = typeof itemKey === 'string' ? itemKey : itemProperties.value;
-			let template = key + level;
+			const key = typeof itemKey === 'string' ? itemKey : itemProperties.value;
+			const template = key + level;
 
-			let elem = new Morebits.quickForm.element({
+			const elem = new Morebits.quickForm.element({
 				type: 'option',
 				label: '{{' + template + '}}: ' + (level ? itemProperties[val].label : itemProperties.label),
 				value: template
@@ -1452,11 +1452,11 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (!selected && old_subvalue && old_subvalue_re.test(template)) {
 				elem.data.selected = selected = true;
 			}
-			let elemRendered = container.appendChild(elem.render());
+			const elemRendered = container.appendChild(elem.render());
 			$(elemRendered).data('messageData', itemProperties);
 		});
 	};
-	let createGroup = function(warnGroup, label, wrapInOptgroup, val) {
+	const createGroup = function(warnGroup, label, wrapInOptgroup, val) {
 		wrapInOptgroup = typeof wrapInOptgroup !== 'undefined' ? wrapInOptgroup : true;
 		let optgroup = new Morebits.quickForm.element({
 			type: 'optgroup',
@@ -1507,15 +1507,15 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		case 'autolevel':
 			// Check user page to determine appropriate level
 			var autolevelProc = function() {
-				let wikitext = Twinkle.warn.talkpageObj.getPageText();
+				const wikitext = Twinkle.warn.talkpageObj.getPageText();
 				// history not needed for autolevel
-				let latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
+				const latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
 				// Pseudo-params with only what's needed to parse the level i.e. no messageData
-				let params = {
+				const params = {
 					sub_group: old_subvalue,
 					article: e.target.root.article.value
 				};
-				let lvl = 'level' + Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[1];
+				const lvl = 'level' + Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[1];
 
 				// Identical to level1, etc. above but explicitly provides the level
 				$.each(Twinkle.warn.messages.levels, function(groupLabel, groupContents) {
@@ -1530,7 +1530,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (Twinkle.warn.talkpageObj) {
 				autolevelProc();
 			} else {
-				let usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
+				const usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
 				usertalk_page.setFollowRedirect(true, false);
 				usertalk_page.load(function(pageobj) {
 					Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
@@ -1539,7 +1539,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 					// Catch and warn if the talkpage can't load,
 					// most likely because it's a cross-namespace redirect
 					// Supersedes the typical $autolevelMessage added in autolevelParseWikitext
-					let $noTalkPageNode = $('<strong/>', {
+					const $noTalkPageNode = $('<strong/>', {
 						text: 'Unable to load user talk page; it might be a cross-namespace redirect.  Autolevel detection will not work.',
 						id: 'twinkle-warn-autolevel-message',
 						css: {color: 'red' }
@@ -1605,11 +1605,11 @@ Twinkle.warn.callback.postCategoryCleanup = function twinklewarnCallbackPostCate
 };
 
 Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSubcategory(e) {
-	let selected_main_group = e.target.form.main_group.value;
-	let selected_template = e.target.form.sub_group.value;
+	const selected_main_group = e.target.form.main_group.value;
+	const selected_template = e.target.form.sub_group.value;
 
 	// If template shouldn't have a linked article, hide the linked article label and text box
-	let hideLinkedPage = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
+	const hideLinkedPage = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
 	if (hideLinkedPage) {
 		e.target.form.article.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.article.parentElement, false);
@@ -1618,7 +1618,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 	}
 
 	// If template shouldn't have an optional message, hide the optional message label and text box
-	let hideReason = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideReason');
+	const hideReason = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideReason');
 	if (hideReason) {
 		e.target.form.reason.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.reason.parentElement, false);
@@ -1628,7 +1628,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 
 	// Tags that don't take a linked article, but something else (often a username).
 	// The value of each tag is the label next to the input field
-	let notLinkedArticle = {
+	const notLinkedArticle = {
 		'uw-agf-sock': 'Optional username of other account (without User:) ',
 		'uw-bite': "Username of 'bitten' user (without User:) ",
 		'uw-socksuspect': 'Username of sock master, if known (without User:) ',
@@ -1636,7 +1636,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 		'uw-aiv': 'Optional username that was reported (without User:) '
 	};
 
-	let hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
+	const hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
 	if (hasLevel) {
 		if (notLinkedArticle[selected_template]) {
 			if (Twinkle.warn.prev_article === null) {
@@ -1707,10 +1707,10 @@ Twinkle.warn.callbacks = {
 		return text + ' ~~~~';
 	},
 	showPreview: function(form, templatename) {
-		let input = Morebits.quickForm.getInputData(form);
+		const input = Morebits.quickForm.getInputData(form);
 		// Provided on autolevel, not otherwise
 		templatename = templatename || input.sub_group;
-		let linkedarticle = input.article;
+		const linkedarticle = input.article;
 		let templatetext;
 
 		templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle,
@@ -1722,28 +1722,28 @@ Twinkle.warn.callbacks = {
 	preview: function(form) {
 		if (form.main_group.value === 'autolevel') {
 			// Always get a new, updated talkpage for autolevel processing
-			let usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
+			const usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
 			usertalk_page.setFollowRedirect(true, false);
 			// Will fail silently if the talk page is a cross-ns redirect,
 			// removal of the preview box handled when loading the menu
 			usertalk_page.load(function(pageobj) {
 				Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
 
-				let wikitext = pageobj.getPageText();
+				const wikitext = pageobj.getPageText();
 				// history not needed for autolevel
-				let latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
-				let params = {
+				const latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
+				const params = {
 					sub_group: form.sub_group.value,
 					article: form.article.value,
 					messageData: $(form.sub_group).find('option[value="' + $(form.sub_group).val() + '"]').data('messageData')
 				};
-				let template = Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[0];
+				const template = Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[0];
 				Twinkle.warn.callbacks.showPreview(form, template);
 
 				// If the templates have diverged, fake a change event
 				// to reload the menu with the updated pageobj
 				if (form.sub_group.value !== template) {
-					let evt = document.createEvent('Event');
+					const evt = document.createEvent('Event');
 					evt.initEvent('change', true, true);
 					form.main_group.dispatchEvent(evt);
 				}
@@ -1760,13 +1760,13 @@ Twinkle.warn.callbacks = {
 	* warning and date; history lists all prior warnings
 	*/
 	dateProcessing: function(wikitext) {
-		let history_re = /<!--\s?Template:([uU]w-.*?)\s?-->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
-		let history = {};
-		let latest = { date: new Morebits.date(0), type: '' };
+		const history_re = /<!--\s?Template:([uU]w-.*?)\s?-->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
+		const history = {};
+		const latest = { date: new Morebits.date(0), type: '' };
 		let current;
 
 		while ((current = history_re.exec(wikitext)) !== null) {
-			let template = current[1], current_date = new Morebits.date(current[2]);
+			const template = current[1], current_date = new Morebits.date(current[2]);
 			if (!(template in history) || history[template].isBefore(current_date)) {
 				history[template] = current_date;
 			}
@@ -1802,7 +1802,7 @@ Twinkle.warn.callbacks = {
 		} else if (latest.type) { // Non-numbered warning
 			// Try to leverage existing categorization of
 			// warnings, all but one are universally lowercased
-			let loweredType = /uw-multipleIPs/i.test(latest.type) ? 'uw-multipleIPs' : latest.type.toLowerCase();
+			const loweredType = /uw-multipleIPs/i.test(latest.type) ? 'uw-multipleIPs' : latest.type.toLowerCase();
 			// It would be nice to account for blocks, but in most
 			// cases the hidden message is terminal, not the sig
 			if (Twinkle.warn.messages.singlewarn[loweredType]) {
@@ -1812,12 +1812,12 @@ Twinkle.warn.callbacks = {
 			}
 		}
 
-		let $autolevelMessage = $('<div/>', {id: 'twinkle-warn-autolevel-message'});
+		const $autolevelMessage = $('<div/>', {id: 'twinkle-warn-autolevel-message'});
 
 		if (isNaN(level)) { // No prior warnings found, this is the first
 			level = 1;
 		} else if (level > 4 || level < 1) { // Shouldn't happen
-			let message = 'Unable to parse previous warning level, please manually select a warning level.';
+			const message = 'Unable to parse previous warning level, please manually select a warning level.';
 			if (statelem) {
 				statelem.error(message);
 			} else {
@@ -1826,14 +1826,14 @@ Twinkle.warn.callbacks = {
 			return;
 		} else {
 			date = date || new Date();
-			let autoTimeout = new Morebits.date(latest.date.getTime()).add(parseInt(Twinkle.getPref('autolevelStaleDays'), 10), 'days');
+			const autoTimeout = new Morebits.date(latest.date.getTime()).add(parseInt(Twinkle.getPref('autolevelStaleDays'), 10), 'days');
 			if (autoTimeout.isAfter(date)) {
 				if (level === 4) {
 					level = 4;
 					// Basically indicates whether we're in the final Main evaluation or not,
 					// and thus whether we can continue or need to display the warning and link
 					if (!statelem) {
-						let $link = $('<a/>', {
+						const $link = $('<a/>', {
 							href: '#',
 							text: 'click here to open the ARV tool.',
 							css: { fontWeight: 'bold' },
@@ -1845,7 +1845,7 @@ Twinkle.warn.callbacks = {
 								$('input[value=final]').prop('checked', true); // Vandalism after final
 							}
 						});
-						let statusNode = $('<div/>', {
+						const statusNode = $('<div/>', {
 							text: mw.config.get('wgRelevantUserName') + ' recently received a level 4 warning (' + latest.type + ') so it might be better to report them instead; ',
 							css: {color: 'red' }
 						});
@@ -1877,19 +1877,19 @@ Twinkle.warn.callbacks = {
 		return [template, level];
 	},
 	main: function(pageobj) {
-		let text = pageobj.getPageText();
-		let statelem = pageobj.getStatusElement();
-		let params = pageobj.getCallbackParameters();
+		const text = pageobj.getPageText();
+		const statelem = pageobj.getStatusElement();
+		const params = pageobj.getCallbackParameters();
 		let messageData = params.messageData;
 
-		let [latest, history] = Twinkle.warn.callbacks.dateProcessing(text);
+		const [latest, history] = Twinkle.warn.callbacks.dateProcessing(text);
 
-		let now = new Morebits.date(pageobj.getLoadTime());
+		const now = new Morebits.date(pageobj.getLoadTime());
 
 		Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj, just in case
 		if (params.main_group === 'autolevel') {
 			// [template, level]
-			let templateAndLevel = Twinkle.warn.callbacks.autolevelParseWikitext(text, params, latest, now, statelem);
+			const templateAndLevel = Twinkle.warn.callbacks.autolevelParseWikitext(text, params, latest, now, statelem);
 
 			// Only if there's a change from the prior display/load
 			if (params.sub_group !== templateAndLevel[0] && !confirm('Will issue a {{' + templateAndLevel[0] + '}} template to the user, okay?')) {
@@ -1919,7 +1919,7 @@ Twinkle.warn.callbacks = {
 
 		// build the edit summary
 		// Function to handle generation of summary prefix for custom templates
-		let customProcess = function(template) {
+		const customProcess = function(template) {
 			template = template.split('|')[0];
 			let prefix;
 			switch (template.substr(-1)) {
@@ -1997,10 +1997,10 @@ Twinkle.warn.callbacks = {
 		// Only check sections if there are sections or there's a chance we won't create our own
 		if (!messageData.heading && text.length) {
 			// Get all sections
-			let sections = text.match(/^(==*).+\1/gm);
+			const sections = text.match(/^(==*).+\1/gm);
 			if (sections && sections.length !== 0) {
 				// Find the index of the section header in question
-				let dateHeaderRegex = now.monthHeaderRegex();
+				const dateHeaderRegex = now.monthHeaderRegex();
 				sectionNumber = 0;
 				// Find this month's section among L2 sections, preferring the bottom-most
 				sectionExists = sections.reverse().some(function(sec, idx) {
@@ -2027,10 +2027,10 @@ Twinkle.warn.callbacks = {
 };
 
 Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
-	let userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
+	const userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
 	// reason, main_group, sub_group, article
-	let params = Morebits.quickForm.getInputData(e.target);
+	const params = Morebits.quickForm.getInputData(e.target);
 
 	// Check that a reason was filled in if uw-username was selected
 	if (params.sub_group === 'uw-username' && !params.article) {
@@ -2046,7 +2046,7 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	// after the form is submitted is probably preferable
 
 	// Find the selected <option> element so we can fetch the data structure
-	let $selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
+	const $selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
 	params.messageData = $selectedEl.data('messageData');
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
@@ -2055,7 +2055,7 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Warning complete, reloading talk page in a few seconds';
 
-	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	const wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.setFollowRedirect(true, false);
 	wikipedia_page.load(Twinkle.warn.callbacks.main);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -30,14 +30,14 @@ Twinkle.warn = function twinklewarn() {
 	// Modify URL of talk page on rollback success pages, makes use of a
 	// custom message box in [[MediaWiki:Rollback-success]]
 	if (mw.config.get('wgAction') === 'rollback') {
-		var $vandalTalkLink = $('#mw-rollback-success').find('.mw-usertoollinks a').first();
+		let $vandalTalkLink = $('#mw-rollback-success').find('.mw-usertoollinks a').first();
 		if ($vandalTalkLink.length) {
 			$vandalTalkLink.css('font-weight', 'bold');
 			$vandalTalkLink.wrapInner($('<span/>').attr('title', 'If appropriate, you can use Twinkle to warn the user about their edits to this page.'));
 
 			// Can't provide vanarticlerevid as only wgCurRevisionId is provided
-			var extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
-			var href = $vandalTalkLink.attr('href');
+			let extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
+			let href = $vandalTalkLink.attr('href');
 			if (href.indexOf('?') === -1) {
 				$vandalTalkLink.attr('href', href + '?' + extraParam);
 			} else {
@@ -56,7 +56,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		return;
 	}
 
-	var dialog;
+	let dialog;
 	Twinkle.warn.dialog = new Morebits.simpleWindow(600, 440);
 	dialog = Twinkle.warn.dialog;
 	dialog.setTitle('Warn/notify user');
@@ -66,21 +66,21 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	dialog.addFooterLink('Twinkle help', 'WP:TW/DOC#warn');
 	dialog.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.warn.callback.evaluate);
-	var main_select = form.append({
+	let form = new Morebits.quickForm(Twinkle.warn.callback.evaluate);
+	let main_select = form.append({
 		type: 'field',
 		label: 'Choose type of warning/notice to issue',
 		tooltip: 'First choose a main warning group, then the specific warning to issue.'
 	});
 
-	var main_group = main_select.append({
+	let main_group = main_select.append({
 		type: 'select',
 		name: 'main_group',
 		tooltip: 'You can customize the default selection in your Twinkle preferences',
 		event: Twinkle.warn.callback.change_category
 	});
 
-	var defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
+	let defaultGroup = parseInt(Twinkle.getPref('defaultWarningGroup'), 10);
 	main_group.append({ type: 'option', label: 'Auto-select level (1-4)', value: 'autolevel', selected: defaultGroup === 11 });
 	main_group.append({ type: 'option', label: '1: General note', value: 'level1', selected: defaultGroup === 1 });
 	main_group.append({ type: 'option', label: '2: Caution', value: 'level2', selected: defaultGroup === 2 });
@@ -116,10 +116,10 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	});
 
 
-	var more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });
+	let more = form.append({ type: 'field', name: 'reasonGroup', label: 'Warning information' });
 	more.append({ type: 'textarea', label: 'Optional message:', name: 'reason', tooltip: 'Perhaps a reason, or that a more detailed notice must be appended' });
 
-	var previewlink = document.createElement('a');
+	let previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.warn.callbacks.preview(result);  // |result| is defined below
 	});
@@ -137,10 +137,10 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinklewarn-previewbox').last()[0]);
 
 	// Potential notices for staleness and missed reverts
-	var vanrevid = Twinkle.getPrefill('vanarticlerevid');
+	let vanrevid = Twinkle.getPrefill('vanarticlerevid');
 	if (vanrevid) {
-		var message = '';
-		var query = {};
+		let message = '';
+		let query = {};
 
 		// If you tried reverting, check if *you* actually reverted
 		if (!Twinkle.getPrefill('noautowarn') && Twinkle.getPrefill('vanarticle')) { // Via fluff link
@@ -156,8 +156,8 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 			};
 
 			new Morebits.wiki.api('Checking if you successfully reverted the page', query, function(apiobj) {
-				var rev = apiobj.getResponse().query.pages[0].revisions;
-				var revertUser = rev && rev[1].user;
+				let rev = apiobj.getResponse().query.pages[0].revisions;
+				let revertUser = rev && rev[1].user;
 				if (revertUser && revertUser !== mw.config.get('wgUserName')) {
 					message += ' Someone else reverted the page and may have already warned the user.';
 					$('#twinkle-warn-warning-messages').text('Note:' + message);
@@ -166,8 +166,8 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 		}
 
 		// Confirm edit wasn't too old for a warning
-		var checkStale = function(vantimestamp) {
-			var revDate = new Morebits.date(vantimestamp);
+		let checkStale = function(vantimestamp) {
+			let revDate = new Morebits.date(vantimestamp);
 			if (vantimestamp && revDate.isValid()) {
 				if (revDate.add(24, 'hours').isBefore(new Date())) {
 					message += ' This edit was made more than 24 hours ago so a warning may be stale.';
@@ -176,7 +176,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 			}
 		};
 
-		var vantimestamp = Twinkle.getPrefill('vantimestamp');
+		let vantimestamp = Twinkle.getPrefill('vantimestamp');
 		// Provided from a fluff module-based revert, no API lookup necessary
 		if (vantimestamp) {
 			checkStale(vantimestamp);
@@ -189,7 +189,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				format: 'json'
 			};
 			new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
-				var rev = apiobj.getResponse().query.pages[0].revisions;
+				let rev = apiobj.getResponse().query.pages[0].revisions;
 				vantimestamp = rev && rev[0].timestamp;
 				checkStale(vantimestamp);
 			}).post();
@@ -198,7 +198,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 
 
 	// We must init the first choice (General Note);
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.main_group.dispatchEvent(evt);
 };
@@ -1360,12 +1360,12 @@ Twinkle.warn.messages = {
  * suppressArticleInSummary, hideLinkedPage, or hideReason)
  */
 Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyName) {
-	var result;
-	var isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);
+	let result;
+	let isNumberedTemplate = templateName.match(/(1|2|3|4|4im)$/);
 	if (isNumberedTemplate) {
-		var unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
-		var level = isNumberedTemplate[0];
-		var numberedWarnings = {};
+		let unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
+		let level = isNumberedTemplate[0];
+		let numberedWarnings = {};
 		$.each(templates.levels, function(key, val) {
 			$.extend(numberedWarnings, val);
 		});
@@ -1377,7 +1377,7 @@ Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyNam
 	}
 
 	// Non-level templates can also end in a number. So check this for all templates.
-	var otherWarnings = {};
+	let otherWarnings = {};
 	$.each(templates, function(key, val) {
 		if (key !== 'levels') {
 			$.extend(otherWarnings, val);
@@ -1398,11 +1398,11 @@ Twinkle.warn.prev_reason = null;
 Twinkle.warn.talkpageObj = null;
 
 Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCategory(e) {
-	var value = e.target.value;
-	var sub_group = e.target.root.sub_group;
+	let value = e.target.value;
+	let sub_group = e.target.root.sub_group;
 	sub_group.main_group = value;
-	var old_subvalue = sub_group.value;
-	var old_subvalue_re;
+	let old_subvalue = sub_group.value;
+	let old_subvalue_re;
 	if (old_subvalue) {
 		if (value === 'kitchensink') { // Exact match possible in kitchensink menu
 			old_subvalue_re = new RegExp(mw.util.escapeRegExp(old_subvalue));
@@ -1416,16 +1416,16 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		sub_group.removeChild(sub_group.firstChild);
 	}
 
-	var selected = false;
+	let selected = false;
 	// worker function to create the combo box entries
-	var createEntries = function(contents, container, wrapInOptgroup, val = value) {
+	let createEntries = function(contents, container, wrapInOptgroup, val = value) {
 		// level2->2, singlewarn->''; also used to distinguish the
 		// scaled levels from singlenotice, singlewarn, and custom
-		var level = val.replace(/^\D+/g, '');
+		let level = val.replace(/^\D+/g, '');
 		// due to an apparent iOS bug, we have to add an option-group to prevent truncation of text
 		// (search WT:TW archives for "Problem selecting warnings on an iPhone")
 		if (wrapInOptgroup && $.client.profile().platform === 'iphone') {
-			var wrapperOptgroup = new Morebits.quickForm.element({
+			let wrapperOptgroup = new Morebits.quickForm.element({
 				type: 'optgroup',
 				label: 'Available templates'
 			});
@@ -1439,10 +1439,10 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (!!level && !itemProperties[val]) {
 				return;
 			}
-			var key = typeof itemKey === 'string' ? itemKey : itemProperties.value;
-			var template = key + level;
+			let key = typeof itemKey === 'string' ? itemKey : itemProperties.value;
+			let template = key + level;
 
-			var elem = new Morebits.quickForm.element({
+			let elem = new Morebits.quickForm.element({
 				type: 'option',
 				label: '{{' + template + '}}: ' + (level ? itemProperties[val].label : itemProperties.label),
 				value: template
@@ -1452,13 +1452,13 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (!selected && old_subvalue && old_subvalue_re.test(template)) {
 				elem.data.selected = selected = true;
 			}
-			var elemRendered = container.appendChild(elem.render());
+			let elemRendered = container.appendChild(elem.render());
 			$(elemRendered).data('messageData', itemProperties);
 		});
 	};
-	var createGroup = function(warnGroup, label, wrapInOptgroup, val) {
+	let createGroup = function(warnGroup, label, wrapInOptgroup, val) {
 		wrapInOptgroup = typeof wrapInOptgroup !== 'undefined' ? wrapInOptgroup : true;
-		var optgroup = new Morebits.quickForm.element({
+		let optgroup = new Morebits.quickForm.element({
 			type: 'optgroup',
 			label: label
 		});
@@ -1507,15 +1507,15 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		case 'autolevel':
 			// Check user page to determine appropriate level
 			var autolevelProc = function() {
-				var wikitext = Twinkle.warn.talkpageObj.getPageText();
+				let wikitext = Twinkle.warn.talkpageObj.getPageText();
 				// history not needed for autolevel
-				var latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
+				let latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
 				// Pseudo-params with only what's needed to parse the level i.e. no messageData
-				var params = {
+				let params = {
 					sub_group: old_subvalue,
 					article: e.target.root.article.value
 				};
-				var lvl = 'level' + Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[1];
+				let lvl = 'level' + Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[1];
 
 				// Identical to level1, etc. above but explicitly provides the level
 				$.each(Twinkle.warn.messages.levels, function(groupLabel, groupContents) {
@@ -1530,7 +1530,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			if (Twinkle.warn.talkpageObj) {
 				autolevelProc();
 			} else {
-				var usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
+				let usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
 				usertalk_page.setFollowRedirect(true, false);
 				usertalk_page.load(function(pageobj) {
 					Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
@@ -1539,7 +1539,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 					// Catch and warn if the talkpage can't load,
 					// most likely because it's a cross-namespace redirect
 					// Supersedes the typical $autolevelMessage added in autolevelParseWikitext
-					var $noTalkPageNode = $('<strong/>', {
+					let $noTalkPageNode = $('<strong/>', {
 						text: 'Unable to load user talk page; it might be a cross-namespace redirect.  Autolevel detection will not work.',
 						id: 'twinkle-warn-autolevel-message',
 						css: {color: 'red' }
@@ -1605,11 +1605,11 @@ Twinkle.warn.callback.postCategoryCleanup = function twinklewarnCallbackPostCate
 };
 
 Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSubcategory(e) {
-	var selected_main_group = e.target.form.main_group.value;
-	var selected_template = e.target.form.sub_group.value;
+	let selected_main_group = e.target.form.main_group.value;
+	let selected_template = e.target.form.sub_group.value;
 
 	// If template shouldn't have a linked article, hide the linked article label and text box
-	var hideLinkedPage = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
+	let hideLinkedPage = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideLinkedPage');
 	if (hideLinkedPage) {
 		e.target.form.article.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.article.parentElement, false);
@@ -1618,7 +1618,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 	}
 
 	// If template shouldn't have an optional message, hide the optional message label and text box
-	var hideReason = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideReason');
+	let hideReason = Twinkle.warn.getTemplateProperty(Twinkle.warn.messages, selected_template, 'hideReason');
 	if (hideReason) {
 		e.target.form.reason.value = '';
 		Morebits.quickForm.setElementVisibility(e.target.form.reason.parentElement, false);
@@ -1628,7 +1628,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 
 	// Tags that don't take a linked article, but something else (often a username).
 	// The value of each tag is the label next to the input field
-	var notLinkedArticle = {
+	let notLinkedArticle = {
 		'uw-agf-sock': 'Optional username of other account (without User:) ',
 		'uw-bite': "Username of 'bitten' user (without User:) ",
 		'uw-socksuspect': 'Username of sock master, if known (without User:) ',
@@ -1636,7 +1636,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 		'uw-aiv': 'Optional username that was reported (without User:) '
 	};
 
-	var hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
+	let hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
 	if (hasLevel) {
 		if (notLinkedArticle[selected_template]) {
 			if (Twinkle.warn.prev_article === null) {
@@ -1661,7 +1661,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 
 	// add big red notice, warning users about how to use {{uw-[coi-]username}} appropriately
 	$('#tw-warn-red-notice').remove();
-	var $redWarning;
+	let $redWarning;
 	if (selected_template === 'uw-username') {
 		$redWarning = $("<div style='color: red;' id='tw-warn-red-notice'>{{uw-username}} should <b>not</b> be used for <b>blatant</b> username policy violations. " +
 			"Blatant violations should be reported directly to UAA (via Twinkle's ARV tab). " +
@@ -1677,7 +1677,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 
 Twinkle.warn.callbacks = {
 	getWarningWikitext: function(templateName, article, reason, isCustom) {
-		var text = '{{subst:' + templateName;
+		let text = '{{subst:' + templateName;
 
 		// add linked article for user warnings
 		if (article) {
@@ -1707,11 +1707,11 @@ Twinkle.warn.callbacks = {
 		return text + ' ~~~~';
 	},
 	showPreview: function(form, templatename) {
-		var input = Morebits.quickForm.getInputData(form);
+		let input = Morebits.quickForm.getInputData(form);
 		// Provided on autolevel, not otherwise
 		templatename = templatename || input.sub_group;
-		var linkedarticle = input.article;
-		var templatetext;
+		let linkedarticle = input.article;
+		let templatetext;
 
 		templatetext = Twinkle.warn.callbacks.getWarningWikitext(templatename, linkedarticle,
 			input.reason, input.main_group === 'custom');
@@ -1722,28 +1722,28 @@ Twinkle.warn.callbacks = {
 	preview: function(form) {
 		if (form.main_group.value === 'autolevel') {
 			// Always get a new, updated talkpage for autolevel processing
-			var usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
+			let usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
 			usertalk_page.setFollowRedirect(true, false);
 			// Will fail silently if the talk page is a cross-ns redirect,
 			// removal of the preview box handled when loading the menu
 			usertalk_page.load(function(pageobj) {
 				Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
 
-				var wikitext = pageobj.getPageText();
+				let wikitext = pageobj.getPageText();
 				// history not needed for autolevel
-				var latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
-				var params = {
+				let latest = Twinkle.warn.callbacks.dateProcessing(wikitext)[0];
+				let params = {
 					sub_group: form.sub_group.value,
 					article: form.article.value,
 					messageData: $(form.sub_group).find('option[value="' + $(form.sub_group).val() + '"]').data('messageData')
 				};
-				var template = Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[0];
+				let template = Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[0];
 				Twinkle.warn.callbacks.showPreview(form, template);
 
 				// If the templates have diverged, fake a change event
 				// to reload the menu with the updated pageobj
 				if (form.sub_group.value !== template) {
-					var evt = document.createEvent('Event');
+					let evt = document.createEvent('Event');
 					evt.initEvent('change', true, true);
 					form.main_group.dispatchEvent(evt);
 				}
@@ -1760,13 +1760,13 @@ Twinkle.warn.callbacks = {
 	* warning and date; history lists all prior warnings
 	*/
 	dateProcessing: function(wikitext) {
-		var history_re = /<!--\s?Template:([uU]w-.*?)\s?-->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
-		var history = {};
-		var latest = { date: new Morebits.date(0), type: '' };
-		var current;
+		let history_re = /<!--\s?Template:([uU]w-.*?)\s?-->.*?(\d{1,2}:\d{1,2}, \d{1,2} \w+ \d{4} \(UTC\))/g;
+		let history = {};
+		let latest = { date: new Morebits.date(0), type: '' };
+		let current;
 
 		while ((current = history_re.exec(wikitext)) !== null) {
-			var template = current[1], current_date = new Morebits.date(current[2]);
+			let template = current[1], current_date = new Morebits.date(current[2]);
 			if (!(template in history) || history[template].isBefore(current_date)) {
 				history[template] = current_date;
 			}
@@ -1796,13 +1796,13 @@ Twinkle.warn.callbacks = {
 	* @returns {Array} - Array that contains the full template and just the warning level
 	*/
 	autolevelParseWikitext: function(wikitext, params, latest, date, statelem) {
-		var level; // undefined rather than '' means the isNaN below will return true
+		let level; // undefined rather than '' means the isNaN below will return true
 		if (/\d(?:im)?$/.test(latest.type)) { // level1-4im
 			level = parseInt(latest.type.replace(/.*(\d)(?:im)?$/, '$1'), 10);
 		} else if (latest.type) { // Non-numbered warning
 			// Try to leverage existing categorization of
 			// warnings, all but one are universally lowercased
-			var loweredType = /uw-multipleIPs/i.test(latest.type) ? 'uw-multipleIPs' : latest.type.toLowerCase();
+			let loweredType = /uw-multipleIPs/i.test(latest.type) ? 'uw-multipleIPs' : latest.type.toLowerCase();
 			// It would be nice to account for blocks, but in most
 			// cases the hidden message is terminal, not the sig
 			if (Twinkle.warn.messages.singlewarn[loweredType]) {
@@ -1812,12 +1812,12 @@ Twinkle.warn.callbacks = {
 			}
 		}
 
-		var $autolevelMessage = $('<div/>', {id: 'twinkle-warn-autolevel-message'});
+		let $autolevelMessage = $('<div/>', {id: 'twinkle-warn-autolevel-message'});
 
 		if (isNaN(level)) { // No prior warnings found, this is the first
 			level = 1;
 		} else if (level > 4 || level < 1) { // Shouldn't happen
-			var message = 'Unable to parse previous warning level, please manually select a warning level.';
+			let message = 'Unable to parse previous warning level, please manually select a warning level.';
 			if (statelem) {
 				statelem.error(message);
 			} else {
@@ -1826,14 +1826,14 @@ Twinkle.warn.callbacks = {
 			return;
 		} else {
 			date = date || new Date();
-			var autoTimeout = new Morebits.date(latest.date.getTime()).add(parseInt(Twinkle.getPref('autolevelStaleDays'), 10), 'days');
+			let autoTimeout = new Morebits.date(latest.date.getTime()).add(parseInt(Twinkle.getPref('autolevelStaleDays'), 10), 'days');
 			if (autoTimeout.isAfter(date)) {
 				if (level === 4) {
 					level = 4;
 					// Basically indicates whether we're in the final Main evaluation or not,
 					// and thus whether we can continue or need to display the warning and link
 					if (!statelem) {
-						var $link = $('<a/>', {
+						let $link = $('<a/>', {
 							href: '#',
 							text: 'click here to open the ARV tool.',
 							css: { fontWeight: 'bold' },
@@ -1845,7 +1845,7 @@ Twinkle.warn.callbacks = {
 								$('input[value=final]').prop('checked', true); // Vandalism after final
 							}
 						});
-						var statusNode = $('<div/>', {
+						let statusNode = $('<div/>', {
 							text: mw.config.get('wgRelevantUserName') + ' recently received a level 4 warning (' + latest.type + ') so it might be better to report them instead; ',
 							css: {color: 'red' }
 						});
@@ -1865,7 +1865,7 @@ Twinkle.warn.callbacks = {
 		$('#twinkle-warn-autolevel-message').remove(); // clean slate
 		$autolevelMessage.insertAfter($('#twinkle-warn-warning-messages'));
 
-		var template = params.sub_group.replace(/(.*)\d$/, '$1');
+		let template = params.sub_group.replace(/(.*)\d$/, '$1');
 		// Validate warning level, falling back to the uw-generic series.
 		// Only a few items are missing a level, and in all but a handful
 		// of cases, the uw-generic series is explicitly used elsewhere per WP:UTM.
@@ -1877,19 +1877,19 @@ Twinkle.warn.callbacks = {
 		return [template, level];
 	},
 	main: function(pageobj) {
-		var text = pageobj.getPageText();
-		var statelem = pageobj.getStatusElement();
-		var params = pageobj.getCallbackParameters();
-		var messageData = params.messageData;
+		let text = pageobj.getPageText();
+		let statelem = pageobj.getStatusElement();
+		let params = pageobj.getCallbackParameters();
+		let messageData = params.messageData;
 
-		var [latest, history] = Twinkle.warn.callbacks.dateProcessing(text);
+		let [latest, history] = Twinkle.warn.callbacks.dateProcessing(text);
 
-		var now = new Morebits.date(pageobj.getLoadTime());
+		let now = new Morebits.date(pageobj.getLoadTime());
 
 		Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj, just in case
 		if (params.main_group === 'autolevel') {
 			// [template, level]
-			var templateAndLevel = Twinkle.warn.callbacks.autolevelParseWikitext(text, params, latest, now, statelem);
+			let templateAndLevel = Twinkle.warn.callbacks.autolevelParseWikitext(text, params, latest, now, statelem);
 
 			// Only if there's a change from the prior display/load
 			if (params.sub_group !== templateAndLevel[0] && !confirm('Will issue a {{' + templateAndLevel[0] + '}} template to the user, okay?')) {
@@ -1919,9 +1919,9 @@ Twinkle.warn.callbacks = {
 
 		// build the edit summary
 		// Function to handle generation of summary prefix for custom templates
-		var customProcess = function(template) {
+		let customProcess = function(template) {
 			template = template.split('|')[0];
-			var prefix;
+			let prefix;
 			switch (template.substr(-1)) {
 				case '1':
 					prefix = 'General note';
@@ -1948,13 +1948,13 @@ Twinkle.warn.callbacks = {
 			return prefix + ': ' + Morebits.string.toUpperCaseFirstChar(messageData.label);
 		};
 
-		var summary;
+		let summary;
 		if (params.main_group === 'custom') {
 			summary = customProcess(params.sub_group);
 		} else {
 			// Normalize kitchensink to the 1-4im style
 			if (params.main_group === 'kitchensink' && !/^D+$/.test(params.sub_group)) {
-				var sub = params.sub_group.substr(-1);
+				let sub = params.sub_group.substr(-1);
 				if (sub === 'm') {
 					sub = params.sub_group.substr(-3);
 				}
@@ -1986,21 +1986,21 @@ Twinkle.warn.callbacks = {
 
 
 		// Get actual warning text
-		var warningText = Twinkle.warn.callbacks.getWarningWikitext(params.sub_group, params.article,
+		let warningText = Twinkle.warn.callbacks.getWarningWikitext(params.sub_group, params.article,
 			params.reason, params.main_group === 'custom');
 		if (Twinkle.getPref('showSharedIPNotice') && mw.util.isIPAddress(mw.config.get('wgTitle'))) {
 			Morebits.status.info('Info', 'Adding a shared IP notice');
 			warningText += '\n{{subst:Shared IP advice}}';
 		}
 
-		var sectionExists = false, sectionNumber = 0;
+		let sectionExists = false, sectionNumber = 0;
 		// Only check sections if there are sections or there's a chance we won't create our own
 		if (!messageData.heading && text.length) {
 			// Get all sections
-			var sections = text.match(/^(==*).+\1/gm);
+			let sections = text.match(/^(==*).+\1/gm);
 			if (sections && sections.length !== 0) {
 				// Find the index of the section header in question
-				var dateHeaderRegex = now.monthHeaderRegex();
+				let dateHeaderRegex = now.monthHeaderRegex();
 				sectionNumber = 0;
 				// Find this month's section among L2 sections, preferring the bottom-most
 				sectionExists = sections.reverse().some(function(sec, idx) {
@@ -2027,10 +2027,10 @@ Twinkle.warn.callbacks = {
 };
 
 Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
-	var userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
+	let userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
 	// reason, main_group, sub_group, article
-	var params = Morebits.quickForm.getInputData(e.target);
+	let params = Morebits.quickForm.getInputData(e.target);
 
 	// Check that a reason was filled in if uw-username was selected
 	if (params.sub_group === 'uw-username' && !params.article) {
@@ -2046,7 +2046,7 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	// after the form is submitted is probably preferable
 
 	// Find the selected <option> element so we can fetch the data structure
-	var $selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
+	let $selectedEl = $(e.target.sub_group).find('option[value="' + $(e.target.sub_group).val() + '"]');
 	params.messageData = $selectedEl.data('messageData');
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
@@ -2055,7 +2055,7 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Warning complete, reloading talk page in a few seconds';
 
-	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.setFollowRedirect(true, false);
 	wikipedia_page.load(Twinkle.warn.callbacks.main);

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -120,7 +120,7 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 	more.append({ type: 'textarea', label: 'Optional message:', name: 'reason', tooltip: 'Perhaps a reason, or that a more detailed notice must be appended' });
 
 	const previewlink = document.createElement('a');
-	$(previewlink).click(function() {
+	$(previewlink).click(() => {
 		Twinkle.warn.callbacks.preview(result);  // |result| is defined below
 	});
 	previewlink.style.cursor = 'pointer';
@@ -155,14 +155,14 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				format: 'json'
 			};
 
-			new Morebits.wiki.api('Checking if you successfully reverted the page', query, function(apiobj) {
+			new Morebits.wiki.api('Checking if you successfully reverted the page', query, ((apiobj) => {
 				const rev = apiobj.getResponse().query.pages[0].revisions;
 				const revertUser = rev && rev[1].user;
 				if (revertUser && revertUser !== mw.config.get('wgUserName')) {
 					message += ' Someone else reverted the page and may have already warned the user.';
 					$('#twinkle-warn-warning-messages').text('Note:' + message);
 				}
-			}).post();
+			})).post();
 		}
 
 		// Confirm edit wasn't too old for a warning
@@ -188,11 +188,11 @@ Twinkle.warn.callback = function twinklewarnCallback() {
 				revids: vanrevid,
 				format: 'json'
 			};
-			new Morebits.wiki.api('Grabbing the revision timestamps', query, function(apiobj) {
+			new Morebits.wiki.api('Grabbing the revision timestamps', query, ((apiobj) => {
 				const rev = apiobj.getResponse().query.pages[0].revisions;
 				vantimestamp = rev && rev[0].timestamp;
 				checkStale(vantimestamp);
-			}).post();
+			})).post();
 		}
 	}
 
@@ -1366,10 +1366,10 @@ Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyNam
 		const unNumberedTemplateName = templateName.replace(/(?:1|2|3|4|4im)$/, '');
 		const level = isNumberedTemplate[0];
 		const numberedWarnings = {};
-		$.each(templates.levels, function(key, val) {
+		$.each(templates.levels, (key, val) => {
 			$.extend(numberedWarnings, val);
 		});
-		$.each(numberedWarnings, function(key) {
+		$.each(numberedWarnings, (key) => {
 			if (key === unNumberedTemplateName) {
 				result = numberedWarnings[key]['level' + level][propertyName];
 			}
@@ -1378,12 +1378,12 @@ Twinkle.warn.getTemplateProperty = function(templates, templateName, propertyNam
 
 	// Non-level templates can also end in a number. So check this for all templates.
 	const otherWarnings = {};
-	$.each(templates, function(key, val) {
+	$.each(templates, (key, val) => {
 		if (key !== 'levels') {
 			$.extend(otherWarnings, val);
 		}
 	});
-	$.each(otherWarnings, function(key) {
+	$.each(otherWarnings, (key) => {
 		if (key === templateName) {
 			result = otherWarnings[key][propertyName];
 		}
@@ -1434,7 +1434,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			container = wrapperOptgroup;
 		}
 
-		$.each(contents, function(itemKey, itemProperties) {
+		$.each(contents, (itemKey, itemProperties) => {
 			// Skip if the current template doesn't have a version for the current level
 			if (!!level && !itemProperties[val]) {
 				return;
@@ -1475,7 +1475,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		case 'singlecombined':
 			var unSortedSinglets = $.extend({}, Twinkle.warn.messages.singlenotice, Twinkle.warn.messages.singlewarn);
 			var sortedSingletMessages = {};
-			Object.keys(unSortedSinglets).sort().forEach(function(key) {
+			Object.keys(unSortedSinglets).sort().forEach((key) => {
 				sortedSingletMessages[key] = unSortedSinglets[key];
 			});
 			createEntries(sortedSingletMessages, sub_group, true);
@@ -1484,8 +1484,8 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			createEntries(Twinkle.getPref('customWarningList'), sub_group, true);
 			break;
 		case 'kitchensink':
-			['level1', 'level2', 'level3', 'level4', 'level4im'].forEach(function(lvl) {
-				$.each(Twinkle.warn.messages.levels, function(levelGroupLabel, levelGroup) {
+			['level1', 'level2', 'level3', 'level4', 'level4im'].forEach((lvl) => {
+				$.each(Twinkle.warn.messages.levels, (levelGroupLabel, levelGroup) => {
 					createGroup(levelGroup, 'Level ' + lvl.slice(5) + ': ' + levelGroupLabel, true, lvl);
 				});
 			});
@@ -1500,7 +1500,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 		case 'level4im':
 			// Creates subgroup regardless of whether there is anything to place in it;
 			// leaves "Removal of deletion tags" empty for 4im
-			$.each(Twinkle.warn.messages.levels, function(groupLabel, groupContents) {
+			$.each(Twinkle.warn.messages.levels, (groupLabel, groupContents) => {
 				createGroup(groupContents, groupLabel, false);
 			});
 			break;
@@ -1518,7 +1518,7 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 				const lvl = 'level' + Twinkle.warn.callbacks.autolevelParseWikitext(wikitext, params, latest)[1];
 
 				// Identical to level1, etc. above but explicitly provides the level
-				$.each(Twinkle.warn.messages.levels, function(groupLabel, groupContents) {
+				$.each(Twinkle.warn.messages.levels, (groupLabel, groupContents) => {
 					createGroup(groupContents, groupLabel, false, lvl);
 				});
 
@@ -1532,10 +1532,10 @@ Twinkle.warn.callback.change_category = function twinklewarnCallbackChangeCatego
 			} else {
 				const usertalk_page = new Morebits.wiki.page('User_talk:' + mw.config.get('wgRelevantUserName'), 'Loading previous warnings');
 				usertalk_page.setFollowRedirect(true, false);
-				usertalk_page.load(function(pageobj) {
+				usertalk_page.load((pageobj) => {
 					Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
 					autolevelProc();
-				}, function() {
+				}, () => {
 					// Catch and warn if the talkpage can't load,
 					// most likely because it's a cross-namespace redirect
 					// Supersedes the typical $autolevelMessage added in autolevelParseWikitext
@@ -1726,7 +1726,7 @@ Twinkle.warn.callbacks = {
 			usertalk_page.setFollowRedirect(true, false);
 			// Will fail silently if the talk page is a cross-ns redirect,
 			// removal of the preview box handled when loading the menu
-			usertalk_page.load(function(pageobj) {
+			usertalk_page.load((pageobj) => {
 				Twinkle.warn.talkpageObj = pageobj; // Update talkpageObj
 
 				const wikitext = pageobj.getPageText();
@@ -2003,7 +2003,7 @@ Twinkle.warn.callbacks = {
 				const dateHeaderRegex = now.monthHeaderRegex();
 				sectionNumber = 0;
 				// Find this month's section among L2 sections, preferring the bottom-most
-				sectionExists = sections.reverse().some(function(sec, idx) {
+				sectionExists = sections.reverse().some((sec, idx) => {
 					return /^(==)[^=].+\1/m.test(sec) && dateHeaderRegex.test(sec) && typeof (sectionNumber = sections.length - 1 - idx) === 'number';
 				});
 			}

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -2003,9 +2003,7 @@ Twinkle.warn.callbacks = {
 				const dateHeaderRegex = now.monthHeaderRegex();
 				sectionNumber = 0;
 				// Find this month's section among L2 sections, preferring the bottom-most
-				sectionExists = sections.reverse().some((sec, idx) => {
-					return /^(==)[^=].+\1/m.test(sec) && dateHeaderRegex.test(sec) && typeof (sectionNumber = sections.length - 1 - idx) === 'number';
-				});
+				sectionExists = sections.reverse().some((sec, idx) => /^(==)[^=].+\1/m.test(sec) && dateHeaderRegex.test(sec) && typeof (sectionNumber = sections.length - 1 - idx) === 'number');
 			}
 		}
 

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -2062,7 +2062,7 @@ Twinkle.warn.callback.evaluate = function twinklewarnCallbackEvaluate(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.warn, 'warn');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -39,34 +39,34 @@ Twinkle.welcome.semiauto = function() {
 };
 
 Twinkle.welcome.normal = function() {
-	let isDiff = mw.util.getParamValue('diff');
+	const isDiff = mw.util.getParamValue('diff');
 	if (isDiff) {
 		// check whether the contributors' talk pages exist yet
-		let $oldDiffUsernameLine = $('#mw-diff-otitle2');
-		let $newDiffUsernameLine = $('#mw-diff-ntitle2');
-		let $oldDiffHasRedlinkedTalkPage = $oldDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
-		let $newDiffHasRedlinkedTalkPage = $newDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
+		const $oldDiffUsernameLine = $('#mw-diff-otitle2');
+		const $newDiffUsernameLine = $('#mw-diff-ntitle2');
+		const $oldDiffHasRedlinkedTalkPage = $oldDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
+		const $newDiffHasRedlinkedTalkPage = $newDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
 
-		let diffHasRedlinkedTalkPage = $oldDiffHasRedlinkedTalkPage.length > 0 || $newDiffHasRedlinkedTalkPage.length > 0;
+		const diffHasRedlinkedTalkPage = $oldDiffHasRedlinkedTalkPage.length > 0 || $newDiffHasRedlinkedTalkPage.length > 0;
 		if (diffHasRedlinkedTalkPage) {
-			let spanTag = function(color, content) {
-				let span = document.createElement('span');
+			const spanTag = function(color, content) {
+				const span = document.createElement('span');
 				span.style.color = color;
 				span.appendChild(document.createTextNode(content));
 				return span;
 			};
 
-			let welcomeNode = document.createElement('strong');
-			let welcomeLink = document.createElement('a');
+			const welcomeNode = document.createElement('strong');
+			const welcomeLink = document.createElement('a');
 			welcomeLink.appendChild(spanTag('Black', '['));
 			welcomeLink.appendChild(spanTag('Goldenrod', 'welcome'));
 			welcomeLink.appendChild(spanTag('Black', ']'));
 			welcomeNode.appendChild(welcomeLink);
 
 			if ($oldDiffHasRedlinkedTalkPage.length > 0) {
-				let oHref = $oldDiffHasRedlinkedTalkPage.attr('href');
+				const oHref = $oldDiffHasRedlinkedTalkPage.attr('href');
 
-				let oWelcomeNode = welcomeNode.cloneNode(true);
+				const oWelcomeNode = welcomeNode.cloneNode(true);
 				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + $.param({
 					twinklewelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
@@ -76,9 +76,9 @@ Twinkle.welcome.normal = function() {
 			}
 
 			if ($newDiffHasRedlinkedTalkPage.length > 0) {
-				let nHref = $newDiffHasRedlinkedTalkPage.attr('href');
+				const nHref = $newDiffHasRedlinkedTalkPage.attr('href');
 
-				let nWelcomeNode = welcomeNode.cloneNode(true);
+				const nWelcomeNode = welcomeNode.cloneNode(true);
 				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + $.param({
 					twinklewelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
@@ -100,17 +100,17 @@ Twinkle.welcome.welcomeUser = function welcomeUser() {
 	Morebits.status.init(document.getElementById('mw-content-text'));
 	$('#catlinks').remove();
 
-	let params = {
+	const params = {
 		template: Twinkle.getPref('quickWelcomeTemplate'),
 		article: Twinkle.getPrefill('vanarticle') || '',
 		mode: 'auto'
 	};
 
-	let userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
+	const userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Welcoming complete, reloading talk page in a few seconds';
 
-	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	const wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.welcome.callbacks.main);
@@ -121,7 +121,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 		return;
 	}
 
-	let Window = new Morebits.simpleWindow(600, 420);
+	const Window = new Morebits.simpleWindow(600, 420);
 	Window.setTitle('Welcome user');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Welcoming Committee', 'WP:WC');
@@ -129,7 +129,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#welcome');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.welcome.callback.evaluate);
+	const form = new Morebits.quickForm(Twinkle.welcome.callback.evaluate);
 
 	form.append({
 		type: 'select',
@@ -158,7 +158,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 		tooltip: 'An article might be linked from within the welcome if the template supports it. Leave empty for no article to be linked.  Templates that support a linked article are marked with an asterisk.'
 	});
 
-	let previewlink = document.createElement('a');
+	const previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.welcome.callbacks.preview(result);  // |result| is defined below
 	});
@@ -173,15 +173,15 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	Window.display();
 
 	// initialize the welcome list
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.type.dispatchEvent(evt);
 };
 
 Twinkle.welcome.populateWelcomeList = function(e) {
-	let type = e.target.value;
+	const type = e.target.value;
 
-	let container = new Morebits.quickForm.element({ type: 'fragment' });
+	const container = new Morebits.quickForm.element({ type: 'fragment' });
 
 	if ((type === 'standard' || type === 'unregistered') && Twinkle.getPref('customWelcomeList').length) {
 		container.append({ type: 'header', label: 'Custom welcome templates' });
@@ -195,7 +195,7 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 		});
 	}
 
-	let sets = Twinkle.welcome.templates[type];
+	const sets = Twinkle.welcome.templates[type];
 	$.each(sets, function(label, templates) {
 		container.append({ type: 'header', label: label });
 		container.append({
@@ -214,12 +214,12 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 		});
 	});
 
-	let rendered = container.render();
+	const rendered = container.render();
 	$(e.target.form).find('div#welcomeWorkArea').empty().append(rendered);
 
-	let firstRadio = e.target.form.template[0];
+	const firstRadio = e.target.form.template[0];
 	firstRadio.checked = true;
-	let vals = Object.values(sets)[0];
+	const vals = Object.values(sets)[0];
 	e.target.form.article.disabled = vals[firstRadio.value] ? !vals[firstRadio.value].linkedArticle : true;
 };
 
@@ -671,21 +671,21 @@ Twinkle.welcome.getTemplateWikitext = function(type, template, article) {
 
 Twinkle.welcome.callbacks = {
 	preview: function(form) {
-		let previewDialog = new Morebits.simpleWindow(750, 400);
+		const previewDialog = new Morebits.simpleWindow(750, 400);
 		previewDialog.setTitle('Welcome template preview');
 		previewDialog.setScriptName('Welcome user');
 		previewDialog.setModality(true);
 
-		let previewdiv = document.createElement('div');
+		const previewdiv = document.createElement('div');
 		previewdiv.style.marginLeft = previewdiv.style.marginRight = '0.5em';
 		previewdiv.style.fontSize = 'small';
 		previewDialog.setContent(previewdiv);
 
-		let previewer = new Morebits.wiki.preview(previewdiv);
-		let input = Morebits.quickForm.getInputData(form);
+		const previewer = new Morebits.wiki.preview(previewdiv);
+		const input = Morebits.quickForm.getInputData(form);
 		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(input.type, input.template, input.article), 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 
-		let submit = document.createElement('input');
+		const submit = document.createElement('input');
 		submit.setAttribute('type', 'submit');
 		submit.setAttribute('value', 'Close');
 		previewDialog.addContent(submit);
@@ -697,7 +697,7 @@ Twinkle.welcome.callbacks = {
 		});
 	},
 	main: function(pageobj) {
-		let params = pageobj.getCallbackParameters();
+		const params = pageobj.getCallbackParameters();
 		let text = pageobj.getPageText();
 
 		// abort if mode is auto and form is not empty
@@ -707,10 +707,10 @@ Twinkle.welcome.callbacks = {
 			return;
 		}
 
-		let welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
+		const welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
 
 		if (Twinkle.getPref('topWelcomes')) {
-			let hasTalkHeader = /^\{\{Talk ?header\}\}/i.test(text);
+			const hasTalkHeader = /^\{\{Talk ?header\}\}/i.test(text);
 			if (hasTalkHeader) {
 				text = text.replace(/^\{\{Talk ?header\}\}\n{0,2}/i, '');
 				text = '{{Talk header}}\n\n' + welcomeText + '\n\n' + text;
@@ -722,7 +722,7 @@ Twinkle.welcome.callbacks = {
 			text += '\n' + welcomeText;
 		}
 
-		let summaryText = 'Welcome to Wikipedia!';
+		const summaryText = 'Welcome to Wikipedia!';
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summaryText);
 		pageobj.setChangeTags(Twinkle.changeTags);
@@ -733,19 +733,19 @@ Twinkle.welcome.callbacks = {
 };
 
 Twinkle.welcome.callback.evaluate = function twinklewelcomeCallbackEvaluate(e) {
-	let form = e.target;
+	const form = e.target;
 
-	let params = Morebits.quickForm.getInputData(form); // : type, template, article
+	const params = Morebits.quickForm.getInputData(form); // : type, template, article
 	params.mode = 'manual';
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	let userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
+	const userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Welcoming complete, reloading talk page in a few seconds';
 
-	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	const wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.welcome.callbacks.main);

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -39,34 +39,34 @@ Twinkle.welcome.semiauto = function() {
 };
 
 Twinkle.welcome.normal = function() {
-	var isDiff = mw.util.getParamValue('diff');
+	let isDiff = mw.util.getParamValue('diff');
 	if (isDiff) {
 		// check whether the contributors' talk pages exist yet
-		var $oldDiffUsernameLine = $('#mw-diff-otitle2');
-		var $newDiffUsernameLine = $('#mw-diff-ntitle2');
-		var $oldDiffHasRedlinkedTalkPage = $oldDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
-		var $newDiffHasRedlinkedTalkPage = $newDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
+		let $oldDiffUsernameLine = $('#mw-diff-otitle2');
+		let $newDiffUsernameLine = $('#mw-diff-ntitle2');
+		let $oldDiffHasRedlinkedTalkPage = $oldDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
+		let $newDiffHasRedlinkedTalkPage = $newDiffUsernameLine.find('span.mw-usertoollinks a.new:contains(talk)').first();
 
-		var diffHasRedlinkedTalkPage = $oldDiffHasRedlinkedTalkPage.length > 0 || $newDiffHasRedlinkedTalkPage.length > 0;
+		let diffHasRedlinkedTalkPage = $oldDiffHasRedlinkedTalkPage.length > 0 || $newDiffHasRedlinkedTalkPage.length > 0;
 		if (diffHasRedlinkedTalkPage) {
-			var spanTag = function(color, content) {
-				var span = document.createElement('span');
+			let spanTag = function(color, content) {
+				let span = document.createElement('span');
 				span.style.color = color;
 				span.appendChild(document.createTextNode(content));
 				return span;
 			};
 
-			var welcomeNode = document.createElement('strong');
-			var welcomeLink = document.createElement('a');
+			let welcomeNode = document.createElement('strong');
+			let welcomeLink = document.createElement('a');
 			welcomeLink.appendChild(spanTag('Black', '['));
 			welcomeLink.appendChild(spanTag('Goldenrod', 'welcome'));
 			welcomeLink.appendChild(spanTag('Black', ']'));
 			welcomeNode.appendChild(welcomeLink);
 
 			if ($oldDiffHasRedlinkedTalkPage.length > 0) {
-				var oHref = $oldDiffHasRedlinkedTalkPage.attr('href');
+				let oHref = $oldDiffHasRedlinkedTalkPage.attr('href');
 
-				var oWelcomeNode = welcomeNode.cloneNode(true);
+				let oWelcomeNode = welcomeNode.cloneNode(true);
 				oWelcomeNode.firstChild.setAttribute('href', oHref + '&' + $.param({
 					twinklewelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
@@ -76,9 +76,9 @@ Twinkle.welcome.normal = function() {
 			}
 
 			if ($newDiffHasRedlinkedTalkPage.length > 0) {
-				var nHref = $newDiffHasRedlinkedTalkPage.attr('href');
+				let nHref = $newDiffHasRedlinkedTalkPage.attr('href');
 
-				var nWelcomeNode = welcomeNode.cloneNode(true);
+				let nWelcomeNode = welcomeNode.cloneNode(true);
 				nWelcomeNode.firstChild.setAttribute('href', nHref + '&' + $.param({
 					twinklewelcome: Twinkle.getPref('quickWelcomeMode') === 'auto' ? 'auto' : 'norm',
 					vanarticle: Morebits.pageNameNorm
@@ -100,17 +100,17 @@ Twinkle.welcome.welcomeUser = function welcomeUser() {
 	Morebits.status.init(document.getElementById('mw-content-text'));
 	$('#catlinks').remove();
 
-	var params = {
+	let params = {
 		template: Twinkle.getPref('quickWelcomeTemplate'),
 		article: Twinkle.getPrefill('vanarticle') || '',
 		mode: 'auto'
 	};
 
-	var userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
+	let userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Welcoming complete, reloading talk page in a few seconds';
 
-	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.welcome.callbacks.main);
@@ -121,7 +121,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 		return;
 	}
 
-	var Window = new Morebits.simpleWindow(600, 420);
+	let Window = new Morebits.simpleWindow(600, 420);
 	Window.setTitle('Welcome user');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('Welcoming Committee', 'WP:WC');
@@ -129,7 +129,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#welcome');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.welcome.callback.evaluate);
+	let form = new Morebits.quickForm(Twinkle.welcome.callback.evaluate);
 
 	form.append({
 		type: 'select',
@@ -158,7 +158,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 		tooltip: 'An article might be linked from within the welcome if the template supports it. Leave empty for no article to be linked.  Templates that support a linked article are marked with an asterisk.'
 	});
 
-	var previewlink = document.createElement('a');
+	let previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.welcome.callbacks.preview(result);  // |result| is defined below
 	});
@@ -173,15 +173,15 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	Window.display();
 
 	// initialize the welcome list
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.type.dispatchEvent(evt);
 };
 
 Twinkle.welcome.populateWelcomeList = function(e) {
-	var type = e.target.value;
+	let type = e.target.value;
 
-	var container = new Morebits.quickForm.element({ type: 'fragment' });
+	let container = new Morebits.quickForm.element({ type: 'fragment' });
 
 	if ((type === 'standard' || type === 'unregistered') && Twinkle.getPref('customWelcomeList').length) {
 		container.append({ type: 'header', label: 'Custom welcome templates' });
@@ -195,7 +195,7 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 		});
 	}
 
-	var sets = Twinkle.welcome.templates[type];
+	let sets = Twinkle.welcome.templates[type];
 	$.each(sets, function(label, templates) {
 		container.append({ type: 'header', label: label });
 		container.append({
@@ -214,12 +214,12 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 		});
 	});
 
-	var rendered = container.render();
+	let rendered = container.render();
 	$(e.target.form).find('div#welcomeWorkArea').empty().append(rendered);
 
-	var firstRadio = e.target.form.template[0];
+	let firstRadio = e.target.form.template[0];
 	firstRadio.checked = true;
-	var vals = Object.values(sets)[0];
+	let vals = Object.values(sets)[0];
 	e.target.form.article.disabled = vals[firstRadio.value] ? !vals[firstRadio.value].linkedArticle : true;
 };
 
@@ -651,7 +651,7 @@ Twinkle.welcome.templates = {
 
 Twinkle.welcome.getTemplateWikitext = function(type, template, article) {
 	// the iteration is required as the type=standard has two groups
-	var properties;
+	let properties;
 	$.each(Twinkle.welcome.templates[type], function(label, templates) {
 		properties = templates[template];
 		if (properties) {
@@ -671,21 +671,21 @@ Twinkle.welcome.getTemplateWikitext = function(type, template, article) {
 
 Twinkle.welcome.callbacks = {
 	preview: function(form) {
-		var previewDialog = new Morebits.simpleWindow(750, 400);
+		let previewDialog = new Morebits.simpleWindow(750, 400);
 		previewDialog.setTitle('Welcome template preview');
 		previewDialog.setScriptName('Welcome user');
 		previewDialog.setModality(true);
 
-		var previewdiv = document.createElement('div');
+		let previewdiv = document.createElement('div');
 		previewdiv.style.marginLeft = previewdiv.style.marginRight = '0.5em';
 		previewdiv.style.fontSize = 'small';
 		previewDialog.setContent(previewdiv);
 
-		var previewer = new Morebits.wiki.preview(previewdiv);
-		var input = Morebits.quickForm.getInputData(form);
+		let previewer = new Morebits.wiki.preview(previewdiv);
+		let input = Morebits.quickForm.getInputData(form);
 		previewer.beginRender(Twinkle.welcome.getTemplateWikitext(input.type, input.template, input.article), 'User talk:' + mw.config.get('wgRelevantUserName')); // Force wikitext/correct username
 
-		var submit = document.createElement('input');
+		let submit = document.createElement('input');
 		submit.setAttribute('type', 'submit');
 		submit.setAttribute('value', 'Close');
 		previewDialog.addContent(submit);
@@ -697,8 +697,8 @@ Twinkle.welcome.callbacks = {
 		});
 	},
 	main: function(pageobj) {
-		var params = pageobj.getCallbackParameters();
-		var text = pageobj.getPageText();
+		let params = pageobj.getCallbackParameters();
+		let text = pageobj.getPageText();
 
 		// abort if mode is auto and form is not empty
 		if (pageobj.exists() && params.mode === 'auto') {
@@ -707,10 +707,10 @@ Twinkle.welcome.callbacks = {
 			return;
 		}
 
-		var welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
+		let welcomeText = Twinkle.welcome.getTemplateWikitext(params.type, params.template, params.article);
 
 		if (Twinkle.getPref('topWelcomes')) {
-			var hasTalkHeader = /^\{\{Talk ?header\}\}/i.test(text);
+			let hasTalkHeader = /^\{\{Talk ?header\}\}/i.test(text);
 			if (hasTalkHeader) {
 				text = text.replace(/^\{\{Talk ?header\}\}\n{0,2}/i, '');
 				text = '{{Talk header}}\n\n' + welcomeText + '\n\n' + text;
@@ -722,7 +722,7 @@ Twinkle.welcome.callbacks = {
 			text += '\n' + welcomeText;
 		}
 
-		var summaryText = 'Welcome to Wikipedia!';
+		let summaryText = 'Welcome to Wikipedia!';
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summaryText);
 		pageobj.setChangeTags(Twinkle.changeTags);
@@ -733,19 +733,19 @@ Twinkle.welcome.callbacks = {
 };
 
 Twinkle.welcome.callback.evaluate = function twinklewelcomeCallbackEvaluate(e) {
-	var form = e.target;
+	let form = e.target;
 
-	var params = Morebits.quickForm.getInputData(form); // : type, template, article
+	let params = Morebits.quickForm.getInputData(form); // : type, template, article
 	params.mode = 'manual';
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
 
-	var userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
+	let userTalkPage = mw.config.get('wgFormattedNamespaces')[3] + ':' + mw.config.get('wgRelevantUserName');
 	Morebits.wiki.actionCompleted.redirect = userTalkPage;
 	Morebits.wiki.actionCompleted.notice = 'Welcoming complete, reloading talk page in a few seconds';
 
-	var wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
+	let wikipedia_page = new Morebits.wiki.page(userTalkPage, 'User talk page modification');
 	wikipedia_page.setFollowRedirect(true);
 	wikipedia_page.setCallbackParameters(params);
 	wikipedia_page.load(Twinkle.welcome.callbacks.main);

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -752,7 +752,7 @@ Twinkle.welcome.callback.evaluate = function twinklewelcomeCallbackEvaluate(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.welcome, 'welcome');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -90,7 +90,7 @@ Twinkle.welcome.normal = function() {
 	}
 	// Users and IPs but not IP ranges
 	if (mw.config.exists('wgRelevantUserName') && !Morebits.ip.isRange(mw.config.get('wgRelevantUserName'))) {
-		Twinkle.addPortletLink(function() {
+		Twinkle.addPortletLink(() => {
 			Twinkle.welcome.callback(mw.config.get('wgRelevantUserName'));
 		}, 'Wel', 'twinkle-welcome', 'Welcome user');
 	}
@@ -159,7 +159,7 @@ Twinkle.welcome.callback = function twinklewelcomeCallback(uid) {
 	});
 
 	const previewlink = document.createElement('a');
-	$(previewlink).click(function() {
+	$(previewlink).click(() => {
 		Twinkle.welcome.callbacks.preview(result);  // |result| is defined below
 	});
 	previewlink.style.cursor = 'pointer';
@@ -196,12 +196,12 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 	}
 
 	const sets = Twinkle.welcome.templates[type];
-	$.each(sets, function(label, templates) {
+	$.each(sets, (label, templates) => {
 		container.append({ type: 'header', label: label });
 		container.append({
 			type: 'radio',
 			name: 'template',
-			list: $.map(templates, function(properties, template) {
+			list: $.map(templates, (properties, template) => {
 				return {
 					value: template,
 					label: '{{' + template + '}}: ' + properties.description + (properties.linkedArticle ? '\u00A0*' : ''),  // U+00A0 NO-BREAK SPACE
@@ -652,7 +652,7 @@ Twinkle.welcome.templates = {
 Twinkle.welcome.getTemplateWikitext = function(type, template, article) {
 	// the iteration is required as the type=standard has two groups
 	let properties;
-	$.each(Twinkle.welcome.templates[type], function(label, templates) {
+	$.each(Twinkle.welcome.templates[type], (label, templates) => {
 		properties = templates[template];
 		if (properties) {
 			return false; // break
@@ -692,7 +692,7 @@ Twinkle.welcome.callbacks = {
 
 		previewDialog.display();
 
-		$(submit).click(function() {
+		$(submit).click(() => {
 			previewDialog.close();
 		});
 	},

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -201,13 +201,11 @@ Twinkle.welcome.populateWelcomeList = function(e) {
 		container.append({
 			type: 'radio',
 			name: 'template',
-			list: $.map(templates, (properties, template) => {
-				return {
+			list: $.map(templates, (properties, template) => ({
 					value: template,
 					label: '{{' + template + '}}: ' + properties.description + (properties.linkedArticle ? '\u00A0*' : ''),  // U+00A0 NO-BREAK SPACE
 					tooltip: properties.tooltip  // may be undefined
-				};
-			}),
+				})),
 			event: function(ev) {
 				ev.target.form.article.disabled = !templates[ev.target.value].linkedArticle;
 			}

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -21,7 +21,7 @@ Twinkle.xfd = function twinklexfd() {
 		return;
 	}
 
-	var tooltip = 'Start a discussion for deleting';
+	let tooltip = 'Start a discussion for deleting';
 	if (mw.config.get('wgIsRedirect')) {
 		tooltip += ' or retargeting this redirect';
 	} else {
@@ -50,7 +50,7 @@ Twinkle.xfd = function twinklexfd() {
 };
 
 
-var utils = {
+let utils = {
 	/** Get ordinal number figure */
 	num2order: function(num) {
 		switch (num) {
@@ -67,7 +67,7 @@ var utils = {
 	 * @param {string} title
 	 */
 	stripNs: function(title) {
-		var title_obj = mw.Title.newFromUserInput(title);
+		let title_obj = mw.Title.newFromUserInput(title);
 		if (!title_obj) {
 			return title; // user entered invalid input; do nothing
 		}
@@ -82,7 +82,7 @@ var utils = {
 	 * @param {number} namespaceNumber
 	 */
 	addNs: function(title, namespaceNumber) {
-		var title_obj = mw.Title.newFromUserInput(title, namespaceNumber);
+		let title_obj = mw.Title.newFromUserInput(title, namespaceNumber);
 		if (!title_obj) {
 			return title;  // user entered invalid input; do nothing
 		}
@@ -116,7 +116,7 @@ Twinkle.xfd.printRationale = function twinklexfdPrintRationale() {
 };
 
 Twinkle.xfd.callback = function twinklexfdCallback() {
-	var Window = new Morebits.simpleWindow(700, 400);
+	let Window = new Morebits.simpleWindow(700, 400);
 	Window.setTitle('Start a deletion discussion (XfD)');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('About deletion discussions', 'WP:XFD');
@@ -124,15 +124,15 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#xfd');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	var form = new Morebits.quickForm(Twinkle.xfd.callback.evaluate);
-	var categories = form.append({
+	let form = new Morebits.quickForm(Twinkle.xfd.callback.evaluate);
+	let categories = form.append({
 		type: 'select',
 		name: 'venue',
 		label: 'Deletion discussion venue:',
 		tooltip: 'When activated, a default choice is made, based on what namespace you are in. This default should be the most appropriate.',
 		event: Twinkle.xfd.callback.change_category
 	});
-	var namespace = mw.config.get('wgNamespaceNumber');
+	let namespace = mw.config.get('wgNamespaceNumber');
 
 	categories.append({
 		type: 'option',
@@ -207,7 +207,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 		name: 'work_area'
 	});
 
-	var previewlink = document.createElement('a');
+	let previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.xfd.callbacks.preview(result);  // |result| is defined below
 	});
@@ -224,14 +224,14 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinklexfd-previewbox').last()[0]);
 
 	// We must init the controls
-	var evt = document.createEvent('Event');
+	let evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.venue.dispatchEvent(evt);
 };
 
 Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(venue) {
-	var text = '';
-	var namespace = mw.config.get('wgNamespaceNumber');
+	let text = '';
+	let namespace = mw.config.get('wgNamespaceNumber');
 
 	switch (venue) {
 		case 'afd':
@@ -280,15 +280,15 @@ Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(ve
 };
 
 Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory(e) {
-	var value = e.target.value;
-	var form = e.target.form;
-	var old_area = Morebits.quickForm.getElements(e.target.form, 'work_area')[0];
-	var work_area = null;
+	let value = e.target.value;
+	let form = e.target.form;
+	let old_area = Morebits.quickForm.getElements(e.target.form, 'work_area')[0];
+	let work_area = null;
 
-	var oldreasontextbox = form.getElementsByTagName('textarea')[0];
-	var oldreason = oldreasontextbox ? oldreasontextbox.value : '';
+	let oldreasontextbox = form.getElementsByTagName('textarea')[0];
+	let oldreason = oldreasontextbox ? oldreasontextbox.value : '';
 
-	var appendReasonBox = function twinklexfdAppendReasonBox() {
+	let appendReasonBox = function twinklexfdAppendReasonBox() {
 		work_area.append({
 			type: 'textarea',
 			name: 'reason',
@@ -358,12 +358,12 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			// grab deletion sort categories from en-wiki
 			Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
-				var $select = $('[name="delsortCats"]');
+				let $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
-					var $optgroup = $('<optgroup>').attr('label', groupname);
-					var $delsortCat = $select.append($optgroup);
+					let $optgroup = $('<optgroup>').attr('label', groupname);
+					let $delsortCat = $select.append($optgroup);
 					list.forEach(function(item) {
-						var $option = $('<option>').val(item).text(item);
+						let $option = $('<option>').val(item).text(item);
 						$delsortCat.append($option);
 					});
 				});
@@ -424,7 +424,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Choose type of action wanted:',
 				name: 'xfdcat',
 				event: function(e) {
-					var target = e.target,
+					let target = e.target,
 						tfdtarget = target.form.tfdtarget;
 					// add/remove extra input box
 					if (target.value === 'tfm' && !tfdtarget) {
@@ -554,7 +554,7 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 				label: 'Choose type of action wanted:',
 				name: 'xfdcat',
 				event: function(e) {
-					var value = e.target.value,
+					let value = e.target.value,
 						cfdtarget = e.target.form.cfdtarget,
 						cfdtarget2 = e.target.form.cfdtarget2;
 
@@ -753,17 +753,17 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 Twinkle.xfd.callbacks = {
 	// Requires having the tag text (params.tagText) set ahead of time
 	autoEditRequest: function(pageobj, params) {
-		var talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
+		let talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
 		if (talkName === pageobj.getPageName()) {
 			pageobj.getStatusElement().error('Page protected and nowhere to add an edit request, aborting');
 		} else {
 			pageobj.getStatusElement().warn('Page protected, requesting edit');
 
-			var editRequest = '{{subst:Xfd edit protected|page=' + pageobj.getPageName() +
+			let editRequest = '{{subst:Xfd edit protected|page=' + pageobj.getPageName() +
 				'|discussion=' + params.discussionpage + (params.venue === 'rfd' ? '|rfd=yes' : '') +
 				'|tag=<nowiki>' + params.tagText + '\u003C/nowiki>}}'; // U+003C: <
 
-			var talk_page = new Morebits.wiki.page(talkName, 'Automatically posting edit request on talk page');
+			let talk_page = new Morebits.wiki.page(talkName, 'Automatically posting edit request on talk page');
 			talk_page.setNewSectionTitle('Edit request to complete ' + utils.toTLACase(params.venue) + ' nomination');
 			talk_page.setNewSectionText(editRequest);
 			talk_page.setCreateOption('recreate');
@@ -784,7 +784,7 @@ Twinkle.xfd.callbacks = {
 		}
 		if (venue === 'rm') {
 			if (params.rmtr) {
-				var rmtrDiscuss = params['rmtr-discuss'] ? '|discuss=no' : '';
+				let rmtrDiscuss = params['rmtr-discuss'] ? '|discuss=no' : '';
 				return params.currentname
 					.map((currentname, i) => `{{subst:RMassist|1=${currentname}|2=${params.newname[i]}${rmtrDiscuss}|reason=${params.reason}}}`)
 					.join('\n');
@@ -796,8 +796,8 @@ Twinkle.xfd.callbacks = {
 			}|reason=${params.reason}}}`;
 		}
 
-		var text = '{{subst:' + venue + '2';
-		var reasonKey = venue === 'ffd' ? 'Reason' : 'text';
+		let text = '{{subst:' + venue + '2';
+		let reasonKey = venue === 'ffd' ? 'Reason' : 'text';
 		// Add a reason unconditionally, so that at least a signature is added
 		text += '|' + reasonKey + '=' + Morebits.string.formatReasonText(params.reason, true);
 
@@ -843,7 +843,7 @@ Twinkle.xfd.callbacks = {
 		return text;
 	},
 	showPreview: function(form, venue, params) {
-		var templatetext = Twinkle.xfd.callbacks.getDiscussionWikitext(venue, params);
+		let templatetext = Twinkle.xfd.callbacks.getDiscussionWikitext(venue, params);
 		if (venue === 'rm') { // RM templates are sensitive to page title
 			form.previewer.beginRender(templatetext, params.rmtr ? 'Wikipedia:Requested moves/Technical requests' : new mw.Title(Morebits.pageNameNorm).getTalkPage().toText());
 		} else {
@@ -852,9 +852,9 @@ Twinkle.xfd.callbacks = {
 	},
 	preview: function(form) {
 		// venue, reason, xfdcat, tfdtarget, cfdtarget, cfdtarget2, cfdstarget, delsortCats, newname
-		var params = Morebits.quickForm.getInputData(form);
+		let params = Morebits.quickForm.getInputData(form);
 
-		var venue = params.venue;
+		let venue = params.venue;
 
 		// Remove CfD or TfD namespace prefixes if given
 		if (params.tfdtarget) {
@@ -870,7 +870,7 @@ Twinkle.xfd.callbacks = {
 
 		if (venue === 'ffd') {
 			// Fetch the uploader
-			var page = new Morebits.wiki.page(mw.config.get('wgPageName'));
+			let page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			page.lookupCreation(function() {
 				params.uploader = page.getCreator();
 				Twinkle.xfd.callbacks.showPreview(form, venue, params);
@@ -901,8 +901,8 @@ Twinkle.xfd.callbacks = {
 		// up at user talkspace as expected, but retain the
 		// prefix-less username for addToLog
 		notifyTarget = mw.Title.newFromText(notifyTarget, 3);
-		var targetNS = notifyTarget.getNamespaceId();
-		var usernameOrTarget = notifyTarget.getRelativeText(3);
+		let targetNS = notifyTarget.getNamespaceId();
+		let usernameOrTarget = notifyTarget.getRelativeText(3);
 		notifyTarget = notifyTarget.toText();
 		if (targetNS === 3) {
 			// Disallow warning yourself
@@ -919,7 +919,7 @@ Twinkle.xfd.callbacks = {
 			actionName = actionName || 'Notifying initial contributor (' + usernameOrTarget + ')';
 		}
 
-		var notifytext = '\n{{subst:' + params.venue + ' notice';
+		let notifytext = '\n{{subst:' + params.venue + ' notice';
 		// Venue-specific parameters
 		switch (params.venue) {
 			case 'afd':
@@ -940,7 +940,7 @@ Twinkle.xfd.callbacks = {
 		notifytext += '|1=' + Morebits.pageNameNorm + '}} ~~~~';
 
 		// Link to the venue; object used here rather than repetitive items in switch
-		var venueNames = {
+		let venueNames = {
 			afd: 'Articles for deletion',
 			tfd: 'Templates for discussion',
 			mfd: 'Miscellany for deletion',
@@ -948,10 +948,10 @@ Twinkle.xfd.callbacks = {
 			ffd: 'Files for discussion',
 			rfd: 'Redirects for discussion'
 		};
-		var editSummary = 'Notification: [[' + params.discussionpage + '|listing]] of [[:' +
+		let editSummary = 'Notification: [[' + params.discussionpage + '|listing]] of [[:' +
 			Morebits.pageNameNorm + ']] at [[WP:' + venueNames[params.venue] + ']].';
 
-		var usertalkpage = new Morebits.wiki.page(notifyTarget, actionName);
+		let usertalkpage = new Morebits.wiki.page(notifyTarget, actionName);
 		usertalkpage.setAppendText(notifytext);
 		usertalkpage.setEditSummary(editSummary);
 		usertalkpage.setChangeTags(Twinkle.changeTags);
@@ -985,7 +985,7 @@ Twinkle.xfd.callbacks = {
 			return;
 		}
 
-		var usl = new Morebits.userspaceLogger(Twinkle.getPref('xfdLogPageName'));// , 'Adding entry to userspace log');
+		let usl = new Morebits.userspaceLogger(Twinkle.getPref('xfdLogPageName'));// , 'Adding entry to userspace log');
 
 		usl.initialText =
 			"This is a log of all [[WP:XFD|deletion discussion]] nominations made by this user using [[WP:TW|Twinkle]]'s XfD module.\n\n" +
@@ -993,7 +993,7 @@ Twinkle.xfd.callbacks = {
 			'nominate this page for speedy deletion under [[WP:CSD#U1|CSD U1]].' +
 			(Morebits.userIsSysop ? '\n\nThis log does not track XfD-related deletions made using Twinkle.' : '');
 
-		var editsummary;
+		let editsummary;
 		if (params.discussionpage) {
 			editsummary = 'Logging [[' + params.discussionpage + '|' + utils.toTLACase(params.venue) + ' nomination]] of [[:' + Morebits.pageNameNorm + ']].';
 		} else {
@@ -1001,18 +1001,18 @@ Twinkle.xfd.callbacks = {
 		}
 
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-		var fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
+		let fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
 		// CFD/S and RM don't have canonical links
-		var nominatedLink = params.discussionpage ? '[[' + params.discussionpage + '|nominated]]' : 'nominated';
+		let nominatedLink = params.discussionpage ? '[[' + params.discussionpage + '|nominated]]' : 'nominated';
 
-		var appendText = '# [[:' + Morebits.pageNameNorm + ']]:' + fileLogLink + ' ' + nominatedLink + ' at [[WP:' + params.venue.toUpperCase() + '|' + utils.toTLACase(params.venue) + ']]';
+		let appendText = '# [[:' + Morebits.pageNameNorm + ']]:' + fileLogLink + ' ' + nominatedLink + ' at [[WP:' + params.venue.toUpperCase() + '|' + utils.toTLACase(params.venue) + ']]';
 
 		switch (params.venue) {
 			case 'tfd':
 				if (params.xfdcat === 'tfm') {
 					appendText += ' (merge)';
 					if (params.tfdtarget) {
-						var contentModel = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'Module:' : 'Template:';
+						let contentModel = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'Module:' : 'Template:';
 						appendText += '; Other ' + contentModel.toLowerCase() + ' [[';
 						if (!new RegExp('^:?' + Morebits.namespaceRegex([10, 828]) + ':', 'i').test(params.tfdtarget)) {
 							appendText += contentModel;
@@ -1029,7 +1029,7 @@ Twinkle.xfd.callbacks = {
 			case 'cfd':
 				appendText += ' (' + utils.toTLACase(params.xfdcat) + ')';
 				if (params.cfdtarget) {
-					var categoryOrTemplate = params.xfdcat.charAt(0) === 's' ? 'Template:' : ':Category:';
+					let categoryOrTemplate = params.xfdcat.charAt(0) === 's' ? 'Template:' : ':Category:';
 					appendText += '; ' + params.action + ' to [[' + categoryOrTemplate + params.cfdtarget + ']]';
 					if (params.xfdcat === 'cfs' && params.cfdtarget2) {
 						appendText += ', [[' + categoryOrTemplate + params.cfdtarget2 + ']]';
@@ -1078,16 +1078,16 @@ Twinkle.xfd.callbacks = {
 
 	afd: {
 		main: function(apiobj) {
-			var response = apiobj.getResponse();
-			var titles = response.query.allpages;
+			let response = apiobj.getResponse();
+			let titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
 				apiobj.params.numbering = apiobj.params.number = '';
 			} else {
-				var number = 0;
-				for (var i = 0; i < titles.length; ++i) {
-					var title = titles[i].title;
+				let number = 0;
+				for (let i = 0; i < titles.length; ++i) {
+					let title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Articles for deletion/' + Morebits.pageNameNorm) {
@@ -1095,10 +1095,10 @@ Twinkle.xfd.callbacks = {
 						continue;
 					}
 
-					var order_re = new RegExp('^' +
+					let order_re = new RegExp('^' +
 						Morebits.string.escapeRegExp('Wikipedia:Articles for deletion/' + Morebits.pageNameNorm) +
 						'\\s*\\(\\s*(\\d+)(?:(?:th|nd|rd|st) nom(?:ination)?)?\\s*\\)\\s*$');
-					var match = order_re.exec(title);
+					let match = order_re.exec(title);
 
 					// No match; A non-good value
 					// Or the match is an unrealistically high number. Avoid false positives such as Wikipedia:Articles for deletion/The Basement (2014), by ignoring matches greater than 100
@@ -1121,7 +1121,7 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = 'Nomination completed, now redirecting to the discussion page';
 
 			// Tagging article
-			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to article');
+			let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to article');
 			wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the article is moved, we would want to follow the redirect
 			wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 			wikipedia_page.setCallbackParameters(apiobj.params);
@@ -1129,9 +1129,9 @@ Twinkle.xfd.callbacks = {
 		},
 		// Tagging needs to happen before everything else: this means we can check if there is an AfD tag already on the page
 		taggingArticle: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist; perhaps it has already been deleted");
@@ -1139,7 +1139,7 @@ Twinkle.xfd.callbacks = {
 			}
 
 			// Check for existing AfD tag, for the benefit of new page patrollers
-			var textNoAfd = text.replace(/<!--.*AfD.*\n\{\{(?:Article for deletion\/dated|AfDM).*\}\}\n<!--.*(?:\n<!--.*)?AfD.*(?:\s*\n)?/g, '');
+			let textNoAfd = text.replace(/<!--.*AfD.*\n\{\{(?:Article for deletion\/dated|AfDM).*\}\}\n<!--.*(?:\n<!--.*)?AfD.*(?:\s*\n)?/g, '');
 			if (text !== textNoAfd) {
 				if (confirm('An AfD tag was found on this article. Maybe someone beat you to it.  \nClick OK to replace the current AfD tag (not recommended), or Cancel to abandon your nomination.')) {
 					text = textNoAfd;
@@ -1158,12 +1158,12 @@ Twinkle.xfd.callbacks = {
 			}
 
 			// Start discussion page, will also handle pagetriage and delsort listings
-			var wikipedia_page = new Morebits.wiki.page(params.discussionpage, 'Creating article deletion discussion page');
+			let wikipedia_page = new Morebits.wiki.page(params.discussionpage, 'Creating article deletion discussion page');
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.discussionPage);
 
 			// Today's list
-			var date = new Morebits.date(pageobj.getLoadTime());
+			let date = new Morebits.date(pageobj.getLoadTime());
 			wikipedia_page = new Morebits.wiki.page('Wikipedia:Articles for deletion/Log/' +
 				date.format('YYYY MMMM D', 'utc'), "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
@@ -1171,7 +1171,7 @@ Twinkle.xfd.callbacks = {
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.todaysList);
 			// Notification to first contributor
 			if (params.notifycreator) {
-				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
 				thispage.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 				thispage.lookupCreation(function(pageobj) {
@@ -1189,13 +1189,13 @@ Twinkle.xfd.callbacks = {
 			// Remove some tags that should always be removed on AfD.
 				text = text.replace(/\{\{\s*(dated prod|dated prod blp|Prod blp\/dated|Proposed deletion\/dated|prod2|Proposed deletion endorsed|Userspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
 				// Then, test if there are speedy deletion-related templates on the article.
-				var textNoSd = text.replace(/\{\{\s*(db(-\w*)?|delete|(?:hang|hold)[- ]?on)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
+				let textNoSd = text.replace(/\{\{\s*(db(-\w*)?|delete|(?:hang|hold)[- ]?on)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
 				if (text !== textNoSd && confirm('A speedy deletion tag was found on this page. Should it be removed?')) {
 					text = textNoSd;
 				}
 
 				// Insert tag after short description or any hatnotes
-				var wikipage = new Morebits.wikitext.page(text);
+				let wikipage = new Morebits.wikitext.page(text);
 				text = wikipage.insertAfterTemplates(params.tagText, Twinkle.hatnoteRegex).getText();
 
 				pageobj.setPageText(text);
@@ -1208,7 +1208,7 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		discussionPage: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('afd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
@@ -1223,7 +1223,7 @@ Twinkle.xfd.callbacks = {
 				// List at deletion sorting pages
 				if (params.delsortCats) {
 					params.delsortCats.forEach(function (cat) {
-						var delsortPage = new Morebits.wiki.page('Wikipedia:WikiProject Deletion sorting/' + cat, 'Adding to list of ' + cat + '-related deletion discussions');
+						let delsortPage = new Morebits.wiki.page('Wikipedia:WikiProject Deletion sorting/' + cat, 'Adding to list of ' + cat + '-related deletion discussions');
 						delsortPage.setFollowRedirect(true); // In case a category gets renamed
 						delsortPage.setCallbackParameters({discussionPage: params.discussionpage});
 						delsortPage.load(Twinkle.xfd.callbacks.afd.delsortListing);
@@ -1232,21 +1232,21 @@ Twinkle.xfd.callbacks = {
 			});
 		},
 		todaysList: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var added_data = '{{subst:afd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}\n';
-			var text;
+			let added_data = '{{subst:afd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}\n';
+			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:AfD log}}\n' + added_data;
 			} else {
-				var old_text = pageobj.getPageText() + '\n';  // MW strips trailing blanks, but we like them, so we add a fake one
+				let old_text = pageobj.getPageText() + '\n';  // MW strips trailing blanks, but we like them, so we add a fake one
 
 				text = old_text.replace(/(<!-- Add new entries to the TOP of the following list -->\n+)/, '$1' + added_data);
 				if (text === old_text) {
-					var linknode = document.createElement('a');
+					let linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing AFD') + '?action=purge');
 					linknode.appendChild(document.createTextNode('How to fix AFD'));
 					statelem.error([ 'Could not find the target spot for the discussion. To fix this problem, please see ', linknode, '.' ]);
@@ -1262,8 +1262,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.save();
 		},
 		delsortListing: function(pageobj) {
-			var discussionPage = pageobj.getCallbackParameters().discussionPage;
-			var text = pageobj.getPageText().replace('directly below this line -->', 'directly below this line -->\n{{' + discussionPage + '}}');
+			let discussionPage = pageobj.getCallbackParameters().discussionPage;
+			let text = pageobj.getPageText().replace('directly below this line -->', 'directly below this line -->\n{{' + discussionPage + '}}');
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Listing [[:' + discussionPage + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
@@ -1275,18 +1275,18 @@ Twinkle.xfd.callbacks = {
 
 	tfd: {
 		main: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
-			var date = new Morebits.date(pageobj.getLoadTime());
+			let date = new Morebits.date(pageobj.getLoadTime());
 			params.logpage = 'Wikipedia:Templates for discussion/Log/' + date.format('YYYY MMMM D', 'utc'),
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 			// Add log/discussion page params to the already-loaded page object
 			pageobj.setCallbackParameters(params);
 
 			// Defined here rather than below to reduce duplication
-			var watchModule, watch_query;
+			let watchModule, watch_query;
 			if (params.scribunto) {
-				var watchPref = Twinkle.getPref('xfdWatchPage');
+				let watchPref = Twinkle.getPref('xfdWatchPage');
 				// action=watch has no way to rely on user
 				// preferences (T262912), so we do it manually.
 				// The watchdefault pref appears to reliably return '1' (string),
@@ -1307,7 +1307,7 @@ Twinkle.xfd.callbacks = {
 
 			// Tagging template(s)/module(s)
 			if (params.xfdcat === 'tfm') { // Merge
-				var wikipedia_otherpage;
+				let wikipedia_otherpage;
 				if (params.scribunto) {
 					wikipedia_otherpage = new Morebits.wiki.page(params.otherTemplateName + '/doc', 'Tagging other module documentation with merge tag');
 
@@ -1324,7 +1324,7 @@ Twinkle.xfd.callbacks = {
 
 				// Tag other template/module
 				wikipedia_otherpage.setFollowRedirect(true);
-				var otherParams = $.extend({}, params);
+				let otherParams = $.extend({}, params);
 				otherParams.otherTemplateName = Morebits.pageNameNorm;
 				wikipedia_otherpage.setCallbackParameters(otherParams);
 				wikipedia_otherpage.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
@@ -1344,15 +1344,15 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = "Nomination completed, now redirecting to today's log";
 
 			// Adding discussion
-			var wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's log");
+			let wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's log");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.tfd.todaysList);
 
 			// Notification to first contributors
 			if (params.notifycreator) {
-				var involvedpages = [];
-				var seenusers = [];
+				let involvedpages = [];
+				let seenusers = [];
 				involvedpages.push(new Morebits.wiki.page(mw.config.get('wgPageName')));
 				if (params.xfdcat === 'tfm') {
 					if (params.scribunto) {
@@ -1364,7 +1364,7 @@ Twinkle.xfd.callbacks = {
 				involvedpages.forEach(function(page) {
 					page.setCallbackParameters(params);
 					page.lookupCreation(function(innerpage) {
-						var username = innerpage.getCreator();
+						let username = innerpage.getCreator();
 						if (seenusers.indexOf(username) === -1) {
 							seenusers.push(username);
 							// Only log once on merge nominations, for the initial template
@@ -1380,8 +1380,8 @@ Twinkle.xfd.callbacks = {
 
 			// Notify developer(s) of script(s) that use(s) the nominated template
 			if (params.devpages) {
-				var inCategories = mw.config.get('wgCategories');
-				var categoryNotificationPageMap = {
+				let inCategories = mw.config.get('wgCategories');
+				let categoryNotificationPageMap = {
 					'Templates used by Twinkle': 'Wikipedia talk:Twinkle',
 					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
 					'Templates used by Ultraviolet': 'Wikipedia talk:Ultraviolet'
@@ -1395,8 +1395,8 @@ Twinkle.xfd.callbacks = {
 
 		},
 		taggingTemplate: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:template for discussion|help=off' + (params.templatetype !== 'standard' ? '|type=' + params.templatetype : '') + '}}';
 
@@ -1423,8 +1423,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingTemplateForMerge: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:tfm|help=off|' + (params.templatetype !== 'standard' ? 'type=' + params.templatetype + '|' : '') +
 				'1=' + params.otherTemplateName.replace(new RegExp('^' + Morebits.namespaceRegex([10, 828]) + ':'), '') + '}}';
@@ -1452,17 +1452,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
-			var text;
+			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
+			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:TfD log}}\n' + added_data;
 			} else {
-				var old_text = pageobj.getPageText();
+				let old_text = pageobj.getPageText();
 
 				text = old_text.replace('-->', '-->\n' + added_data);
 				if (text === old_text) {
@@ -1485,16 +1485,16 @@ Twinkle.xfd.callbacks = {
 
 	mfd: {
 		main: function(apiobj) {
-			var response = apiobj.getResponse();
-			var titles = response.query.allpages;
+			let response = apiobj.getResponse();
+			let titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
 				apiobj.params.numbering = apiobj.params.number = '';
 			} else {
-				var number = 0;
-				for (var i = 0; i < titles.length; ++i) {
-					var title = titles[i].title;
+				let number = 0;
+				for (let i = 0; i < titles.length; ++i) {
+					let title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Miscellany for deletion/' + Morebits.pageNameNorm) {
@@ -1502,10 +1502,10 @@ Twinkle.xfd.callbacks = {
 						continue;
 					}
 
-					var order_re = new RegExp('^' +
+					let order_re = new RegExp('^' +
 							Morebits.string.escapeRegExp('Wikipedia:Miscellany for deletion/' + Morebits.pageNameNorm) +
 							'\\s*\\(\\s*(\\d+)(?:(?:th|nd|rd|st) nom(?:ination)?)?\\s*\\)\\s*$');
-					var match = order_re.exec(title);
+					let match = order_re.exec(title);
 
 					// No match; A non-good value
 					if (!match) {
@@ -1522,7 +1522,7 @@ Twinkle.xfd.callbacks = {
 
 			apiobj.statelem.info('next in order is [[' + apiobj.params.discussionpage + ']]');
 
-			var wikipedia_page;
+			let wikipedia_page;
 
 			// Tagging page
 			if (mw.config.get('wgNamespaceNumber') !== 710) { // cannot tag TimedText pages
@@ -1550,7 +1550,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notification to first contributor and/or notification to owner of userspace
 			if (apiobj.params.notifycreator || apiobj.params.notifyuserspace) {
-				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(apiobj.params);
 				thispage.lookupCreation(Twinkle.xfd.callbacks.mfd.sendNotifications);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1559,8 +1559,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingPage: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{' + (params.number === '' ? 'mfd' : 'mfdx|' + params.number) + '|help=off}}';
 
@@ -1585,7 +1585,7 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		discussionPage: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('mfd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
@@ -1597,14 +1597,14 @@ Twinkle.xfd.callbacks = {
 			});
 		},
 		todaysList: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var date = new Morebits.date(pageobj.getLoadTime());
-			var date_header = date.format('===MMMM D, YYYY===\n', 'utc');
-			var date_header_regex = new RegExp(date.format('(===[\\s]*MMMM[\\s]+D,[\\s]+YYYY[\\s]*===)', 'utc'));
-			var added_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
+			let date = new Morebits.date(pageobj.getLoadTime());
+			let date_header = date.format('===MMMM D, YYYY===\n', 'utc');
+			let date_header_regex = new RegExp(date.format('(===[\\s]*MMMM[\\s]+D,[\\s]+YYYY[\\s]*===)', 'utc'));
+			let added_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
 
 			if (date_header_regex.test(text)) { // we have a section already
 				statelem.info('Found today\'s section, proceeding to add new entry');
@@ -1622,8 +1622,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.save();
 		},
 		sendNotifications: function(pageobj) {
-			var initialContrib = pageobj.getCreator();
-			var params = pageobj.getCallbackParameters();
+			let initialContrib = pageobj.getCreator();
+			let params = pageobj.getCallbackParameters();
 
 			// Notify the creator
 			if (params.notifycreator) {
@@ -1649,10 +1649,10 @@ Twinkle.xfd.callbacks = {
 
 	ffd: {
 		taggingImage: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
-			var date = new Morebits.date(pageobj.getLoadTime()).format('YYYY MMMM D', 'utc');
+			let date = new Morebits.date(pageobj.getLoadTime()).format('YYYY MMMM D', 'utc');
 			params.logpage = 'Wikipedia:Files for discussion/' + date;
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
@@ -1675,18 +1675,18 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = 'Nomination completed, now redirecting to the discussion page';
 
 			// Contributor specific edits
-			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
+			let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.lookupCreation(Twinkle.xfd.callbacks.ffd.main);
 		},
 		main: function(pageobj) {
 			// this is coming in from lookupCreation...!
-			var params = pageobj.getCallbackParameters();
-			var initialContrib = pageobj.getCreator();
+			let params = pageobj.getCallbackParameters();
+			let initialContrib = pageobj.getCreator();
 			params.uploader = initialContrib;
 
 			// Adding discussion
-			var wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
+			let wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.ffd.todaysList);
@@ -1700,8 +1700,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
@@ -1722,9 +1722,9 @@ Twinkle.xfd.callbacks = {
 
 	cfd: {
 		main: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
-			var date = new Morebits.date(pageobj.getLoadTime());
+			let date = new Morebits.date(pageobj.getLoadTime());
 			params.logpage = 'Wikipedia:Categories for discussion/Log/' + date.format('YYYY MMMM D', 'utc');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 			// Add log/discussion page params to the already-loaded page object
@@ -1738,7 +1738,7 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = "Nomination completed, now redirecting to today's log";
 
 			// Adding discussion to list
-			var wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
+			let wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.cfd.todaysList);
@@ -1756,11 +1756,11 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingCategory: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:' + params.xfdcat;
-			var editsummary = (mw.config.get('wgNamespaceNumber') === 14 ? 'Category' : 'Stub template') +
+			let editsummary = (mw.config.get('wgNamespaceNumber') === 14 ? 'Category' : 'Stub template') +
 				' being considered for ' + params.action;
 			switch (params.xfdcat) {
 				case 'cfd':
@@ -1796,17 +1796,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
-			var text;
+			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
+			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:CfD log}}\n' + added_data;
 			} else {
-				var old_text = pageobj.getPageText();
+				let old_text = pageobj.getPageText();
 
 				text = old_text.replace('below this line -->', 'below this line -->\n' + added_data);
 				if (text === old_text) {
@@ -1829,8 +1829,8 @@ Twinkle.xfd.callbacks = {
 
 	cfds: {
 		taggingCategory: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 			if (params.xfdcat === 'C2F') {
 				params.tagText = '{{subst:cfm-speedy|1=' + params.cfdstarget.replace(/^:?Category:/, '') + '}}\n';
 			} else {
@@ -1854,11 +1854,11 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		addToList: function(pageobj) {
-			var old_text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let old_text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var text = old_text.replace('BELOW THIS LINE -->', 'BELOW THIS LINE -->\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('cfds', params));
+			let text = old_text.replace('BELOW THIS LINE -->', 'BELOW THIS LINE -->\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('cfds', params));
 			if (text === old_text) {
 				statelem.error('failed to find target spot for the discussion');
 				return;
@@ -1881,7 +1881,7 @@ Twinkle.xfd.callbacks = {
 		findTarget: function(params, callback) {
 			// Used by regular redirects to find the target, but for all redirects,
 			// avoid relying on the client clock to build the log page
-			var query = {
+			let query = {
 				action: 'query',
 				curtimestamp: true,
 				format: 'json'
@@ -1895,20 +1895,20 @@ Twinkle.xfd.callbacks = {
 				query.titles = mw.config.get('wgPageName');
 				query.redirects = true;
 			}
-			var wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
+			let wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
 			wikipedia_api.params = params;
 			wikipedia_api.post();
 		},
 		// This is a closure for the callback from the above API request, which gets the target of the redirect
 		findTargetCallback: function(callback) {
 			return function(apiobj) {
-				var response = apiobj.getResponse();
+				let response = apiobj.getResponse();
 				apiobj.params.curtimestamp = response.curtimestamp;
 
 				if (!apiobj.params.rfdtarget) { // Not a softredirect
-					var target = response.query.redirects && response.query.redirects[0].to;
+					let target = response.query.redirects && response.query.redirects[0].to;
 					if (!target) {
-						var message = 'No target found. this page does not appear to be a redirect, aborting';
+						let message = 'No target found. this page does not appear to be a redirect, aborting';
 						if (mw.config.get('wgAction') === 'history') {
 							message += '. If this is a soft redirect, try again from the content page, not the page history.';
 						}
@@ -1916,19 +1916,19 @@ Twinkle.xfd.callbacks = {
 						return;
 					}
 					apiobj.params.rfdtarget = target;
-					var section = response.query.redirects[0].tofragment;
+					let section = response.query.redirects[0].tofragment;
 					apiobj.params.section = section;
 				}
 				callback(apiobj.params);
 			};
 		},
 		main: function(params) {
-			var date = new Morebits.date(params.curtimestamp);
+			let date = new Morebits.date(params.curtimestamp);
 			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.format('YYYY MMMM D', 'utc');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
 			// Tagging redirect
-			var wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to redirect');
+			let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to redirect');
 			wikipedia_page.setFollowRedirect(false);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.rfd.taggingRedirect);
@@ -1945,7 +1945,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notifications
 			if (params.notifycreator || params.relatedpage) {
-				var thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
 				thispage.lookupCreation(Twinkle.xfd.callbacks.rfd.sendNotifications);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1954,8 +1954,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingRedirect: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
 			// Imperfect for edit request but so be it
 			params.tagText = '{{subst:rfd|' + (mw.config.get('wgNamespaceNumber') === 10 ? 'showontransclusion=1|' : '') + 'content=\n';
 
@@ -1971,17 +1971,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var added_data = Twinkle.xfd.callbacks.getDiscussionWikitext('rfd', params);
-			var text;
+			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext('rfd', params);
+			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:RfD log}}' + added_data;
 			} else {
-				var old_text = pageobj.getPageText();
+				let old_text = pageobj.getPageText();
 				text = old_text.replace(/(<!-- Add new entries directly below this line\.? -->)/, '$1\n' + added_data);
 				if (text === old_text) {
 					statelem.error('failed to find target spot for the discussion');
@@ -1999,9 +1999,9 @@ Twinkle.xfd.callbacks = {
 			});
 		},
 		sendNotifications: function(pageobj) {
-			var initialContrib = pageobj.getCreator();
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let initialContrib = pageobj.getCreator();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
 			// Notifying initial contributor
 			if (params.notifycreator) {
@@ -2010,7 +2010,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notifying target page's watchers, if not a soft redirect
 			if (params.relatedpage) {
-				var targetTalk = new mw.Title(params.rfdtarget).getTalkPage();
+				let targetTalk = new mw.Title(params.rfdtarget).getTalkPage();
 
 				// On the offchance it's a circular redirect
 				if (params.rfdtarget === mw.config.get('wgPageName')) {
@@ -2038,7 +2038,7 @@ Twinkle.xfd.callbacks = {
 
 	rm: {
 		listAtTalk: function(pageobj) {
-			var params = pageobj.getCallbackParameters();
+			let params = pageobj.getCallbackParameters();
 
 			pageobj.setAppendText('\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to [[:' + params.newname + ']]' : ''));
@@ -2053,12 +2053,12 @@ Twinkle.xfd.callbacks = {
 		},
 
 		listAtRMTR: function(pageobj) {
-			var text = pageobj.getPageText();
-			var params = pageobj.getCallbackParameters();
-			var statelem = pageobj.getStatusElement();
+			let text = pageobj.getPageText();
+			let params = pageobj.getCallbackParameters();
+			let statelem = pageobj.getStatusElement();
 
-			var discussionWikitext = Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params);
-			var newtext = Twinkle.xfd.insertRMTR(text, discussionWikitext);
+			let discussionWikitext = Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params);
+			let newtext = Twinkle.xfd.insertRMTR(text, discussionWikitext);
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;
@@ -2082,14 +2082,14 @@ Twinkle.xfd.callbacks = {
  * @return {String} pageWikitext
  */
 Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
-	var placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
+	let placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
 	return pageWikitext.replace(placementRE, '\n' + wikitextToInsert + '\n\n$1');
 };
 
 Twinkle.xfd.callback.evaluate = function(e) {
-	var form = e.target;
+	let form = e.target;
 
-	var params = Morebits.quickForm.getInputData(form);
+	let params = Morebits.quickForm.getInputData(form);
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);
@@ -2097,7 +2097,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 	Twinkle.xfd.currentRationale = params.reason;
 	Morebits.status.onError(Twinkle.xfd.printRationale);
 
-	var query, wikipedia_page, wikipedia_api;
+	let query, wikipedia_page, wikipedia_api;
 	switch (params.venue) {
 
 		case 'afd': // AFD

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -2254,7 +2254,7 @@ Twinkle.xfd.callback.evaluate = function(e) {
 };
 
 Twinkle.addInitCallback(Twinkle.xfd, 'xfd');
-})(jQuery);
+}(jQuery));
 
 
 // </nowiki>

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -208,7 +208,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	});
 
 	const previewlink = document.createElement('a');
-	$(previewlink).click(function() {
+	$(previewlink).click(() => {
 		Twinkle.xfd.callbacks.preview(result);  // |result| is defined below
 	});
 	previewlink.style.cursor = 'pointer';
@@ -357,12 +357,12 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 			});
 
 			// grab deletion sort categories from en-wiki
-			Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
+			Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then((delsortCategories) => {
 				const $select = $('[name="delsortCats"]');
-				$.each(delsortCategories, function(groupname, list) {
+				$.each(delsortCategories, (groupname, list) => {
 					const $optgroup = $('<optgroup>').attr('label', groupname);
 					const $delsortCat = $select.append($optgroup);
-					list.forEach(function(item) {
+					list.forEach((item) => {
 						const $option = $('<option>').val(item).text(item);
 						$delsortCat.append($option);
 					});
@@ -771,7 +771,7 @@ Twinkle.xfd.callbacks = {
 			talk_page.setFollowRedirect(true);  // should never be needed, but if the article is moved, we would want to follow the redirect
 			talk_page.setChangeTags(Twinkle.changeTags);
 			talk_page.setCallbackParameters(params);
-			talk_page.newSection(null, function() {
+			talk_page.newSection(null, () => {
 				talk_page.getStatusElement().warn('Unable to add edit request, the talk page may be protected');
 			});
 		}
@@ -871,12 +871,12 @@ Twinkle.xfd.callbacks = {
 		if (venue === 'ffd') {
 			// Fetch the uploader
 			const page = new Morebits.wiki.page(mw.config.get('wgPageName'));
-			page.lookupCreation(function() {
+			page.lookupCreation(() => {
 				params.uploader = page.getCreator();
 				Twinkle.xfd.callbacks.showPreview(form, venue, params);
 			});
 		} else if (venue === 'rfd') { // Find the target
-			Twinkle.xfd.callbacks.rfd.findTarget(params, function(params) {
+			Twinkle.xfd.callbacks.rfd.findTarget(params, (params) => {
 				Twinkle.xfd.callbacks.showPreview(form, venue, params);
 			});
 		} else if (venue === 'cfd') { // Swap in CfD subactions
@@ -967,14 +967,14 @@ Twinkle.xfd.callbacks = {
 		if (noLog) {
 			usertalkpage.append();
 		} else {
-			usertalkpage.append(function onNotifySuccess() {
+			usertalkpage.append(() => {
 				// Don't treat RfD target or MfD userspace owner as initialContrib in log
 				if (!params.notifycreator) {
 					notifyTarget = null;
 				}
 				// add this nomination to the user's userspace log
 				Twinkle.xfd.callbacks.addToLog(params, usernameOrTarget);
-			}, function onNotifyError() {
+			}, () => {
 				// if user could not be notified, log nomination without mentioning that notification was sent
 				Twinkle.xfd.callbacks.addToLog(params, null);
 			});
@@ -1174,7 +1174,7 @@ Twinkle.xfd.callbacks = {
 				const thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
 				thispage.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
-				thispage.lookupCreation(function(pageobj) {
+				thispage.lookupCreation((pageobj) => {
 					Twinkle.xfd.callbacks.notifyUser(pageobj.getCallbackParameters(), pageobj.getCreator());
 				});
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1215,14 +1215,14 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 
 				// Actions that should wait on the discussion page actually being created
 				// and whose errors shouldn't output the user rationale
 				// List at deletion sorting pages
 				if (params.delsortCats) {
-					params.delsortCats.forEach(function (cat) {
+					params.delsortCats.forEach((cat) => {
 						const delsortPage = new Morebits.wiki.page('Wikipedia:WikiProject Deletion sorting/' + cat, 'Adding to list of ' + cat + '-related deletion discussions');
 						delsortPage.setFollowRedirect(true); // In case a category gets renamed
 						delsortPage.setCallbackParameters({discussionPage: params.discussionpage});
@@ -1361,9 +1361,9 @@ Twinkle.xfd.callbacks = {
 						involvedpages.push(new Morebits.wiki.page('Template:' + params.tfdtarget));
 					}
 				}
-				involvedpages.forEach(function(page) {
+				involvedpages.forEach((page) => {
 					page.setCallbackParameters(params);
-					page.lookupCreation(function(innerpage) {
+					page.lookupCreation((innerpage) => {
 						const username = innerpage.getCreator();
 						if (seenusers.indexOf(username) === -1) {
 							seenusers.push(username);
@@ -1386,7 +1386,7 @@ Twinkle.xfd.callbacks = {
 					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
 					'Templates used by Ultraviolet': 'Wikipedia talk:Ultraviolet'
 				};
-				$.each(categoryNotificationPageMap, function(category, page) {
+				$.each(categoryNotificationPageMap, (category, page) => {
 					if (inCategories.indexOf(category) !== -1) {
 						Twinkle.xfd.callbacks.notifyUser(params, page, true, 'Notifying ' + page + ' of template nomination');
 					}
@@ -1476,7 +1476,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		}
@@ -1592,7 +1592,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('createonly');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		},
@@ -1713,7 +1713,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		}
@@ -1747,7 +1747,7 @@ Twinkle.xfd.callbacks = {
 			if (params.notifycreator) {
 				wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				wikipedia_page.setCallbackParameters(params);
-				wikipedia_page.lookupCreation(function(pageobj) {
+				wikipedia_page.lookupCreation((pageobj) => {
 					Twinkle.xfd.callbacks.notifyUser(pageobj.getCallbackParameters(), pageobj.getCreator());
 				});
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1820,7 +1820,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		}
@@ -1843,7 +1843,7 @@ Twinkle.xfd.callbacks = {
 				pageobj.setChangeTags(Twinkle.changeTags);
 				pageobj.setWatchlist(Twinkle.getPref('xfdWatchPage'));
 				pageobj.setCreateOption('recreate');  // since categories can be populated without an actual page at that title
-				pageobj.save(function() {
+				pageobj.save(() => {
 					// No user notification for CfDS, so just add this nomination to the user's userspace log
 					Twinkle.xfd.callbacks.addToLog(params, null);
 				});
@@ -1869,7 +1869,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		}
@@ -1994,7 +1994,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
 			pageobj.setCreateOption('recreate');
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 			});
 		},
@@ -2045,7 +2045,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setChangeTags(Twinkle.changeTags);
 			pageobj.setCreateOption('recreate'); // since the talk page need not exist
 			pageobj.setWatchlist(Twinkle.getPref('xfdWatchDiscussion'));
-			pageobj.append(function() {
+			pageobj.append(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 				// add this nomination to the user's userspace log
 				Twinkle.xfd.callbacks.addToLog(params, null);
@@ -2066,7 +2066,7 @@ Twinkle.xfd.callbacks = {
 			pageobj.setPageText(newtext);
 			pageobj.setEditSummary('Adding [[:' + Morebits.pageNameNorm + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
-			pageobj.save(function() {
+			pageobj.save(() => {
 				Twinkle.xfd.currentRationale = null;  // any errors from now on do not need to print the rationale, as it is safely saved on-wiki
 				// add this nomination to the user's userspace log
 				Twinkle.xfd.callbacks.addToLog(params, null);

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -50,7 +50,7 @@ Twinkle.xfd = function twinklexfd() {
 };
 
 
-let utils = {
+const utils = {
 	/** Get ordinal number figure */
 	num2order: function(num) {
 		switch (num) {
@@ -67,7 +67,7 @@ let utils = {
 	 * @param {string} title
 	 */
 	stripNs: function(title) {
-		let title_obj = mw.Title.newFromUserInput(title);
+		const title_obj = mw.Title.newFromUserInput(title);
 		if (!title_obj) {
 			return title; // user entered invalid input; do nothing
 		}
@@ -82,7 +82,7 @@ let utils = {
 	 * @param {number} namespaceNumber
 	 */
 	addNs: function(title, namespaceNumber) {
-		let title_obj = mw.Title.newFromUserInput(title, namespaceNumber);
+		const title_obj = mw.Title.newFromUserInput(title, namespaceNumber);
 		if (!title_obj) {
 			return title;  // user entered invalid input; do nothing
 		}
@@ -116,7 +116,7 @@ Twinkle.xfd.printRationale = function twinklexfdPrintRationale() {
 };
 
 Twinkle.xfd.callback = function twinklexfdCallback() {
-	let Window = new Morebits.simpleWindow(700, 400);
+	const Window = new Morebits.simpleWindow(700, 400);
 	Window.setTitle('Start a deletion discussion (XfD)');
 	Window.setScriptName('Twinkle');
 	Window.addFooterLink('About deletion discussions', 'WP:XFD');
@@ -124,15 +124,15 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#xfd');
 	Window.addFooterLink('Give feedback', 'WT:TW');
 
-	let form = new Morebits.quickForm(Twinkle.xfd.callback.evaluate);
-	let categories = form.append({
+	const form = new Morebits.quickForm(Twinkle.xfd.callback.evaluate);
+	const categories = form.append({
 		type: 'select',
 		name: 'venue',
 		label: 'Deletion discussion venue:',
 		tooltip: 'When activated, a default choice is made, based on what namespace you are in. This default should be the most appropriate.',
 		event: Twinkle.xfd.callback.change_category
 	});
-	let namespace = mw.config.get('wgNamespaceNumber');
+	const namespace = mw.config.get('wgNamespaceNumber');
 
 	categories.append({
 		type: 'option',
@@ -207,7 +207,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 		name: 'work_area'
 	});
 
-	let previewlink = document.createElement('a');
+	const previewlink = document.createElement('a');
 	$(previewlink).click(function() {
 		Twinkle.xfd.callbacks.preview(result);  // |result| is defined below
 	});
@@ -224,14 +224,14 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	result.previewer = new Morebits.wiki.preview($(result).find('div#twinklexfd-previewbox').last()[0]);
 
 	// We must init the controls
-	let evt = document.createEvent('Event');
+	const evt = document.createEvent('Event');
 	evt.initEvent('change', true, true);
 	result.venue.dispatchEvent(evt);
 };
 
 Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(venue) {
 	let text = '';
-	let namespace = mw.config.get('wgNamespaceNumber');
+	const namespace = mw.config.get('wgNamespaceNumber');
 
 	switch (venue) {
 		case 'afd':
@@ -280,15 +280,15 @@ Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(ve
 };
 
 Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory(e) {
-	let value = e.target.value;
-	let form = e.target.form;
-	let old_area = Morebits.quickForm.getElements(e.target.form, 'work_area')[0];
+	const value = e.target.value;
+	const form = e.target.form;
+	const old_area = Morebits.quickForm.getElements(e.target.form, 'work_area')[0];
 	let work_area = null;
 
-	let oldreasontextbox = form.getElementsByTagName('textarea')[0];
-	let oldreason = oldreasontextbox ? oldreasontextbox.value : '';
+	const oldreasontextbox = form.getElementsByTagName('textarea')[0];
+	const oldreason = oldreasontextbox ? oldreasontextbox.value : '';
 
-	let appendReasonBox = function twinklexfdAppendReasonBox() {
+	const appendReasonBox = function twinklexfdAppendReasonBox() {
 		work_area.append({
 			type: 'textarea',
 			name: 'reason',
@@ -358,12 +358,12 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 
 			// grab deletion sort categories from en-wiki
 			Morebits.wiki.getCachedJson('Wikipedia:WikiProject_Deletion_sorting/Computer-readable.json').then(function(delsortCategories) {
-				let $select = $('[name="delsortCats"]');
+				const $select = $('[name="delsortCats"]');
 				$.each(delsortCategories, function(groupname, list) {
-					let $optgroup = $('<optgroup>').attr('label', groupname);
-					let $delsortCat = $select.append($optgroup);
+					const $optgroup = $('<optgroup>').attr('label', groupname);
+					const $delsortCat = $select.append($optgroup);
 					list.forEach(function(item) {
-						let $option = $('<option>').val(item).text(item);
+						const $option = $('<option>').val(item).text(item);
 						$delsortCat.append($option);
 					});
 				});
@@ -753,17 +753,17 @@ Twinkle.xfd.callback.change_category = function twinklexfdCallbackChangeCategory
 Twinkle.xfd.callbacks = {
 	// Requires having the tag text (params.tagText) set ahead of time
 	autoEditRequest: function(pageobj, params) {
-		let talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
+		const talkName = new mw.Title(pageobj.getPageName()).getTalkPage().toText();
 		if (talkName === pageobj.getPageName()) {
 			pageobj.getStatusElement().error('Page protected and nowhere to add an edit request, aborting');
 		} else {
 			pageobj.getStatusElement().warn('Page protected, requesting edit');
 
-			let editRequest = '{{subst:Xfd edit protected|page=' + pageobj.getPageName() +
+			const editRequest = '{{subst:Xfd edit protected|page=' + pageobj.getPageName() +
 				'|discussion=' + params.discussionpage + (params.venue === 'rfd' ? '|rfd=yes' : '') +
 				'|tag=<nowiki>' + params.tagText + '\u003C/nowiki>}}'; // U+003C: <
 
-			let talk_page = new Morebits.wiki.page(talkName, 'Automatically posting edit request on talk page');
+			const talk_page = new Morebits.wiki.page(talkName, 'Automatically posting edit request on talk page');
 			talk_page.setNewSectionTitle('Edit request to complete ' + utils.toTLACase(params.venue) + ' nomination');
 			talk_page.setNewSectionText(editRequest);
 			talk_page.setCreateOption('recreate');
@@ -784,7 +784,7 @@ Twinkle.xfd.callbacks = {
 		}
 		if (venue === 'rm') {
 			if (params.rmtr) {
-				let rmtrDiscuss = params['rmtr-discuss'] ? '|discuss=no' : '';
+				const rmtrDiscuss = params['rmtr-discuss'] ? '|discuss=no' : '';
 				return params.currentname
 					.map((currentname, i) => `{{subst:RMassist|1=${currentname}|2=${params.newname[i]}${rmtrDiscuss}|reason=${params.reason}}}`)
 					.join('\n');
@@ -797,7 +797,7 @@ Twinkle.xfd.callbacks = {
 		}
 
 		let text = '{{subst:' + venue + '2';
-		let reasonKey = venue === 'ffd' ? 'Reason' : 'text';
+		const reasonKey = venue === 'ffd' ? 'Reason' : 'text';
 		// Add a reason unconditionally, so that at least a signature is added
 		text += '|' + reasonKey + '=' + Morebits.string.formatReasonText(params.reason, true);
 
@@ -843,7 +843,7 @@ Twinkle.xfd.callbacks = {
 		return text;
 	},
 	showPreview: function(form, venue, params) {
-		let templatetext = Twinkle.xfd.callbacks.getDiscussionWikitext(venue, params);
+		const templatetext = Twinkle.xfd.callbacks.getDiscussionWikitext(venue, params);
 		if (venue === 'rm') { // RM templates are sensitive to page title
 			form.previewer.beginRender(templatetext, params.rmtr ? 'Wikipedia:Requested moves/Technical requests' : new mw.Title(Morebits.pageNameNorm).getTalkPage().toText());
 		} else {
@@ -852,9 +852,9 @@ Twinkle.xfd.callbacks = {
 	},
 	preview: function(form) {
 		// venue, reason, xfdcat, tfdtarget, cfdtarget, cfdtarget2, cfdstarget, delsortCats, newname
-		let params = Morebits.quickForm.getInputData(form);
+		const params = Morebits.quickForm.getInputData(form);
 
-		let venue = params.venue;
+		const venue = params.venue;
 
 		// Remove CfD or TfD namespace prefixes if given
 		if (params.tfdtarget) {
@@ -870,7 +870,7 @@ Twinkle.xfd.callbacks = {
 
 		if (venue === 'ffd') {
 			// Fetch the uploader
-			let page = new Morebits.wiki.page(mw.config.get('wgPageName'));
+			const page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			page.lookupCreation(function() {
 				params.uploader = page.getCreator();
 				Twinkle.xfd.callbacks.showPreview(form, venue, params);
@@ -901,8 +901,8 @@ Twinkle.xfd.callbacks = {
 		// up at user talkspace as expected, but retain the
 		// prefix-less username for addToLog
 		notifyTarget = mw.Title.newFromText(notifyTarget, 3);
-		let targetNS = notifyTarget.getNamespaceId();
-		let usernameOrTarget = notifyTarget.getRelativeText(3);
+		const targetNS = notifyTarget.getNamespaceId();
+		const usernameOrTarget = notifyTarget.getRelativeText(3);
 		notifyTarget = notifyTarget.toText();
 		if (targetNS === 3) {
 			// Disallow warning yourself
@@ -940,7 +940,7 @@ Twinkle.xfd.callbacks = {
 		notifytext += '|1=' + Morebits.pageNameNorm + '}} ~~~~';
 
 		// Link to the venue; object used here rather than repetitive items in switch
-		let venueNames = {
+		const venueNames = {
 			afd: 'Articles for deletion',
 			tfd: 'Templates for discussion',
 			mfd: 'Miscellany for deletion',
@@ -948,10 +948,10 @@ Twinkle.xfd.callbacks = {
 			ffd: 'Files for discussion',
 			rfd: 'Redirects for discussion'
 		};
-		let editSummary = 'Notification: [[' + params.discussionpage + '|listing]] of [[:' +
+		const editSummary = 'Notification: [[' + params.discussionpage + '|listing]] of [[:' +
 			Morebits.pageNameNorm + ']] at [[WP:' + venueNames[params.venue] + ']].';
 
-		let usertalkpage = new Morebits.wiki.page(notifyTarget, actionName);
+		const usertalkpage = new Morebits.wiki.page(notifyTarget, actionName);
 		usertalkpage.setAppendText(notifytext);
 		usertalkpage.setEditSummary(editSummary);
 		usertalkpage.setChangeTags(Twinkle.changeTags);
@@ -985,7 +985,7 @@ Twinkle.xfd.callbacks = {
 			return;
 		}
 
-		let usl = new Morebits.userspaceLogger(Twinkle.getPref('xfdLogPageName'));// , 'Adding entry to userspace log');
+		const usl = new Morebits.userspaceLogger(Twinkle.getPref('xfdLogPageName'));// , 'Adding entry to userspace log');
 
 		usl.initialText =
 			"This is a log of all [[WP:XFD|deletion discussion]] nominations made by this user using [[WP:TW|Twinkle]]'s XfD module.\n\n" +
@@ -1001,9 +1001,9 @@ Twinkle.xfd.callbacks = {
 		}
 
 		// If a logged file is deleted but exists on commons, the wikilink will be blue, so provide a link to the log
-		let fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
+		const fileLogLink = mw.config.get('wgNamespaceNumber') === 6 ? ' ([{{fullurl:Special:Log|page=' + mw.util.wikiUrlencode(mw.config.get('wgPageName')) + '}} log])' : '';
 		// CFD/S and RM don't have canonical links
-		let nominatedLink = params.discussionpage ? '[[' + params.discussionpage + '|nominated]]' : 'nominated';
+		const nominatedLink = params.discussionpage ? '[[' + params.discussionpage + '|nominated]]' : 'nominated';
 
 		let appendText = '# [[:' + Morebits.pageNameNorm + ']]:' + fileLogLink + ' ' + nominatedLink + ' at [[WP:' + params.venue.toUpperCase() + '|' + utils.toTLACase(params.venue) + ']]';
 
@@ -1012,7 +1012,7 @@ Twinkle.xfd.callbacks = {
 				if (params.xfdcat === 'tfm') {
 					appendText += ' (merge)';
 					if (params.tfdtarget) {
-						let contentModel = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'Module:' : 'Template:';
+						const contentModel = mw.config.get('wgPageContentModel') === 'Scribunto' ? 'Module:' : 'Template:';
 						appendText += '; Other ' + contentModel.toLowerCase() + ' [[';
 						if (!new RegExp('^:?' + Morebits.namespaceRegex([10, 828]) + ':', 'i').test(params.tfdtarget)) {
 							appendText += contentModel;
@@ -1029,7 +1029,7 @@ Twinkle.xfd.callbacks = {
 			case 'cfd':
 				appendText += ' (' + utils.toTLACase(params.xfdcat) + ')';
 				if (params.cfdtarget) {
-					let categoryOrTemplate = params.xfdcat.charAt(0) === 's' ? 'Template:' : ':Category:';
+					const categoryOrTemplate = params.xfdcat.charAt(0) === 's' ? 'Template:' : ':Category:';
 					appendText += '; ' + params.action + ' to [[' + categoryOrTemplate + params.cfdtarget + ']]';
 					if (params.xfdcat === 'cfs' && params.cfdtarget2) {
 						appendText += ', [[' + categoryOrTemplate + params.cfdtarget2 + ']]';
@@ -1078,8 +1078,8 @@ Twinkle.xfd.callbacks = {
 
 	afd: {
 		main: function(apiobj) {
-			let response = apiobj.getResponse();
-			let titles = response.query.allpages;
+			const response = apiobj.getResponse();
+			const titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
@@ -1087,7 +1087,7 @@ Twinkle.xfd.callbacks = {
 			} else {
 				let number = 0;
 				for (let i = 0; i < titles.length; ++i) {
-					let title = titles[i].title;
+					const title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Articles for deletion/' + Morebits.pageNameNorm) {
@@ -1095,10 +1095,10 @@ Twinkle.xfd.callbacks = {
 						continue;
 					}
 
-					let order_re = new RegExp('^' +
+					const order_re = new RegExp('^' +
 						Morebits.string.escapeRegExp('Wikipedia:Articles for deletion/' + Morebits.pageNameNorm) +
 						'\\s*\\(\\s*(\\d+)(?:(?:th|nd|rd|st) nom(?:ination)?)?\\s*\\)\\s*$');
-					let match = order_re.exec(title);
+					const match = order_re.exec(title);
 
 					// No match; A non-good value
 					// Or the match is an unrealistically high number. Avoid false positives such as Wikipedia:Articles for deletion/The Basement (2014), by ignoring matches greater than 100
@@ -1121,7 +1121,7 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = 'Nomination completed, now redirecting to the discussion page';
 
 			// Tagging article
-			let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to article');
+			const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'), 'Adding deletion tag to article');
 			wikipedia_page.setFollowRedirect(true);  // should never be needed, but if the article is moved, we would want to follow the redirect
 			wikipedia_page.setChangeTags(Twinkle.changeTags); // Here to apply to triage
 			wikipedia_page.setCallbackParameters(apiobj.params);
@@ -1130,8 +1130,8 @@ Twinkle.xfd.callbacks = {
 		// Tagging needs to happen before everything else: this means we can check if there is an AfD tag already on the page
 		taggingArticle: function(pageobj) {
 			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
 			if (!pageobj.exists()) {
 				statelem.error("It seems that the page doesn't exist; perhaps it has already been deleted");
@@ -1139,7 +1139,7 @@ Twinkle.xfd.callbacks = {
 			}
 
 			// Check for existing AfD tag, for the benefit of new page patrollers
-			let textNoAfd = text.replace(/<!--.*AfD.*\n\{\{(?:Article for deletion\/dated|AfDM).*\}\}\n<!--.*(?:\n<!--.*)?AfD.*(?:\s*\n)?/g, '');
+			const textNoAfd = text.replace(/<!--.*AfD.*\n\{\{(?:Article for deletion\/dated|AfDM).*\}\}\n<!--.*(?:\n<!--.*)?AfD.*(?:\s*\n)?/g, '');
 			if (text !== textNoAfd) {
 				if (confirm('An AfD tag was found on this article. Maybe someone beat you to it.  \nClick OK to replace the current AfD tag (not recommended), or Cancel to abandon your nomination.')) {
 					text = textNoAfd;
@@ -1163,7 +1163,7 @@ Twinkle.xfd.callbacks = {
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.discussionPage);
 
 			// Today's list
-			let date = new Morebits.date(pageobj.getLoadTime());
+			const date = new Morebits.date(pageobj.getLoadTime());
 			wikipedia_page = new Morebits.wiki.page('Wikipedia:Articles for deletion/Log/' +
 				date.format('YYYY MMMM D', 'utc'), "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
@@ -1171,7 +1171,7 @@ Twinkle.xfd.callbacks = {
 			wikipedia_page.load(Twinkle.xfd.callbacks.afd.todaysList);
 			// Notification to first contributor
 			if (params.notifycreator) {
-				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				const thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
 				thispage.setLookupNonRedirectCreator(true); // Look for author of first non-redirect revision
 				thispage.lookupCreation(function(pageobj) {
@@ -1189,13 +1189,13 @@ Twinkle.xfd.callbacks = {
 			// Remove some tags that should always be removed on AfD.
 				text = text.replace(/\{\{\s*(dated prod|dated prod blp|Prod blp\/dated|Proposed deletion\/dated|prod2|Proposed deletion endorsed|Userspace draft)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
 				// Then, test if there are speedy deletion-related templates on the article.
-				let textNoSd = text.replace(/\{\{\s*(db(-\w*)?|delete|(?:hang|hold)[- ]?on)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
+				const textNoSd = text.replace(/\{\{\s*(db(-\w*)?|delete|(?:hang|hold)[- ]?on)\s*(\|(?:\{\{[^{}]*\}\}|[^{}])*)?\}\}\s*/ig, '');
 				if (text !== textNoSd && confirm('A speedy deletion tag was found on this page. Should it be removed?')) {
 					text = textNoSd;
 				}
 
 				// Insert tag after short description or any hatnotes
-				let wikipage = new Morebits.wikitext.page(text);
+				const wikipage = new Morebits.wikitext.page(text);
 				text = wikipage.insertAfterTemplates(params.tagText, Twinkle.hatnoteRegex).getText();
 
 				pageobj.setPageText(text);
@@ -1208,7 +1208,7 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		discussionPage: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('afd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
@@ -1223,7 +1223,7 @@ Twinkle.xfd.callbacks = {
 				// List at deletion sorting pages
 				if (params.delsortCats) {
 					params.delsortCats.forEach(function (cat) {
-						let delsortPage = new Morebits.wiki.page('Wikipedia:WikiProject Deletion sorting/' + cat, 'Adding to list of ' + cat + '-related deletion discussions');
+						const delsortPage = new Morebits.wiki.page('Wikipedia:WikiProject Deletion sorting/' + cat, 'Adding to list of ' + cat + '-related deletion discussions');
 						delsortPage.setFollowRedirect(true); // In case a category gets renamed
 						delsortPage.setCallbackParameters({discussionPage: params.discussionpage});
 						delsortPage.load(Twinkle.xfd.callbacks.afd.delsortListing);
@@ -1232,21 +1232,21 @@ Twinkle.xfd.callbacks = {
 			});
 		},
 		todaysList: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let added_data = '{{subst:afd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}\n';
+			const added_data = '{{subst:afd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}\n';
 			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:AfD log}}\n' + added_data;
 			} else {
-				let old_text = pageobj.getPageText() + '\n';  // MW strips trailing blanks, but we like them, so we add a fake one
+				const old_text = pageobj.getPageText() + '\n';  // MW strips trailing blanks, but we like them, so we add a fake one
 
 				text = old_text.replace(/(<!-- Add new entries to the TOP of the following list -->\n+)/, '$1' + added_data);
 				if (text === old_text) {
-					let linknode = document.createElement('a');
+					const linknode = document.createElement('a');
 					linknode.setAttribute('href', mw.util.getUrl('Wikipedia:Twinkle/Fixing AFD') + '?action=purge');
 					linknode.appendChild(document.createTextNode('How to fix AFD'));
 					statelem.error([ 'Could not find the target spot for the discussion. To fix this problem, please see ', linknode, '.' ]);
@@ -1262,8 +1262,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.save();
 		},
 		delsortListing: function(pageobj) {
-			let discussionPage = pageobj.getCallbackParameters().discussionPage;
-			let text = pageobj.getPageText().replace('directly below this line -->', 'directly below this line -->\n{{' + discussionPage + '}}');
+			const discussionPage = pageobj.getCallbackParameters().discussionPage;
+			const text = pageobj.getPageText().replace('directly below this line -->', 'directly below this line -->\n{{' + discussionPage + '}}');
 			pageobj.setPageText(text);
 			pageobj.setEditSummary('Listing [[:' + discussionPage + ']].');
 			pageobj.setChangeTags(Twinkle.changeTags);
@@ -1275,9 +1275,9 @@ Twinkle.xfd.callbacks = {
 
 	tfd: {
 		main: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
-			let date = new Morebits.date(pageobj.getLoadTime());
+			const date = new Morebits.date(pageobj.getLoadTime());
 			params.logpage = 'Wikipedia:Templates for discussion/Log/' + date.format('YYYY MMMM D', 'utc'),
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 			// Add log/discussion page params to the already-loaded page object
@@ -1286,7 +1286,7 @@ Twinkle.xfd.callbacks = {
 			// Defined here rather than below to reduce duplication
 			let watchModule, watch_query;
 			if (params.scribunto) {
-				let watchPref = Twinkle.getPref('xfdWatchPage');
+				const watchPref = Twinkle.getPref('xfdWatchPage');
 				// action=watch has no way to rely on user
 				// preferences (T262912), so we do it manually.
 				// The watchdefault pref appears to reliably return '1' (string),
@@ -1324,7 +1324,7 @@ Twinkle.xfd.callbacks = {
 
 				// Tag other template/module
 				wikipedia_otherpage.setFollowRedirect(true);
-				let otherParams = $.extend({}, params);
+				const otherParams = $.extend({}, params);
 				otherParams.otherTemplateName = Morebits.pageNameNorm;
 				wikipedia_otherpage.setCallbackParameters(otherParams);
 				wikipedia_otherpage.load(Twinkle.xfd.callbacks.tfd.taggingTemplateForMerge);
@@ -1344,15 +1344,15 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = "Nomination completed, now redirecting to today's log";
 
 			// Adding discussion
-			let wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's log");
+			const wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's log");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.tfd.todaysList);
 
 			// Notification to first contributors
 			if (params.notifycreator) {
-				let involvedpages = [];
-				let seenusers = [];
+				const involvedpages = [];
+				const seenusers = [];
 				involvedpages.push(new Morebits.wiki.page(mw.config.get('wgPageName')));
 				if (params.xfdcat === 'tfm') {
 					if (params.scribunto) {
@@ -1364,7 +1364,7 @@ Twinkle.xfd.callbacks = {
 				involvedpages.forEach(function(page) {
 					page.setCallbackParameters(params);
 					page.lookupCreation(function(innerpage) {
-						let username = innerpage.getCreator();
+						const username = innerpage.getCreator();
 						if (seenusers.indexOf(username) === -1) {
 							seenusers.push(username);
 							// Only log once on merge nominations, for the initial template
@@ -1380,8 +1380,8 @@ Twinkle.xfd.callbacks = {
 
 			// Notify developer(s) of script(s) that use(s) the nominated template
 			if (params.devpages) {
-				let inCategories = mw.config.get('wgCategories');
-				let categoryNotificationPageMap = {
+				const inCategories = mw.config.get('wgCategories');
+				const categoryNotificationPageMap = {
 					'Templates used by Twinkle': 'Wikipedia talk:Twinkle',
 					'Templates used by AutoWikiBrowser': 'Wikipedia talk:AutoWikiBrowser',
 					'Templates used by Ultraviolet': 'Wikipedia talk:Ultraviolet'
@@ -1395,8 +1395,8 @@ Twinkle.xfd.callbacks = {
 
 		},
 		taggingTemplate: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:template for discussion|help=off' + (params.templatetype !== 'standard' ? '|type=' + params.templatetype : '') + '}}';
 
@@ -1423,8 +1423,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingTemplateForMerge: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:tfm|help=off|' + (params.templatetype !== 'standard' ? 'type=' + params.templatetype + '|' : '') +
 				'1=' + params.otherTemplateName.replace(new RegExp('^' + Morebits.namespaceRegex([10, 828]) + ':'), '') + '}}';
@@ -1452,17 +1452,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
+			const added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
 			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:TfD log}}\n' + added_data;
 			} else {
-				let old_text = pageobj.getPageText();
+				const old_text = pageobj.getPageText();
 
 				text = old_text.replace('-->', '-->\n' + added_data);
 				if (text === old_text) {
@@ -1485,8 +1485,8 @@ Twinkle.xfd.callbacks = {
 
 	mfd: {
 		main: function(apiobj) {
-			let response = apiobj.getResponse();
-			let titles = response.query.allpages;
+			const response = apiobj.getResponse();
+			const titles = response.query.allpages;
 
 			// There has been no earlier entries with this prefix, just go on.
 			if (titles.length <= 0) {
@@ -1494,7 +1494,7 @@ Twinkle.xfd.callbacks = {
 			} else {
 				let number = 0;
 				for (let i = 0; i < titles.length; ++i) {
-					let title = titles[i].title;
+					const title = titles[i].title;
 
 					// First, simple test, is there an instance with this exact name?
 					if (title === 'Wikipedia:Miscellany for deletion/' + Morebits.pageNameNorm) {
@@ -1502,10 +1502,10 @@ Twinkle.xfd.callbacks = {
 						continue;
 					}
 
-					let order_re = new RegExp('^' +
+					const order_re = new RegExp('^' +
 							Morebits.string.escapeRegExp('Wikipedia:Miscellany for deletion/' + Morebits.pageNameNorm) +
 							'\\s*\\(\\s*(\\d+)(?:(?:th|nd|rd|st) nom(?:ination)?)?\\s*\\)\\s*$');
-					let match = order_re.exec(title);
+					const match = order_re.exec(title);
 
 					// No match; A non-good value
 					if (!match) {
@@ -1550,7 +1550,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notification to first contributor and/or notification to owner of userspace
 			if (apiobj.params.notifycreator || apiobj.params.notifyuserspace) {
-				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				const thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(apiobj.params);
 				thispage.lookupCreation(Twinkle.xfd.callbacks.mfd.sendNotifications);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1559,8 +1559,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingPage: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{' + (params.number === '' ? 'mfd' : 'mfdx|' + params.number) + '|help=off}}';
 
@@ -1585,7 +1585,7 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		discussionPage: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			pageobj.setPageText(Twinkle.xfd.callbacks.getDiscussionWikitext('mfd', params));
 			pageobj.setEditSummary('Creating deletion discussion page for [[:' + Morebits.pageNameNorm + ']].');
@@ -1598,13 +1598,13 @@ Twinkle.xfd.callbacks = {
 		},
 		todaysList: function(pageobj) {
 			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let date = new Morebits.date(pageobj.getLoadTime());
-			let date_header = date.format('===MMMM D, YYYY===\n', 'utc');
-			let date_header_regex = new RegExp(date.format('(===[\\s]*MMMM[\\s]+D,[\\s]+YYYY[\\s]*===)', 'utc'));
-			let added_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
+			const date = new Morebits.date(pageobj.getLoadTime());
+			const date_header = date.format('===MMMM D, YYYY===\n', 'utc');
+			const date_header_regex = new RegExp(date.format('(===[\\s]*MMMM[\\s]+D,[\\s]+YYYY[\\s]*===)', 'utc'));
+			const added_data = '{{subst:mfd3|pg=' + Morebits.pageNameNorm + params.numbering + '}}';
 
 			if (date_header_regex.test(text)) { // we have a section already
 				statelem.info('Found today\'s section, proceeding to add new entry');
@@ -1622,8 +1622,8 @@ Twinkle.xfd.callbacks = {
 			pageobj.save();
 		},
 		sendNotifications: function(pageobj) {
-			let initialContrib = pageobj.getCreator();
-			let params = pageobj.getCallbackParameters();
+			const initialContrib = pageobj.getCreator();
+			const params = pageobj.getCallbackParameters();
 
 			// Notify the creator
 			if (params.notifycreator) {
@@ -1650,9 +1650,9 @@ Twinkle.xfd.callbacks = {
 	ffd: {
 		taggingImage: function(pageobj) {
 			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
-			let date = new Morebits.date(pageobj.getLoadTime()).format('YYYY MMMM D', 'utc');
+			const date = new Morebits.date(pageobj.getLoadTime()).format('YYYY MMMM D', 'utc');
 			params.logpage = 'Wikipedia:Files for discussion/' + date;
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
@@ -1675,18 +1675,18 @@ Twinkle.xfd.callbacks = {
 			Morebits.wiki.actionCompleted.notice = 'Nomination completed, now redirecting to the discussion page';
 
 			// Contributor specific edits
-			let wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
+			const wikipedia_page = new Morebits.wiki.page(mw.config.get('wgPageName'));
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.lookupCreation(Twinkle.xfd.callbacks.ffd.main);
 		},
 		main: function(pageobj) {
 			// this is coming in from lookupCreation...!
-			let params = pageobj.getCallbackParameters();
-			let initialContrib = pageobj.getCreator();
+			const params = pageobj.getCallbackParameters();
+			const initialContrib = pageobj.getCreator();
 			params.uploader = initialContrib;
 
 			// Adding discussion
-			let wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
+			const wikipedia_page = new Morebits.wiki.page(params.logpage, "Adding discussion to today's list");
 			wikipedia_page.setFollowRedirect(true);
 			wikipedia_page.setCallbackParameters(params);
 			wikipedia_page.load(Twinkle.xfd.callbacks.ffd.todaysList);
@@ -1701,7 +1701,7 @@ Twinkle.xfd.callbacks = {
 		},
 		todaysList: function(pageobj) {
 			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
@@ -1722,9 +1722,9 @@ Twinkle.xfd.callbacks = {
 
 	cfd: {
 		main: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
-			let date = new Morebits.date(pageobj.getLoadTime());
+			const date = new Morebits.date(pageobj.getLoadTime());
 			params.logpage = 'Wikipedia:Categories for discussion/Log/' + date.format('YYYY MMMM D', 'utc');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 			// Add log/discussion page params to the already-loaded page object
@@ -1756,8 +1756,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingCategory: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 
 			params.tagText = '{{subst:' + params.xfdcat;
 			let editsummary = (mw.config.get('wgNamespaceNumber') === 14 ? 'Category' : 'Stub template') +
@@ -1796,17 +1796,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
+			const added_data = Twinkle.xfd.callbacks.getDiscussionWikitext(params.xfdcat, params);
 			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:CfD log}}\n' + added_data;
 			} else {
-				let old_text = pageobj.getPageText();
+				const old_text = pageobj.getPageText();
 
 				text = old_text.replace('below this line -->', 'below this line -->\n' + added_data);
 				if (text === old_text) {
@@ -1829,8 +1829,8 @@ Twinkle.xfd.callbacks = {
 
 	cfds: {
 		taggingCategory: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 			if (params.xfdcat === 'C2F') {
 				params.tagText = '{{subst:cfm-speedy|1=' + params.cfdstarget.replace(/^:?Category:/, '') + '}}\n';
 			} else {
@@ -1854,11 +1854,11 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		addToList: function(pageobj) {
-			let old_text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const old_text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let text = old_text.replace('BELOW THIS LINE -->', 'BELOW THIS LINE -->\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('cfds', params));
+			const text = old_text.replace('BELOW THIS LINE -->', 'BELOW THIS LINE -->\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('cfds', params));
 			if (text === old_text) {
 				statelem.error('failed to find target spot for the discussion');
 				return;
@@ -1881,7 +1881,7 @@ Twinkle.xfd.callbacks = {
 		findTarget: function(params, callback) {
 			// Used by regular redirects to find the target, but for all redirects,
 			// avoid relying on the client clock to build the log page
-			let query = {
+			const query = {
 				action: 'query',
 				curtimestamp: true,
 				format: 'json'
@@ -1895,18 +1895,18 @@ Twinkle.xfd.callbacks = {
 				query.titles = mw.config.get('wgPageName');
 				query.redirects = true;
 			}
-			let wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
+			const wikipedia_api = new Morebits.wiki.api('Finding target of redirect', query, Twinkle.xfd.callbacks.rfd.findTargetCallback(callback));
 			wikipedia_api.params = params;
 			wikipedia_api.post();
 		},
 		// This is a closure for the callback from the above API request, which gets the target of the redirect
 		findTargetCallback: function(callback) {
 			return function(apiobj) {
-				let response = apiobj.getResponse();
+				const response = apiobj.getResponse();
 				apiobj.params.curtimestamp = response.curtimestamp;
 
 				if (!apiobj.params.rfdtarget) { // Not a softredirect
-					let target = response.query.redirects && response.query.redirects[0].to;
+					const target = response.query.redirects && response.query.redirects[0].to;
 					if (!target) {
 						let message = 'No target found. this page does not appear to be a redirect, aborting';
 						if (mw.config.get('wgAction') === 'history') {
@@ -1916,14 +1916,14 @@ Twinkle.xfd.callbacks = {
 						return;
 					}
 					apiobj.params.rfdtarget = target;
-					let section = response.query.redirects[0].tofragment;
+					const section = response.query.redirects[0].tofragment;
 					apiobj.params.section = section;
 				}
 				callback(apiobj.params);
 			};
 		},
 		main: function(params) {
-			let date = new Morebits.date(params.curtimestamp);
+			const date = new Morebits.date(params.curtimestamp);
 			params.logpage = 'Wikipedia:Redirects for discussion/Log/' + date.format('YYYY MMMM D', 'utc');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 
@@ -1945,7 +1945,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notifications
 			if (params.notifycreator || params.relatedpage) {
-				let thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
+				const thispage = new Morebits.wiki.page(mw.config.get('wgPageName'));
 				thispage.setCallbackParameters(params);
 				thispage.lookupCreation(Twinkle.xfd.callbacks.rfd.sendNotifications);
 			// or, if not notifying, add this nomination to the user's userspace log without the initial contributor's name
@@ -1954,8 +1954,8 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		taggingRedirect: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
 			// Imperfect for edit request but so be it
 			params.tagText = '{{subst:rfd|' + (mw.config.get('wgNamespaceNumber') === 10 ? 'showontransclusion=1|' : '') + 'content=\n';
 
@@ -1971,17 +1971,17 @@ Twinkle.xfd.callbacks = {
 			}
 		},
 		todaysList: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let added_data = Twinkle.xfd.callbacks.getDiscussionWikitext('rfd', params);
+			const added_data = Twinkle.xfd.callbacks.getDiscussionWikitext('rfd', params);
 			let text;
 
 			// add date header if the log is found to be empty (a bot should do this automatically)
 			if (!pageobj.exists()) {
 				text = '{{subst:RfD log}}' + added_data;
 			} else {
-				let old_text = pageobj.getPageText();
+				const old_text = pageobj.getPageText();
 				text = old_text.replace(/(<!-- Add new entries directly below this line\.? -->)/, '$1\n' + added_data);
 				if (text === old_text) {
 					statelem.error('failed to find target spot for the discussion');
@@ -1999,9 +1999,9 @@ Twinkle.xfd.callbacks = {
 			});
 		},
 		sendNotifications: function(pageobj) {
-			let initialContrib = pageobj.getCreator();
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const initialContrib = pageobj.getCreator();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
 			// Notifying initial contributor
 			if (params.notifycreator) {
@@ -2010,7 +2010,7 @@ Twinkle.xfd.callbacks = {
 
 			// Notifying target page's watchers, if not a soft redirect
 			if (params.relatedpage) {
-				let targetTalk = new mw.Title(params.rfdtarget).getTalkPage();
+				const targetTalk = new mw.Title(params.rfdtarget).getTalkPage();
 
 				// On the offchance it's a circular redirect
 				if (params.rfdtarget === mw.config.get('wgPageName')) {
@@ -2038,7 +2038,7 @@ Twinkle.xfd.callbacks = {
 
 	rm: {
 		listAtTalk: function(pageobj) {
-			let params = pageobj.getCallbackParameters();
+			const params = pageobj.getCallbackParameters();
 
 			pageobj.setAppendText('\n\n' + Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params));
 			pageobj.setEditSummary('Proposing move' + (params.newname ? ' to [[:' + params.newname + ']]' : ''));
@@ -2053,12 +2053,12 @@ Twinkle.xfd.callbacks = {
 		},
 
 		listAtRMTR: function(pageobj) {
-			let text = pageobj.getPageText();
-			let params = pageobj.getCallbackParameters();
-			let statelem = pageobj.getStatusElement();
+			const text = pageobj.getPageText();
+			const params = pageobj.getCallbackParameters();
+			const statelem = pageobj.getStatusElement();
 
-			let discussionWikitext = Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params);
-			let newtext = Twinkle.xfd.insertRMTR(text, discussionWikitext);
+			const discussionWikitext = Twinkle.xfd.callbacks.getDiscussionWikitext('rm', params);
+			const newtext = Twinkle.xfd.insertRMTR(text, discussionWikitext);
 			if (text === newtext) {
 				statelem.error('failed to find target spot for the entry');
 				return;
@@ -2082,14 +2082,14 @@ Twinkle.xfd.callbacks = {
  * @return {String} pageWikitext
  */
 Twinkle.xfd.insertRMTR = function(pageWikitext, wikitextToInsert) {
-	let placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
+	const placementRE = /\n{1,}(==== ?Requests to revert undiscussed moves ?====)/i;
 	return pageWikitext.replace(placementRE, '\n' + wikitextToInsert + '\n\n$1');
 };
 
 Twinkle.xfd.callback.evaluate = function(e) {
-	let form = e.target;
+	const form = e.target;
 
-	let params = Morebits.quickForm.getInputData(form);
+	const params = Morebits.quickForm.getInputData(form);
 
 	Morebits.simpleWindow.setButtonsEnabled(false);
 	Morebits.status.init(form);

--- a/morebits.js
+++ b/morebits.js
@@ -217,7 +217,7 @@ Morebits.createHtml = function(input) {
 		if (input[i] instanceof Node) {
 			fragment.appendChild(input[i]);
 		} else {
-			$.parseHTML(Morebits.createHtml.renderWikilinks(input[i])).forEach(function(node) {
+			$.parseHTML(Morebits.createHtml.renderWikilinks(input[i])).forEach((node) => {
 				fragment.appendChild(node);
 			});
 		}
@@ -236,7 +236,7 @@ Morebits.createHtml.renderWikilinks = function (text) {
 	ub.unbind('<code>', '</code>');
 	ub.content = ub.content.replace(
 		/\[\[:?(?:([^|\]]+?)\|)?([^\]|]+?)\]\]/g,
-		function(_, target, text) {
+		(_, target, text) => {
 			if (!target) {
 				target = text;
 			}
@@ -266,12 +266,12 @@ Morebits.namespaceRegex = function(namespaces) {
 		namespaces = [namespaces];
 	}
 	let aliases = [], regex;
-	$.each(mw.config.get('wgNamespaceIds'), function(name, number) {
+	$.each(mw.config.get('wgNamespaceIds'), (name, number) => {
 		if (namespaces.indexOf(number) !== -1) {
 			// Namespaces are completely agnostic as to case,
 			// and a regex string is more useful/compatible than a RegExp object,
 			// so we accept any casing for any letter.
-			aliases.push(name.split('').map(function(char) {
+			aliases.push(name.split('').map((char) => {
 				return Morebits.pageNameRegex(char);
 			}).join(''));
 		}
@@ -603,7 +603,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							type: 'div',
 							id: id + '_' + i + '_subgroup'
 						});
-						$.each(tmpgroup, function(idx, el) {
+						$.each(tmpgroup, (idx, el) => {
 							const newEl = $.extend({}, el);
 							if (!newEl.type) {
 								newEl.type = data.type;
@@ -679,19 +679,19 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				subnode.setAttribute('type', 'text');
 			} else {
 				subnode.setAttribute('type', 'number');
-				['min', 'max', 'step', 'list'].forEach(function(att) {
+				['min', 'max', 'step', 'list'].forEach((att) => {
 					if (data[att]) {
 						subnode.setAttribute(att, data[att]);
 					}
 				});
 			}
 
-			['value', 'size', 'placeholder', 'maxlength'].forEach(function(att) {
+			['value', 'size', 'placeholder', 'maxlength'].forEach((att) => {
 				if (data[att]) {
 					subnode.setAttribute(att, data[att]);
 				}
 			});
-			['disabled', 'required', 'readonly'].forEach(function(att) {
+			['disabled', 'required', 'readonly'].forEach((att) => {
 				if (data[att]) {
 					subnode.setAttribute(att, att);
 				}
@@ -760,7 +760,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 		case '_dyninput_row': // Private
 			node = document.createElement('div');
 
-			data.inputs.forEach(function(subdata) {
+			data.inputs.forEach((subdata) => {
 				const cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
 				node.appendChild(cell.render());
 			});
@@ -1047,7 +1047,7 @@ Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) 
  * @returns {HTMLInputElement}
  */
 Morebits.quickForm.getCheckboxOrRadio = function QuickFormGetCheckboxOrRadio(elementArray, value) {
-	const found = $.grep(elementArray, function(el) {
+	const found = $.grep(elementArray, (el) => {
 		return el.value === value;
 	});
 	if (found.length > 0) {
@@ -1598,7 +1598,7 @@ Morebits.array = {
 		if (!Array.isArray(arr)) {
 			throw 'A non-array object passed to Morebits.array.uniq';
 		}
-		return arr.filter(function(item, idx) {
+		return arr.filter((item, idx) => {
 			return arr.indexOf(item) === idx;
 		});
 	},
@@ -1615,7 +1615,7 @@ Morebits.array = {
 		if (!Array.isArray(arr)) {
 			throw 'A non-array object passed to Morebits.array.dups';
 		}
-		return arr.filter(function(item, idx) {
+		return arr.filter((item, idx) => {
 			return arr.indexOf(item) !== idx;
 		});
 	},
@@ -2091,7 +2091,7 @@ Morebits.date.prototype = {
 			 * Y{1,2}(Y{2})? matches exactly 1, 2 or 4 occurrences of 'Y'
 			 */
 			/H{1,2}|h{1,2}|m{1,2}|s{1,2}|SSS|d(d{2,3})?|D{1,2}|M{1,4}|Y{1,2}(Y{2})?|A/g,
-			function(match) {
+			(match) => {
 				return replacementMap[match];
 			}
 		);
@@ -2163,7 +2163,7 @@ Morebits.date.prototype = {
 };
 
 // Allow native Date.prototype methods to be used on Morebits.date objects
-Object.getOwnPropertyNames(Date.prototype).forEach(function(func) {
+Object.getOwnPropertyNames(Date.prototype).forEach((func) => {
 	Morebits.date.prototype[func] = function() {
 		return this._d[func].apply(this._d, Array.prototype.slice.call(arguments));
 	};
@@ -2251,7 +2251,7 @@ Morebits.wiki.actionCompleted.event = function() {
 				Morebits.wiki.actionCompleted.redirect += '?redirect=no';
 			}
 		}
-		window.setTimeout(function() {
+		window.setTimeout(() => {
 			window.location = Morebits.wiki.actionCompleted.redirect;
 		}, Morebits.wiki.actionCompleted.timeOut);
 	}
@@ -2377,7 +2377,7 @@ Morebits.wiki.api.prototype = {
 
 		++Morebits.wiki.numberOfActionsLeft;
 
-		const queryString = $.map(this.query, function(val, i) {
+		const queryString = $.map(this.query, (val, i) => {
 			if (Array.isArray(val)) {
 				return encodeURIComponent(i) + '=' + val.map(encodeURIComponent).join('|');
 			} else if (val !== undefined) {
@@ -2452,10 +2452,10 @@ Morebits.wiki.api.prototype = {
 			this.badtokenRetry = true;
 			// Get a new CSRF token and retry. If the original action needs a different
 			// type of action than CSRF, we do one pointless retry before bailing out
-			return Morebits.wiki.api.getToken().then(function(token) {
+			return Morebits.wiki.api.getToken().then((token) => {
 				this.query.token = token;
 				return this.post(callerAjaxParameters);
-			}.bind(this));
+			});
 		}
 
 		this.statelem.error(this.errorText + ' (' + this.errorCode + ')');
@@ -2506,7 +2506,7 @@ Morebits.wiki.getCachedJson = function(title) {
 		smaxage: '86400', // cache for 1 day
 		maxage: '86400' // cache for 1 day
 	};
-	return new Morebits.wiki.api('', query).post().then(function(apiobj) {
+	return new Morebits.wiki.api('', query).post().then((apiobj) => {
 		apiobj.getStatusElement().unlink();
 		const response = apiobj.getResponse();
 		const wikitext = response.query.pages[0].revisions[0].slots.main.content;
@@ -2558,7 +2558,7 @@ Morebits.wiki.api.getToken = function() {
 		type: 'csrf',
 		format: 'json'
 	});
-	return tokenApi.post().then(function(apiobj) {
+	return tokenApi.post().then((apiobj) => {
 		return apiobj.response.query.tokens.csrftoken;
 	});
 };
@@ -3895,7 +3895,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info, to alert admins when they are about to edit a protected page
 		// Includes cascading protection
 		if (Morebits.userIsSysop) {
-			const editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter((pr) => {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -3909,7 +3909,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		const testactions = page.actions;
 		ctx.testActions = []; // was null
-		Object.keys(testactions).forEach(function(action) {
+		Object.keys(testactions).forEach((action) => {
 			if (testactions[action]) {
 				ctx.testActions.push(action);
 			}
@@ -4077,7 +4077,7 @@ Morebits.wiki.page = function(pageName, status) {
 				titles: ctx.pageName  // redirects are already resolved
 			};
 
-			const purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, function() {
+			const purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, (() => {
 				--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 
 				ctx.statusElement.info(msg('editconflict-retrying', 'Edit conflict detected, reapplying edit'));
@@ -4086,7 +4086,7 @@ Morebits.wiki.page = function(pageName, status) {
 				} else {
 					ctx.loadApi.post(); // reload the page and reapply the edit
 				}
-			}, ctx.statusElement);
+			}), ctx.statusElement);
 			purgeApi.post();
 
 		// check for network or server error
@@ -4097,7 +4097,7 @@ Morebits.wiki.page = function(pageName, status) {
 			--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 
 			// wait for sometime for client to regain connectivity
-			sleep(2000).then(function() {
+			sleep(2000).then(() => {
 				ctx.saveApi.post(); // give it another go!
 			});
 
@@ -4145,7 +4145,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (!text) { // no text - content empty or inaccessible (revdelled or suppressed)
 			return false;
 		}
-		return Morebits.l10n.redirectTagAliases.some(function(tag) {
+		return Morebits.l10n.redirectTagAliases.some((tag) => {
 			return new RegExp('^\\s*' + tag + '\\W', 'i').test(text);
 		});
 	};
@@ -4279,11 +4279,11 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info
 		let editprot;
 		if (action === 'undelete') {
-			editprot = response.pages[0].protection.filter(function(pr) {
+			editprot = response.pages[0].protection.filter((pr) => {
 				return pr.type === 'create' && pr.level === 'sysop';
 			}).pop();
 		} else if (action === 'delete' || action === 'move') {
-			editprot = response.pages[0].protection.filter(function(pr) {
+			editprot = response.pages[0].protection.filter((pr) => {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 		}
@@ -4608,7 +4608,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// Fetch existing protection levels
 		const prs = response.pages[0].protection;
 		let editprot, moveprot, createprot;
-		prs.forEach(function(pr) {
+		prs.forEach((pr) => {
 			// Filter out protection from cascading
 			if (pr.type === 'edit' && !pr.source) {
 				editprot = pr;
@@ -4633,7 +4633,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// Default to pre-existing cascading protection if unchanged (similar to above)
 		if (ctx.protectCascade === null) {
-			ctx.protectCascade = !!prs.filter(function(pr) {
+			ctx.protectCascade = !!prs.filter((pr) => {
 				return pr.cascade;
 			}).length;
 		}
@@ -5206,7 +5206,7 @@ Morebits.userspaceLogger = function(logPageName) {
 		}
 		const page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
 			'Adding entry to userspace log'); // make this '... to ' + logPageName ?
-		page.load(function(pageobj) {
+		page.load((pageobj) => {
 			// add blurb if log page doesn't exist or is blank
 			let text = pageobj.getPageText() || this.initialText;
 
@@ -5221,7 +5221,7 @@ Morebits.userspaceLogger = function(logPageName) {
 			pageobj.setChangeTags(this.changeTags);
 			pageobj.setCreateOption('recreate');
 			pageobj.save(def.resolve, def.reject);
-		}.bind(this));
+		});
 		return def;
 	};
 };
@@ -5707,7 +5707,7 @@ Morebits.batchOperation = function(currentAction) {
 
 		// start workers for the current chunk
 		ctx.countStarted += chunk.length;
-		chunk.forEach(function(page) {
+		chunk.forEach((page) => {
 			ctx.worker(page, thisProxy);
 		});
 	};
@@ -5780,7 +5780,7 @@ Morebits.taskManager = function(context) {
 	 */
 	this.add = function(func, deps, onFailure) {
 		this.taskDependencyMap.set(func, deps);
-		this.failureCallbackMap.set(func, onFailure || function() {});
+		this.failureCallbackMap.set(func, onFailure || (() => {}));
 		const deferred = $.Deferred();
 		this.deferreds.set(func, deferred);
 	};
@@ -5792,8 +5792,8 @@ Morebits.taskManager = function(context) {
 	 */
 	this.execute = function() {
 		const self = this; // proxy for `this` for use inside functions where `this` is something else
-		this.taskDependencyMap.forEach(function(deps, task) {
-			const dependencyPromisesArray = deps.map(function(dep) {
+		this.taskDependencyMap.forEach((deps, task) => {
+			const dependencyPromisesArray = deps.map((dep) => {
 				return self.deferreds.get(dep);
 			});
 			$.when.apply(self.context, dependencyPromisesArray).then(function() {
@@ -5869,7 +5869,7 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 	const $widget = $(this.content).dialog('widget');
 
 	// delete the placeholder button (it's only there so the buttonpane gets created)
-	$widget.find('button').each(function(key, value) {
+	$widget.find('button').each((key, value) => {
 		value.parentNode.removeChild(value);
 	});
 
@@ -6027,7 +6027,7 @@ Morebits.simpleWindow.prototype = {
 
 		// look for submit buttons in the content, hide them, and add a proxy button to the button pane
 		const thisproxy = this;
-		$(this.content).find('input[type="submit"], button[type="submit"]').each(function(key, value) {
+		$(this.content).find('input[type="submit"], button[type="submit"]').each((key, value) => {
 			value.style.display = 'none';
 			const button = document.createElement('button');
 
@@ -6041,7 +6041,7 @@ Morebits.simpleWindow.prototype = {
 
 			button.className = value.className || 'submitButtonProxy';
 			// here is an instance of cheap coding, probably a memory-usage hit in using a closure here
-			button.addEventListener('click', function() {
+			button.addEventListener('click', () => {
 				value.click();
 			}, false);
 			thisproxy.buttons.push(button);

--- a/morebits.js
+++ b/morebits.js
@@ -37,7 +37,7 @@
 (function (window, document, $) { // Wrap entire file with anonymous function
 
 /** @lends Morebits */
-var Morebits = {};
+let Morebits = {};
 window.Morebits = Morebits;  // allow global access
 
 /**
@@ -66,18 +66,18 @@ Morebits.i18n = {
 	 * @returns {string}
 	 */
 	getMessage: function () {
-		var args = Array.prototype.slice.call(arguments); // array of size `n`
+		let args = Array.prototype.slice.call(arguments); // array of size `n`
 		// 1st arg: message name
 		// 2nd to (n-1)th arg: message parameters
 		// nth arg: legacy English fallback
-		var msgName = args[0];
-		var fallback = args[args.length - 1];
+		let msgName = args[0];
+		let fallback = args[args.length - 1];
 		if (!Morebits.i18n.parser) {
 			return fallback;
 		}
 		// i18n libraries are generally invoked with variable number of arguments
 		// as msg(msgName, ...parameters)
-		var i18nMessage = Morebits.i18n.parser.get.apply(null, args.slice(0, -1));
+		let i18nMessage = Morebits.i18n.parser.get.apply(null, args.slice(0, -1));
 		// if no i18n message exists, i18n libraries generally give back the message name
 		if (i18nMessage === msgName) {
 			return fallback;
@@ -87,7 +87,7 @@ Morebits.i18n = {
 };
 
 // shortcut
-var msg = Morebits.i18n.getMessage;
+let msg = Morebits.i18n.getMessage;
 
 
 /**
@@ -110,12 +110,12 @@ Morebits.l10n = {
 	 */
 	signatureTimestampFormat: function (str) {
 		// HH:mm, DD Month YYYY (UTC)
-		var rgx = /(\d{2}):(\d{2}), (\d{1,2}) (\w+) (\d{4}) \(UTC\)/;
-		var match = rgx.exec(str);
+		let rgx = /(\d{2}):(\d{2}), (\d{1,2}) (\w+) (\d{4}) \(UTC\)/;
+		let match = rgx.exec(str);
 		if (!match) {
 			return null;
 		}
-		var month = Morebits.date.localeData.months.indexOf(match[4]);
+		let month = Morebits.date.localeData.months.indexOf(match[4]);
 		if (month === -1) {
 			return null;
 		}
@@ -189,7 +189,7 @@ Morebits.pageNameRegex = function(pageName) {
 	if (pageName === '') {
 		return '';
 	}
-	var firstChar = pageName[0],
+	let firstChar = pageName[0],
 		remainder = Morebits.string.escapeRegExp(pageName.slice(1));
 	if (mw.Title.phpCharToUpper(firstChar) !== firstChar.toLowerCase()) {
 		return '[' + mw.Title.phpCharToUpper(firstChar) + firstChar.toLowerCase() + ']' + remainder;
@@ -206,14 +206,14 @@ Morebits.pageNameRegex = function(pageName) {
  * @returns {DocumentFragment}
  */
 Morebits.createHtml = function(input) {
-	var fragment = document.createDocumentFragment();
+	let fragment = document.createDocumentFragment();
 	if (!input) {
 		return fragment;
 	}
 	if (!Array.isArray(input)) {
 		input = [ input ];
 	}
-	for (var i = 0; i < input.length; ++i) {
+	for (let i = 0; i < input.length; ++i) {
 		if (input[i] instanceof Node) {
 			fragment.appendChild(input[i]);
 		} else {
@@ -231,7 +231,7 @@ Morebits.createHtml = function(input) {
  * @returns {*}
  */
 Morebits.createHtml.renderWikilinks = function (text) {
-	var ub = new Morebits.unbinder(text);
+	let ub = new Morebits.unbinder(text);
 	// Don't convert wikilinks within code tags as they're used for displaying wiki-code
 	ub.unbind('<code>', '</code>');
 	ub.content = ub.content.replace(
@@ -265,7 +265,7 @@ Morebits.namespaceRegex = function(namespaces) {
 	if (!Array.isArray(namespaces)) {
 		namespaces = [namespaces];
 	}
-	var aliases = [], regex;
+	let aliases = [], regex;
 	$.each(mw.config.get('wgNamespaceIds'), function(name, number) {
 		if (namespaces.indexOf(number) !== -1) {
 			// Namespaces are completely agnostic as to case,
@@ -312,7 +312,7 @@ Morebits.quickForm = function QuickForm(event, eventType) {
  * @returns {HTMLElement}
  */
 Morebits.quickForm.prototype.render = function QuickFormRender() {
-	var ret = this.root.render();
+	let ret = this.root.render();
 	ret.names = {};
 	return ret;
 };
@@ -406,7 +406,7 @@ Morebits.quickForm.element.id = 0;
  * @returns {Morebits.quickForm.element} The same element passed in.
  */
 Morebits.quickForm.element.prototype.append = function QuickFormElementAppend(data) {
-	var child;
+	let child;
 	if (data instanceof Morebits.quickForm.element) {
 		child = data;
 	} else {
@@ -424,9 +424,9 @@ Morebits.quickForm.element.prototype.append = function QuickFormElementAppend(da
  * @returns {HTMLElement}
  */
 Morebits.quickForm.element.prototype.render = function QuickFormElementRender(internal_subgroup_id) {
-	var currentNode = this.compute(this.data, internal_subgroup_id);
+	let currentNode = this.compute(this.data, internal_subgroup_id);
 
-	for (var i = 0; i < this.childs.length; ++i) {
+	for (let i = 0; i < this.childs.length; ++i) {
 		// do not pass internal_subgroup_id to recursive calls
 		currentNode[1].appendChild(this.childs[i].render());
 	}
@@ -436,16 +436,16 @@ Morebits.quickForm.element.prototype.render = function QuickFormElementRender(in
 
 /** @memberof Morebits.quickForm.element */
 Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(data, in_id) {
-	var node;
-	var childContainer = null;
-	var label;
-	var id = (in_id ? in_id + '_' : '') + 'node_' + Morebits.quickForm.element.id++;
+	let node;
+	let childContainer = null;
+	let label;
+	let id = (in_id ? in_id + '_' : '') + 'node_' + Morebits.quickForm.element.id++;
 	if (data.adminonly && !Morebits.userIsSysop) {
 		// hell hack alpha
 		data.type = 'hidden';
 	}
 
-	var i, current, subnode;
+	let i, current, subnode;
 	switch (data.type) {
 		case 'form':
 			node = document.createElement('form');
@@ -546,7 +546,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 			if (data.list) {
 				for (i = 0; i < data.list.length; ++i) {
-					var cur_id = id + '_' + i;
+					let cur_id = id + '_' + i;
 					current = data.list[i];
 					var cur_div;
 					if (current.type === 'header') {
@@ -593,7 +593,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 
 					var event;
 					if (current.subgroup) {
-						var tmpgroup = current.subgroup;
+						let tmpgroup = current.subgroup;
 
 						if (!Array.isArray(tmpgroup)) {
 							tmpgroup = [ tmpgroup ];
@@ -604,7 +604,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							id: id + '_' + i + '_subgroup'
 						});
 						$.each(tmpgroup, function(idx, el) {
-							var newEl = $.extend({}, el);
+							let newEl = $.extend({}, el);
 							if (!newEl.type) {
 								newEl.type = data.type;
 							}
@@ -612,7 +612,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							subgroupRaw.append(newEl);
 						});
 
-						var subgroup = subgroupRaw.render(cur_id);
+						let subgroup = subgroupRaw.render(cur_id);
 						subgroup.className = 'quickformSubgroup';
 						subnode.subgroup = subgroup;
 						subnode.shown = false;
@@ -621,7 +621,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							if (e.target.checked) {
 								e.target.parentNode.appendChild(e.target.subgroup);
 								if (e.target.type === 'radio') {
-									var name = e.target.name;
+									let name = e.target.name;
 									if (e.target.form.names[name] !== undefined) {
 										e.target.form.names[name].parentNode.removeChild(e.target.form.names[name].subgroup);
 									}
@@ -638,7 +638,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					} else if (data.type === 'radio') {
 						event = function(e) {
 							if (e.target.checked) {
-								var name = e.target.name;
+								let name = e.target.name;
 								if (e.target.form.names[name] !== undefined) {
 									e.target.form.names[name].parentNode.removeChild(e.target.form.names[name].subgroup);
 								}
@@ -717,7 +717,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				label: 'more',
 				disabled: min >= max,
 				event: function(e) {
-					var new_node = new Morebits.quickForm.element(e.target.sublist);
+					let new_node = new Morebits.quickForm.element(e.target.sublist);
 					e.target.area.appendChild(new_node.render());
 
 					if (++e.target.counter >= e.target.max) {
@@ -745,7 +745,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			};
 
 			for (i = 0; i < min; ++i) {
-				var elem = new Morebits.quickForm.element(sublist);
+				let elem = new Morebits.quickForm.element(sublist);
 				listNode.appendChild(elem.render());
 			}
 			sublist.remove = true;
@@ -761,17 +761,17 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 
 			data.inputs.forEach(function(subdata) {
-				var cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
+				let cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
 				node.appendChild(cell.render());
 			});
 			if (data.remove) {
-				var remove = this.compute({
+				let remove = this.compute({
 					type: 'button',
 					label: 'remove',
 					event: function(e) {
-						var list = e.target.listnode;
-						var node = e.target.inputnode;
-						var more = e.target.morebutton;
+						let list = e.target.listnode;
+						let node = e.target.inputnode;
+						let more = e.target.morebutton;
 
 						list.removeChild(node);
 						--more.counter;
@@ -780,7 +780,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					}
 				});
 				node.appendChild(remove[0]);
-				var removeButton = remove[1];
+				let removeButton = remove[1];
 				removeButton.inputnode = node;
 				removeButton.listnode = data.listnode;
 				removeButton.morebutton = data.morebutton;
@@ -838,7 +838,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				node.setAttribute('name', data.name);
 			}
 			if (data.label) {
-				var result = document.createElement('span');
+				let result = document.createElement('span');
 				result.className = 'quickformDescription';
 				result.appendChild(Morebits.createHtml(data.label));
 				node.appendChild(result);
@@ -876,7 +876,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node.setAttribute('id', 'div_' + id);
 			if (data.label) {
 				label = node.appendChild(document.createElement('h5'));
-				var labelElement = document.createElement('label');
+				let labelElement = document.createElement('label');
 				labelElement.appendChild(Morebits.createHtml(data.label));
 				labelElement.setAttribute('for', data.id || id);
 				label.appendChild(labelElement);
@@ -942,7 +942,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
  * @param {object} data - Tooltip-related configuration data.
  */
 Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTooltip(node, data) {
-	var tooltipButton = node.appendChild(document.createElement('span'));
+	let tooltipButton = node.appendChild(document.createElement('span'));
 	tooltipButton.className = 'morebits-tooltipButton';
 	tooltipButton.title = data.tooltip; // Provides the content for jQuery UI
 	tooltipButton.appendChild(document.createTextNode(msg('tooltip-mark', '?')));
@@ -966,10 +966,10 @@ Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTo
  * @returns {object} With field names as keys, input data as values.
  */
 Morebits.quickForm.getInputData = function(form) {
-	var result = {};
+	let result = {};
 
-	for (var i = 0; i < form.elements.length; i++) {
-		var field = form.elements[i];
+	for (let i = 0; i < form.elements.length; i++) {
+		let field = form.elements[i];
 		if (field.disabled || !field.name || !field.type ||
 			field.type === 'submit' || field.type === 'button') {
 			continue;
@@ -977,7 +977,7 @@ Morebits.quickForm.getInputData = function(form) {
 
 		// For elements in subgroups, quickform prepends element names with
 		// name of the parent group followed by a period, get rid of that.
-		var fieldNameNorm = field.name.slice(field.name.indexOf('.') + 1);
+		let fieldNameNorm = field.name.slice(field.name.indexOf('.') + 1);
 
 		switch (field.type) {
 			case 'radio':
@@ -1027,9 +1027,9 @@ Morebits.quickForm.getInputData = function(form) {
  * @returns {HTMLElement[]} - Array of matching form elements.
  */
 Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) {
-	var $form = $(form);
+	let $form = $(form);
 	fieldName = $.escapeSelector(fieldName); // sanitize input
-	var $elements = $form.find('[name="' + fieldName + '"]');
+	let $elements = $form.find('[name="' + fieldName + '"]');
 	if ($elements.length > 0) {
 		return $elements.toArray();
 	}
@@ -1047,7 +1047,7 @@ Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) 
  * @returns {HTMLInputElement}
  */
 Morebits.quickForm.getCheckboxOrRadio = function QuickFormGetCheckboxOrRadio(elementArray, value) {
-	var found = $.grep(elementArray, function(el) {
+	let found = $.grep(elementArray, function(el) {
 		return el.value === value;
 	});
 	if (found.length > 0) {
@@ -1107,7 +1107,7 @@ Morebits.quickForm.getElementLabelObject = function QuickFormGetElementLabelObje
  * @returns {string}
  */
 Morebits.quickForm.getElementLabel = function QuickFormGetElementLabel(element) {
-	var labelElement = Morebits.quickForm.getElementLabelObject(element);
+	let labelElement = Morebits.quickForm.getElementLabelObject(element);
 
 	if (!labelElement) {
 		return null;
@@ -1124,7 +1124,7 @@ Morebits.quickForm.getElementLabel = function QuickFormGetElementLabel(element) 
  * @returns {boolean} True if succeeded, false if the label element is unavailable.
  */
 Morebits.quickForm.setElementLabel = function QuickFormSetElementLabel(element, labelText) {
-	var labelElement = Morebits.quickForm.getElementLabelObject(element);
+	let labelElement = Morebits.quickForm.getElementLabelObject(element);
 
 	if (!labelElement) {
 		return false;
@@ -1202,14 +1202,14 @@ Morebits.quickForm.setElementTooltipVisibility = function QuickFormSetElementToo
  * checked property set to true.
  */
 HTMLFormElement.prototype.getChecked = function(name, type) {
-	var elements = this.elements[name];
+	let elements = this.elements[name];
 	if (!elements) {
 		return [];
 	}
-	var return_array = [];
-	var i;
+	let return_array = [];
+	let i;
 	if (elements instanceof HTMLSelectElement) {
-		var options = elements.options;
+		let options = elements.options;
 		for (i = 0; i < options.length; ++i) {
 			if (options[i].selected) {
 				if (options[i].values) {
@@ -1256,14 +1256,14 @@ HTMLFormElement.prototype.getChecked = function(name, type) {
  * checked property set to true.
  */
 HTMLFormElement.prototype.getUnchecked = function(name, type) {
-	var elements = this.elements[name];
+	let elements = this.elements[name];
 	if (!elements) {
 		return [];
 	}
-	var return_array = [];
-	var i;
+	let return_array = [];
+	let i;
 	if (elements instanceof HTMLSelectElement) {
-		var options = elements.options;
+		let options = elements.options;
 		for (i = 0; i < options.length; ++i) {
 			if (!options[i].selected) {
 				if (options[i].values) {
@@ -1324,14 +1324,14 @@ Morebits.ip = {
 		// Remove any whitespaces, convert to upper case
 		address = address.toUpperCase();
 		// Expand zero abbreviations
-		var abbrevPos = address.indexOf('::');
+		let abbrevPos = address.indexOf('::');
 		if (abbrevPos > -1) {
 			// We know this is valid IPv6. Find the last index of the
 			// address before any CIDR number (e.g. "a:b:c::/24").
-			var CIDRStart = address.indexOf('/');
-			var addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
+			let CIDRStart = address.indexOf('/');
+			let addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
 			// If the '::' is at the beginning...
-			var repeat, extra, pad;
+			let repeat, extra, pad;
 			if (abbrevPos === 0) {
 				repeat = '0:';
 				extra = address === '::' ? '0' : ''; // for the address '::'
@@ -1347,9 +1347,9 @@ Morebits.ip = {
 				extra = ':';
 				pad = 8; // 6+2 (due to '::')
 			}
-			var replacement = repeat;
+			let replacement = repeat;
 			pad -= address.split(':').length - 1;
-			for (var i = 1; i < pad; i++) {
+			for (let i = 1; i < pad; i++) {
 				replacement += repeat;
 			}
 			replacement += extra;
@@ -1380,7 +1380,7 @@ Morebits.ip = {
 	 */
 	validCIDR: function (ip) {
 		if (Morebits.ip.isRange(ip)) {
-			var subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
+			let subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
 			if (subnet) { // Should be redundant
 				if (mw.util.isIPv6Address(ip, true)) {
 					if (subnet >= 32) {
@@ -1407,12 +1407,12 @@ Morebits.ip = {
 		if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
 			return false;
 		}
-		var subnetMatch = ipv6.match(/\/(\d{1,3})$/);
+		let subnetMatch = ipv6.match(/\/(\d{1,3})$/);
 		if (subnetMatch && parseInt(subnetMatch[1], 10) < 64) {
 			return false;
 		}
 		ipv6 = Morebits.ip.sanitizeIPv6(ipv6);
-		var ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
+		let ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
 		return ipv6.replace(ip_re, '$1' + '0:0:0:0/64');
 	}
 };
@@ -1459,9 +1459,9 @@ Morebits.string = {
 		if (start.length !== end.length) {
 			throw new Error('start marker and end marker must be of the same length');
 		}
-		var level = 0;
-		var initial = null;
-		var result = [];
+		let level = 0;
+		let initial = null;
+		let result = [];
 		if (!Array.isArray(skiplist)) {
 			if (skiplist === undefined) {
 				skiplist = [];
@@ -1471,8 +1471,8 @@ Morebits.string = {
 				throw new Error('non-applicable skiplist parameter');
 			}
 		}
-		for (var i = 0; i < str.length; ++i) {
-			for (var j = 0; j < skiplist.length; ++j) {
+		for (let i = 0; i < str.length; ++i) {
+			for (let j = 0; j < skiplist.length; ++j) {
 				if (str.substr(i, skiplist[j].length) === skiplist[j]) {
 					i += skiplist[j].length - 1;
 					continue;
@@ -1508,13 +1508,13 @@ Morebits.string = {
 	 * @returns {string}
 	 */
 	formatReasonText: function(str, addSig) {
-		var reason = (str || '').toString().trim();
-		var unbinder = new Morebits.unbinder(reason);
+		let reason = (str || '').toString().trim();
+		let unbinder = new Morebits.unbinder(reason);
 		unbinder.unbind('<no' + 'wiki>', '</no' + 'wiki>');
 		unbinder.content = unbinder.content.replace(/\|/g, '{{subst:!}}');
 		reason = unbinder.rebind();
 		if (addSig) {
-			var sig = '~~~~', sigIndex = reason.lastIndexOf(sig);
+			let sig = '~~~~', sigIndex = reason.lastIndexOf(sig);
 			if (sigIndex === -1 || sigIndex !== reason.length - sig.length) {
 				reason += ' ' + sig;
 			}
@@ -1636,9 +1636,9 @@ Morebits.array = {
 		if (typeof size !== 'number' || size <= 0) { // pretty impossible to do anything :)
 			return [ arr ]; // we return an array consisting of this array.
 		}
-		var numChunks = Math.ceil(arr.length / size);
-		var result = new Array(numChunks);
-		for (var i = 0; i < numChunks; i++) {
+		let numChunks = Math.ceil(arr.length / size);
+		let result = new Array(numChunks);
+		for (let i = 0; i < numChunks; i++) {
 			result[i] = arr.slice(i * size, (i + 1) * size);
 		}
 		return result;
@@ -1662,8 +1662,8 @@ Morebits.select2 = {
 		 * group are shown, like in jquery.chosen.
 		 */
 		optgroupFull: function(params, data) {
-			var originalMatcher = $.fn.select2.defaults.defaults.matcher;
-			var result = originalMatcher(params, data);
+			let originalMatcher = $.fn.select2.defaults.defaults.matcher;
+			let result = originalMatcher(params, data);
 
 			if (result && params.term &&
 				data.text.toUpperCase().indexOf(params.term.toUpperCase()) !== -1) {
@@ -1674,8 +1674,8 @@ Morebits.select2 = {
 
 		/** Custom matcher that matches from the beginning of words only. */
 		wordBeginning: function(params, data) {
-			var originalMatcher = $.fn.select2.defaults.defaults.matcher;
-			var result = originalMatcher(params, data);
+			let originalMatcher = $.fn.select2.defaults.defaults.matcher;
+			let result = originalMatcher(params, data);
 			if (!params.term || (result &&
 				new RegExp('\\b' + mw.util.escapeRegExp(params.term), 'i').test(result.text))) {
 				return result;
@@ -1686,11 +1686,11 @@ Morebits.select2 = {
 
 	/** Underline matched part of options. */
 	highlightSearchMatches: function(data) {
-		var searchTerm = Morebits.select2SearchQuery;
+		let searchTerm = Morebits.select2SearchQuery;
 		if (!searchTerm || data.loading) {
 			return data.text;
 		}
-		var idx = data.text.toUpperCase().indexOf(searchTerm.toUpperCase());
+		let idx = data.text.toUpperCase().indexOf(searchTerm.toUpperCase());
 		if (idx < 0) {
 			return data.text;
 		}
@@ -1717,13 +1717,13 @@ Morebits.select2 = {
 		if (ev.which < 48) {
 			return;
 		}
-		var target = $(ev.target).closest('.select2-container');
+		let target = $(ev.target).closest('.select2-container');
 		if (!target.length) {
 			return;
 		}
 		target = target.prev();
 		target.select2('open');
-		var search = target.data('select2').dropdown.$search ||
+		let search = target.data('select2').dropdown.$search ||
 			target.data('select2').selection.$search;
 		// Use DOM .focus() to work around a jQuery 3.6.0 regression (https://github.com/select2/select2/issues/5993)
 		search[0].focus();
@@ -1770,7 +1770,7 @@ Morebits.unbinder.prototype = {
 		if (!prefix || !postfix) {
 			throw new Error('Both prefix and postfix must be provided');
 		}
-		var re = new RegExp(prefix + '([\\s\\S]*?)' + postfix, 'g');
+		let re = new RegExp(prefix + '([\\s\\S]*?)' + postfix, 'g');
 		this.content = this.content.replace(re, Morebits.unbinder.getCallback(this));
 	},
 
@@ -1780,9 +1780,9 @@ Morebits.unbinder.prototype = {
 	 * @returns {string} The processed output.
 	 */
 	rebind: function UnbinderRebind() {
-		var content = this.content;
+		let content = this.content;
 		content.self = this;
-		for (var current in this.history) {
+		for (let current in this.history) {
 			if (Object.prototype.hasOwnProperty.call(this.history, current)) {
 				content = content.replace(current, this.history[current]);
 			}
@@ -1798,7 +1798,7 @@ Morebits.unbinder.prototype = {
 /** @memberof Morebits.unbinder */
 Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
 	return function UnbinderCallback(match) {
-		var current = self.prefix + self.counter + self.postfix;
+		let current = self.prefix + self.counter + self.postfix;
 		self.history[current] = match;
 		++self.counter;
 		return current;
@@ -1817,24 +1817,24 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * @class
  */
 Morebits.date = function() {
-	var args = Array.prototype.slice.call(arguments);
+	let args = Array.prototype.slice.call(arguments);
 
 	// Check MediaWiki formats
 	// Must be first since firefox erroneously accepts the timestamp
 	// format, sans timezone (See also: #921, #936, #1174, #1187), and the
 	// 14-digit string will be interpreted differently.
 	if (args.length === 1) {
-		var param = args[0];
+		let param = args[0];
 		if (/^\d{14}$/.test(param)) {
 			// YYYYMMDDHHmmss
-			var digitMatch = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(param);
+			let digitMatch = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(param);
 			if (digitMatch) {
 				// ..... year ... month .. date ... hour .... minute ..... second
 				this._d = new Date(Date.UTC.apply(null, [digitMatch[1], digitMatch[2] - 1, digitMatch[3], digitMatch[4], digitMatch[5], digitMatch[6]]));
 			}
 		} else if (typeof param === 'string') {
 			// Wikitext signature timestamp
-			var dateParts = Morebits.l10n.signatureTimestampFormat(param);
+			let dateParts = Morebits.l10n.signatureTimestampFormat(param);
 			if (dateParts) {
 				this._d = new Date(Date.UTC.apply(null, dateParts));
 			}
@@ -1979,13 +1979,13 @@ Morebits.date.prototype = {
 	 * @returns {Morebits.date}
 	 */
 	add: function(number, unit) {
-		var num = parseInt(number, 10); // normalize
+		let num = parseInt(number, 10); // normalize
 		if (isNaN(num)) {
 			throw new Error('Invalid number "' + number + '" provided.');
 		}
 		unit = unit.toLowerCase(); // normalize
-		var unitMap = Morebits.date.unitMap;
-		var unitNorm = unitMap[unit] || unitMap[unit + 's']; // so that both singular and  plural forms work
+		let unitMap = Morebits.date.unitMap;
+		let unitNorm = unitMap[unit] || unitMap[unit + 's']; // so that both singular and  plural forms work
 		if (unitNorm) {
 			// No built-in week functions, so rather than build out ISO's getWeek/setWeek, just multiply
 			// Probably can't be used for Julian->Gregorian changeovers, etc.
@@ -2051,7 +2051,7 @@ Morebits.date.prototype = {
 		if (!this.isValid()) {
 			return 'Invalid date'; // Put the truth out, preferable to "NaNNaNNan NaN:NaN" or whatever
 		}
-		var udate = this;
+		let udate = this;
 		// create a new date object that will contain the date to display as system time
 		if (zone === 'utc') {
 			udate = new Morebits.date(this.getTime()).add(this.getTimezoneOffset(), 'minutes');
@@ -2065,14 +2065,14 @@ Morebits.date.prototype = {
 			return udate.toISOString();
 		}
 
-		var pad = function(num, len) {
+		let pad = function(num, len) {
 			len = len || 2; // Up to length of 00 + 1
 			return ('00' + num).toString().slice(0 - len);
 		};
-		var h24 = udate.getHours(), m = udate.getMinutes(), s = udate.getSeconds(), ms = udate.getMilliseconds();
-		var D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
-		var h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? msg('period-pm', 'PM') : msg('period-am', 'AM');
-		var replacementMap = {
+		let h24 = udate.getHours(), m = udate.getMinutes(), s = udate.getSeconds(), ms = udate.getMilliseconds();
+		let D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
+		let h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? msg('period-pm', 'PM') : msg('period-am', 'AM');
+		let replacementMap = {
 			HH: pad(h24), H: h24, hh: pad(h12), h: h12, A: amOrPm,
 			mm: pad(m), m: m,
 			ss: pad(s), s: s,
@@ -2083,7 +2083,7 @@ Morebits.date.prototype = {
 			YYYY: Y, YY: pad(Y % 100), Y: Y
 		};
 
-		var unbinder = new Morebits.unbinder(formatstr); // escape stuff between [...]
+		let unbinder = new Morebits.unbinder(formatstr); // escape stuff between [...]
 		unbinder.unbind('\\[', '\\]');
 		unbinder.content = unbinder.content.replace(
 			/* Regex notes:
@@ -2109,7 +2109,7 @@ Morebits.date.prototype = {
 	calendar: function(zone) {
 		// Zero out the hours, minutes, seconds and milliseconds - keeping only the date;
 		// find the difference. Note that setHours() returns the same thing as getTime().
-		var dateDiff = (new Date().setHours(0, 0, 0, 0) -
+		let dateDiff = (new Date().setHours(0, 0, 0, 0) -
 			new Date(this).setHours(0, 0, 0, 0)) / 8.64e7;
 		switch (true) {
 			case dateDiff === 0:
@@ -2150,8 +2150,8 @@ Morebits.date.prototype = {
 		level = parseInt(level, 10);
 		level = isNaN(level) ? 2 : level;
 
-		var header = '='.repeat(level);
-		var text = this.getUTCMonthName() + ' ' + this.getUTCFullYear();
+		let header = '='.repeat(level);
+		let text = this.getUTCMonthName() + ' ' + this.getUTCFullYear();
 
 		if (header.length) { // wikitext-formatted header
 			return header + ' ' + text + ' ' + header;
@@ -2377,7 +2377,7 @@ Morebits.wiki.api.prototype = {
 
 		++Morebits.wiki.numberOfActionsLeft;
 
-		var queryString = $.map(this.query, function(val, i) {
+		let queryString = $.map(this.query, function(val, i) {
 			if (Array.isArray(val)) {
 				return encodeURIComponent(i) + '=' + val.map(encodeURIComponent).join('|');
 			} else if (val !== undefined) {
@@ -2386,7 +2386,7 @@ Morebits.wiki.api.prototype = {
 		}).join('&').replace(/^(.*?)(\btoken=[^&]*)&(.*)/, '$1$3&$2');
 		// token should always be the last item in the query string (bug TW-B-0013)
 
-		var ajaxparams = $.extend({}, {
+		let ajaxparams = $.extend({}, {
 			context: this,
 			type: this.query.action === 'query' ? 'GET' : 'POST',
 			url: mw.util.wikiScript('api'),
@@ -2496,7 +2496,7 @@ Morebits.wiki.api.prototype = {
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
 Morebits.wiki.getCachedJson = function(title) {
-	var query = {
+	let query = {
 		action: 'query',
 		prop: 'revisions',
 		titles: title,
@@ -2508,8 +2508,8 @@ Morebits.wiki.getCachedJson = function(title) {
 	};
 	return new Morebits.wiki.api('', query).post().then(function(apiobj) {
 		apiobj.getStatusElement().unlink();
-		var response = apiobj.getResponse();
-		var wikitext = response.query.pages[0].revisions[0].slots.main.content;
+		let response = apiobj.getResponse();
+		let wikitext = response.query.pages[0].revisions[0].slots.main.content;
 		return JSON.parse(wikitext);
 	});
 };
@@ -2552,7 +2552,7 @@ var morebitsWikiChangeTag = '';
  * @returns {string} MediaWiki CSRF token.
  */
 Morebits.wiki.api.getToken = function() {
-	var tokenApi = new Morebits.wiki.api(msg('getting-token', 'Getting token'), {
+	let tokenApi = new Morebits.wiki.api(msg('getting-token', 'Getting token'), {
 		action: 'query',
 		meta: 'tokens',
 		type: 'csrf',
@@ -2626,7 +2626,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 *
 	 * @private
 	 */
-	var ctx = {
+	let ctx = {
 		// backing fields for public properties
 		pageName: pageName,
 		pageExists: false,
@@ -2738,7 +2738,7 @@ Morebits.wiki.page = function(pageName, status) {
 		stabilizeProcessApi: null
 	};
 
-	var emptyFunction = function() { };
+	let emptyFunction = function() { };
 
 	/**
 	 * Loads the text for the page.
@@ -2811,7 +2811,7 @@ Morebits.wiki.page = function(pageName, status) {
 		ctx.onSaveFailure = onFailure || emptyFunction;
 
 		// are we getting our editing token from mw.user.tokens?
-		var canUseMwUserToken = fnCanUseMwUserToken('edit');
+		let canUseMwUserToken = fnCanUseMwUserToken('edit');
 
 		if (!ctx.pageLoaded && !canUseMwUserToken) {
 			ctx.statusElement.error('Internal error: attempt to save a page that has not been loaded!');
@@ -2851,7 +2851,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		ctx.retries = 0;
 
-		var query = {
+		let query = {
 			action: 'edit',
 			title: ctx.pageName,
 			summary: ctx.editSummary,
@@ -3487,7 +3487,7 @@ Morebits.wiki.page = function(pageName, status) {
 			return;
 		}
 
-		var query = {
+		let query = {
 			action: 'query',
 			prop: 'revisions',
 			titles: ctx.pageName,
@@ -3559,7 +3559,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('move')) {
 			fnProcessMove.call(this, this);
 		} else {
-			var query = fnNeedTokenInfoQuery('move');
+			let query = fnNeedTokenInfoQuery('move');
 
 			ctx.moveApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessMove, ctx.statusElement, ctx.onMoveFailure);
 			ctx.moveApi.setParent(this);
@@ -3583,11 +3583,11 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// If a link is present, don't need to check if it's patrolled
 		if ($('.patrollink').length) {
-			var patrolhref = $('.patrollink a').attr('href');
+			let patrolhref = $('.patrollink a').attr('href');
 			ctx.rcid = mw.util.getParamValue('rcid', patrolhref);
 			fnProcessPatrol(this, this);
 		} else {
-			var patrolQuery = {
+			let patrolQuery = {
 				action: 'query',
 				prop: 'info',
 				meta: 'tokens',
@@ -3637,7 +3637,7 @@ Morebits.wiki.page = function(pageName, status) {
 				ctx.pageID = mw.config.get('wgArticleId');
 				fnProcessTriageList(this, this);
 			} else {
-				var query = fnNeedTokenInfoQuery('triage');
+				let query = fnNeedTokenInfoQuery('triage');
 
 				ctx.triageApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessTriageList);
 				ctx.triageApi.setParent(this);
@@ -3664,7 +3664,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('delete')) {
 			fnProcessDelete.call(this, this);
 		} else {
-			var query = fnNeedTokenInfoQuery('delete');
+			let query = fnNeedTokenInfoQuery('delete');
 
 			ctx.deleteApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessDelete, ctx.statusElement, ctx.onDeleteFailure);
 			ctx.deleteApi.setParent(this);
@@ -3689,7 +3689,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('undelete')) {
 			fnProcessUndelete.call(this, this);
 		} else {
-			var query = fnNeedTokenInfoQuery('undelete');
+			let query = fnNeedTokenInfoQuery('undelete');
 
 			ctx.undeleteApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessUndelete, ctx.statusElement, ctx.onUndeleteFailure);
 			ctx.undeleteApi.setParent(this);
@@ -3720,7 +3720,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// because of the way MW API interprets protection levels
 		// (absolute, not differential), we always need to request
 		// protection levels from the server
-		var query = fnNeedTokenInfoQuery('protect');
+		let query = fnNeedTokenInfoQuery('protect');
 
 		ctx.protectApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessProtect, ctx.statusElement, ctx.onProtectFailure);
 		ctx.protectApi.setParent(this);
@@ -3755,7 +3755,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('stabilize')) {
 			fnProcessStabilize.call(this, this);
 		} else {
-			var query = fnNeedTokenInfoQuery('stabilize');
+			let query = fnNeedTokenInfoQuery('stabilize');
 
 			ctx.stabilizeApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessStabilize, ctx.statusElement, ctx.onStabilizeFailure);
 			ctx.stabilizeApi.setParent(this);
@@ -3808,7 +3808,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 			// wgRestrictionEdit is null on non-existent pages,
 			// so this neatly handles nonexistent pages
-			var editRestriction = mw.config.get('wgRestrictionEdit');
+			let editRestriction = mw.config.get('wgRestrictionEdit');
 			if (!editRestriction || editRestriction.indexOf('sysop') !== -1) {
 				return false;
 			}
@@ -3833,7 +3833,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 * @returns {object} Appropriate query.
 	 */
 	var fnNeedTokenInfoQuery = function(action) {
-		var query = {
+		let query = {
 			action: 'query',
 			meta: 'tokens',
 			type: 'csrf',
@@ -3859,13 +3859,13 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from loadApi.post()
 	var fnLoadSuccess = function() {
-		var response = ctx.loadApi.getResponse().query;
+		let response = ctx.loadApi.getResponse().query;
 
 		if (!fnCheckPageName(response, ctx.onLoadFailure)) {
 			return; // abort
 		}
 
-		var page = response.pages[0], rev;
+		let page = response.pages[0], rev;
 		ctx.pageExists = !page.missing;
 		if (ctx.pageExists) {
 			rev = page.revisions[0];
@@ -3895,7 +3895,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info, to alert admins when they are about to edit a protected page
 		// Includes cascading protection
 		if (Morebits.userIsSysop) {
-			var editProt = page.protection.filter(function(pr) {
+			let editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -3907,7 +3907,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		ctx.revertCurID = page.lastrevid;
 
-		var testactions = page.actions;
+		let testactions = page.actions;
 		ctx.testActions = []; // was null
 		Object.keys(testactions).forEach(function(action) {
 			if (testactions[action]) {
@@ -3948,7 +3948,7 @@ Morebits.wiki.page = function(pageName, status) {
 			onFailure = emptyFunction;
 		}
 
-		var page = response.pages && response.pages[0];
+		let page = response.pages && response.pages[0];
 		if (page) {
 			// check for invalid titles
 			if (page.invalid) {
@@ -3958,12 +3958,12 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 
 			// retrieve actual title of the page after normalization and redirects
-			var resolvedName = page.title;
+			let resolvedName = page.title;
 
 			if (response.redirects) {
 				// check for cross-namespace redirect:
-				var origNs = new mw.Title(ctx.pageName).namespace;
-				var newNs = new mw.Title(resolvedName).namespace;
+				let origNs = new mw.Title(ctx.pageName).namespace;
+				let newNs = new mw.Title(resolvedName).namespace;
 				if (origNs !== newNs && !ctx.followCrossNsRedirect) {
 					ctx.statusElement.error(msg('cross-redirect-abort', ctx.pageName, resolvedName, ctx.pageName + ' is a cross-namespace redirect to ' + resolvedName + ', aborted'));
 					onFailure(this);
@@ -4004,10 +4004,10 @@ Morebits.wiki.page = function(pageName, status) {
 			if (!ctx.watched || Morebits.string.isInfinity(ctx.watchlistExpiry)) {
 				return true;
 			} else if (typeof ctx.watched === 'string') {
-				var newExpiry;
+				let newExpiry;
 				// Attempt to determine if the new expiry is a
 				// relative (e.g. `1 month`) or absolute datetime
-				var rel = ctx.watchlistExpiry.split(' ');
+				let rel = ctx.watchlistExpiry.split(' ');
 				try {
 					newExpiry = new Morebits.date().add(rel[0], rel[1]);
 				} catch (e) {
@@ -4033,14 +4033,14 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from saveApi.post()
 	var fnSaveSuccess = function() {
 		ctx.editMode = 'all';  // cancel append/prepend/newSection/revert modes
-		var response = ctx.saveApi.getResponse();
+		let response = ctx.saveApi.getResponse();
 
 		// see if the API thinks we were successful
 		if (response.edit.result === 'Success') {
 
 			// real success
 			// default on success action - display link for edited page
-			var link = document.createElement('a');
+			let link = document.createElement('a');
 			link.setAttribute('href', mw.util.getUrl(ctx.pageName));
 			link.appendChild(document.createTextNode(ctx.pageName));
 			ctx.statusElement.info(['completed (', link, ')']);
@@ -4066,18 +4066,18 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from saveApi.post()
 	var fnSaveError = function() {
-		var errorCode = ctx.saveApi.getErrorCode();
+		let errorCode = ctx.saveApi.getErrorCode();
 
 		// check for edit conflict
 		if (errorCode === 'editconflict' && ctx.conflictRetries++ < ctx.maxConflictRetries) {
 
 			// edit conflicts can occur when the page needs to be purged from the server cache
-			var purgeQuery = {
+			let purgeQuery = {
 				action: 'purge',
 				titles: ctx.pageName  // redirects are already resolved
 			};
 
-			var purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, function() {
+			let purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, function() {
 				--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 
 				ctx.statusElement.info(msg('editconflict-retrying', 'Edit conflict detected, reapplying edit'));
@@ -4103,8 +4103,8 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// hard error, give up
 		} else {
-			var response = ctx.saveApi.getResponse();
-			var errorData = response.error || // bc error format
+			let response = ctx.saveApi.getResponse();
+			let errorData = response.error || // bc error format
 				response.errors[0].data; // html/wikitext/plaintext error format
 
 			switch (errorCode) {
@@ -4141,7 +4141,7 @@ Morebits.wiki.page = function(pageName, status) {
 		}
 	};
 
-	var isTextRedirect = function(text) {
+	let isTextRedirect = function(text) {
 		if (!text) { // no text - content empty or inaccessible (revdelled or suppressed)
 			return false;
 		}
@@ -4151,13 +4151,13 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnLookupCreationSuccess = function() {
-		var response = ctx.lookupCreationApi.getResponse().query;
+		let response = ctx.lookupCreationApi.getResponse().query;
 
 		if (!fnCheckPageName(response, ctx.onLookupCreationFailure)) {
 			return; // abort
 		}
 
-		var rev = response.pages[0].revisions && response.pages[0].revisions[0];
+		let rev = response.pages[0].revisions && response.pages[0].revisions[0];
 		if (!rev) {
 			ctx.statusElement.error('Could not find any revisions of ' + ctx.pageName);
 			ctx.onLookupCreationFailure(this);
@@ -4194,10 +4194,10 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnLookupNonRedirectCreator = function() {
-		var response = ctx.lookupCreationApi.getResponse().query;
-		var revs = response.pages[0].revisions;
+		let response = ctx.lookupCreationApi.getResponse().query;
+		let revs = response.pages[0].revisions;
 
-		for (var i = 0; i < revs.length; i++) {
+		for (let i = 0; i < revs.length; i++) {
 
 			if (!isTextRedirect(revs[i].content)) {
 				ctx.creator = revs[i].user;
@@ -4261,13 +4261,13 @@ Morebits.wiki.page = function(pageName, status) {
 	 * @param {string} response - The response document from the API call.
 	 * @returns {boolean}
 	 */
-	var fnProcessChecks = function(action, onFailure, response) {
-		var missing = response.pages[0].missing;
+	let fnProcessChecks = function(action, onFailure, response) {
+		let missing = response.pages[0].missing;
 
 		// No undelete as an existing page could have deleted revisions
-		var actionMissing = missing && ['delete', 'stabilize', 'move'].indexOf(action) !== -1;
-		var protectMissing = action === 'protect' && missing && (ctx.protectEdit || ctx.protectMove);
-		var saltMissing = action === 'protect' && !missing && ctx.protectCreate;
+		let actionMissing = missing && ['delete', 'stabilize', 'move'].indexOf(action) !== -1;
+		let protectMissing = action === 'protect' && missing && (ctx.protectEdit || ctx.protectMove);
+		let saltMissing = action === 'protect' && !missing && ctx.protectCreate;
 
 		if (actionMissing || protectMissing || saltMissing) {
 			ctx.statusElement.error('Cannot ' + action + ' the page because it ' + (missing ? 'no longer' : 'already') + ' exists');
@@ -4277,7 +4277,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// Delete, undelete, move
 		// extract protection info
-		var editprot;
+		let editprot;
 		if (action === 'undelete') {
 			editprot = response.pages[0].protection.filter(function(pr) {
 				return pr.type === 'create' && pr.level === 'sysop';
@@ -4305,25 +4305,25 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessMove = function() {
-		var pageTitle, token;
+		let pageTitle, token;
 
 		if (fnCanUseMwUserToken('move')) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			var response = ctx.moveApi.getResponse().query;
+			let response = ctx.moveApi.getResponse().query;
 
 			if (!fnProcessChecks('move', ctx.onMoveFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			var page = response.pages[0];
+			let page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		var query = {
+		let query = {
 			action: 'move',
 			from: pageTitle,
 			to: ctx.moveDestination,
@@ -4355,7 +4355,7 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessPatrol = function() {
-		var query = {
+		let query = {
 			action: 'patrol',
 			format: 'json'
 		};
@@ -4365,20 +4365,20 @@ Morebits.wiki.page = function(pageName, status) {
 			query.rcid = ctx.rcid;
 			query.token = mw.user.tokens.get('patrolToken');
 		} else {
-			var response = ctx.patrolApi.getResponse().query;
+			let response = ctx.patrolApi.getResponse().query;
 
 			// Don't patrol if not unpatrolled
 			if (!response.recentchanges[0].unpatrolled) {
 				return;
 			}
 
-			var lastrevid = response.pages[0].lastrevid;
+			let lastrevid = response.pages[0].lastrevid;
 			if (!lastrevid) {
 				return;
 			}
 			query.revid = lastrevid;
 
-			var token = response.tokens.csrftoken;
+			let token = response.tokens.csrftoken;
 			if (!token) {
 				return;
 			}
@@ -4388,7 +4388,7 @@ Morebits.wiki.page = function(pageName, status) {
 			query.tags = ctx.changeTags;
 		}
 
-		var patrolStat = new Morebits.status('Marking page as patrolled');
+		let patrolStat = new Morebits.status('Marking page as patrolled');
 
 		ctx.patrolProcessApi = new Morebits.wiki.api('patrolling page...', query, null, patrolStat);
 		ctx.patrolProcessApi.setParent(this);
@@ -4400,7 +4400,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (ctx.pageID) {
 			ctx.csrfToken = mw.user.tokens.get('csrfToken');
 		} else {
-			var response = ctx.triageApi.getResponse().query;
+			let response = ctx.triageApi.getResponse().query;
 
 			ctx.pageID = response.pages[0].pageid;
 			if (!ctx.pageID) {
@@ -4413,7 +4413,7 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 		}
 
-		var query = {
+		let query = {
 			action: 'pagetriagelist',
 			page_id: ctx.pageID,
 			format: 'json'
@@ -4426,15 +4426,15 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from triageProcessListApi.post()
 	var fnProcessTriage = function() {
-		var responseList = ctx.triageProcessListApi.getResponse().pagetriagelist;
+		let responseList = ctx.triageProcessListApi.getResponse().pagetriagelist;
 		// Exit if not in the queue
 		if (!responseList || responseList.result !== 'success') {
 			return;
 		}
-		var page = responseList.pages && responseList.pages[0];
+		let page = responseList.pages && responseList.pages[0];
 		// Do nothing if page already triaged/patrolled
 		if (!page || !parseInt(page.patrol_status, 10)) {
-			var query = {
+			let query = {
 				action: 'pagetriageaction',
 				pageid: ctx.pageID,
 				reviewed: 1,
@@ -4444,7 +4444,7 @@ Morebits.wiki.page = function(pageName, status) {
 				token: ctx.csrfToken,
 				format: 'json'
 			};
-			var triageStat = new Morebits.status('Marking page as curated');
+			let triageStat = new Morebits.status('Marking page as curated');
 			ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, null, triageStat);
 			ctx.triageProcessApi.setParent(this);
 			ctx.triageProcessApi.post();
@@ -4452,25 +4452,25 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessDelete = function() {
-		var pageTitle, token;
+		let pageTitle, token;
 
 		if (fnCanUseMwUserToken('delete')) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			var response = ctx.deleteApi.getResponse().query;
+			let response = ctx.deleteApi.getResponse().query;
 
 			if (!fnProcessChecks('delete', ctx.onDeleteFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			var page = response.pages[0];
+			let page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		var query = {
+		let query = {
 			action: 'delete',
 			title: pageTitle,
 			token: token,
@@ -4497,7 +4497,7 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from deleteProcessApi.post()
 	var fnProcessDeleteError = function() {
 
-		var errorCode = ctx.deleteProcessApi.getErrorCode();
+		let errorCode = ctx.deleteProcessApi.getErrorCode();
 
 		// check for "Database query error"
 		if (errorCode === 'internal_api_error_DBQueryError' && ctx.retries++ < ctx.maxRetries) {
@@ -4520,25 +4520,25 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessUndelete = function() {
-		var pageTitle, token;
+		let pageTitle, token;
 
 		if (fnCanUseMwUserToken('undelete')) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			var response = ctx.undeleteApi.getResponse().query;
+			let response = ctx.undeleteApi.getResponse().query;
 
 			if (!fnProcessChecks('undelete', ctx.onUndeleteFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			var page = response.pages[0];
+			let page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		var query = {
+		let query = {
 			action: 'undelete',
 			title: pageTitle,
 			token: token,
@@ -4565,7 +4565,7 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from undeleteProcessApi.post()
 	var fnProcessUndeleteError = function() {
 
-		var errorCode = ctx.undeleteProcessApi.getErrorCode();
+		let errorCode = ctx.undeleteProcessApi.getErrorCode();
 
 		// check for "Database query error"
 		if (errorCode === 'internal_api_error_DBQueryError') {
@@ -4594,20 +4594,20 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessProtect = function() {
-		var response = ctx.protectApi.getResponse().query;
+		let response = ctx.protectApi.getResponse().query;
 
 		if (!fnProcessChecks('protect', ctx.onProtectFailure, response)) {
 			return; // abort
 		}
 
-		var token = response.tokens.csrftoken;
-		var page = response.pages[0];
-		var pageTitle = page.title;
+		let token = response.tokens.csrftoken;
+		let page = response.pages[0];
+		let pageTitle = page.title;
 		ctx.watched = page.watchlistexpiry || page.watched;
 
 		// Fetch existing protection levels
-		var prs = response.pages[0].protection;
-		var editprot, moveprot, createprot;
+		let prs = response.pages[0].protection;
+		let editprot, moveprot, createprot;
 		prs.forEach(function(pr) {
 			// Filter out protection from cascading
 			if (pr.type === 'edit' && !pr.source) {
@@ -4657,7 +4657,7 @@ Morebits.wiki.page = function(pageName, status) {
 		}
 
 		// Build protection levels and expirys (expiries?) for query
-		var protections = [], expirys = [];
+		let protections = [], expirys = [];
 		if (ctx.protectEdit) {
 			protections.push('edit=' + ctx.protectEdit.level);
 			expirys.push(ctx.protectEdit.expiry);
@@ -4673,7 +4673,7 @@ Morebits.wiki.page = function(pageName, status) {
 			expirys.push(ctx.protectCreate.expiry);
 		}
 
-		var query = {
+		let query = {
 			action: 'protect',
 			title: pageTitle,
 			token: token,
@@ -4701,13 +4701,13 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessStabilize = function() {
-		var pageTitle, token;
+		let pageTitle, token;
 
 		if (fnCanUseMwUserToken('stabilize')) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			var response = ctx.stabilizeApi.getResponse().query;
+			let response = ctx.stabilizeApi.getResponse().query;
 
 			// 'stabilize' as a verb not necessarily well understood
 			if (!fnProcessChecks('stabilize', ctx.onStabilizeFailure, response)) {
@@ -4715,13 +4715,13 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 
 			token = response.tokens.csrftoken;
-			var page = response.pages[0];
+			let page = response.pages[0];
 			pageTitle = page.title;
 			// Doesn't support watchlist expiry [[phab:T263336]]
 			// ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		var query = {
+		let query = {
 			action: 'stabilize',
 			title: pageTitle,
 			token: token,
@@ -4745,7 +4745,7 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var sleep = function(milliseconds) {
-		var deferred = $.Deferred();
+		let deferred = $.Deferred();
 		setTimeout(deferred.resolve, milliseconds);
 		return deferred;
 	};
@@ -4791,11 +4791,11 @@ Morebits.wiki.preview = function(previewbox) {
 	this.beginRender = function(wikitext, pageTitle, sectionTitle) {
 		$(previewbox).show();
 
-		var statusspan = document.createElement('span');
+		let statusspan = document.createElement('span');
 		previewbox.appendChild(statusspan);
 		Morebits.status.init(statusspan);
 
-		var query = {
+		let query = {
 			action: 'parse',
 			prop: ['text', 'modules'],
 			pst: true,  // PST = pre-save transform; this makes substitution work properly
@@ -4810,13 +4810,13 @@ Morebits.wiki.preview = function(previewbox) {
 			query.section = 'new';
 			query.sectiontitle = sectionTitle;
 		}
-		var renderApi = new Morebits.wiki.api('loading...', query, fnRenderSuccess, new Morebits.status('Preview'));
+		let renderApi = new Morebits.wiki.api('loading...', query, fnRenderSuccess, new Morebits.status('Preview'));
 		return renderApi.post();
 	};
 
 	var fnRenderSuccess = function(apiobj) {
-		var response = apiobj.getResponse();
-		var html = response.parse.text;
+		let response = apiobj.getResponse();
+		let html = response.parse.text;
 		if (!html) {
 			apiobj.statelem.error('failed to retrieve preview, or template was blanked');
 			return;
@@ -4857,16 +4857,16 @@ Morebits.wikitext = {};
 Morebits.wikitext.parseTemplate = function(text, start) {
 	start = start || 0;
 
-	var level = []; // Track of how deep we are ({{, {{{, or [[)
-	var count = -1;  // Number of parameters found
-	var unnamed = 0; // Keep track of what number an unnamed parameter should receive
-	var equals = -1; // After finding "=" before a parameter, the index; otherwise, -1
-	var current = '';
-	var result = {
+	let level = []; // Track of how deep we are ({{, {{{, or [[)
+	let count = -1;  // Number of parameters found
+	let unnamed = 0; // Keep track of what number an unnamed parameter should receive
+	let equals = -1; // After finding "=" before a parameter, the index; otherwise, -1
+	let current = '';
+	let result = {
 		name: '',
 		parameters: {}
 	};
-	var key, value;
+	let key, value;
 
 	/**
 	 * Function to handle finding parameter values.
@@ -4889,7 +4889,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 				equals = -1;
 			} else {
 				// No equals, so it must be unnamed; no trim since whitespace allowed
-				var param = final ? current.substring(equals + 1, current.length - 2) : current;
+				let param = final ? current.substring(equals + 1, current.length - 2) : current;
 				if (param) {
 					result.parameters[++unnamed] = param;
 					++count;
@@ -4898,8 +4898,8 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 		}
 	}
 
-	for (var i = start; i < text.length; ++i) {
-		var test3 = text.substr(i, 3);
+	for (let i = start; i < text.length; ++i) {
+		let test3 = text.substr(i, 3);
 		if (test3 === '{{{' || (test3 === '}}}' && level[level.length - 1] === 3)) {
 			current += test3;
 			i += 2;
@@ -4910,7 +4910,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 			}
 			continue;
 		}
-		var test2 = text.substr(i, 2);
+		let test2 = text.substr(i, 2);
 		// Entering a template (or link)
 		if (test2 === '{{' || test2 === '[[') {
 			current += test2;
@@ -4975,11 +4975,11 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeLink: function(link_target) {
-		var mwTitle = mw.Title.newFromText(link_target);
-		var namespaceID = mwTitle.getNamespaceId();
-		var title = mwTitle.getMainText();
+		let mwTitle = mw.Title.newFromText(link_target);
+		let namespaceID = mwTitle.getNamespaceId();
+		let title = mwTitle.getMainText();
 
-		var link_regex_string = '';
+		let link_regex_string = '';
 		if (namespaceID !== 0) {
 			link_regex_string = Morebits.namespaceRegex(namespaceID) + ':';
 		}
@@ -4987,11 +4987,11 @@ Morebits.wikitext.page.prototype = {
 
 		// For most namespaces, unlink both [[User:Test]] and [[:User:Test]]
 		// For files and categories, only unlink [[:Category:Test]]. Do not unlink [[Category:Test]]
-		var isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
-		var colon = isFileOrCategory ? ':' : ':?';
+		let isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
+		let colon = isFileOrCategory ? ':' : ':?';
 
-		var simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
-		var piped_link_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
+		let simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
+		let piped_link_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
 		this.text = this.text.replace(simple_link_regex, '$1').replace(piped_link_regex, '$1');
 		return this;
 	},
@@ -5005,19 +5005,19 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	commentOutImage: function(image, reason) {
-		var unbinder = new Morebits.unbinder(this.text);
+		let unbinder = new Morebits.unbinder(this.text);
 		unbinder.unbind('<!--', '-->');
 
 		reason = reason ? reason + ': ' : '';
-		var image_re_string = Morebits.pageNameRegex(image);
+		let image_re_string = Morebits.pageNameRegex(image);
 
 		// Check for normal image links, i.e. [[File:Foobar.png|...]]
 		// Will eat the whole link
-		var links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		var allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
-		for (var i = 0; i < allLinks.length; ++i) {
+		let links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		let allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
+		for (let i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
-				var replacement = '<!-- ' + reason + allLinks[i] + ' -->';
+				let replacement = '<!-- ' + reason + allLinks[i] + ' -->';
 				unbinder.content = unbinder.content.replace(allLinks[i], replacement);
 				// unbind the newly created comments
 				unbinder.unbind('<!--', '-->');
@@ -5027,7 +5027,7 @@ Morebits.wikitext.page.prototype = {
 		// Check for gallery images, i.e. instances that must start on a new line,
 		// eventually preceded with some space, and must include File: prefix
 		// Will eat the whole line.
-		var gallery_image_re = new RegExp('(^\\s*' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
+		let gallery_image_re = new RegExp('(^\\s*' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
 		unbinder.content = unbinder.content.replace(gallery_image_re, '<!-- ' + reason + '$1 -->');
 
 		// unbind the newly created comments
@@ -5035,7 +5035,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Check free image usages, for example as template arguments, might have the File: prefix excluded, but must be preceded by an |
 		// Will only eat the image name and the preceding bar and an eventual named parameter
-		var free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:' + Morebits.namespaceRegex(6) + ':\\s*)?' + image_re_string + ')', 'mg');
+		let free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:' + Morebits.namespaceRegex(6) + ':\\s*)?' + image_re_string + ')', 'mg');
 		unbinder.content = unbinder.content.replace(free_image_re, '<!-- ' + reason + '$1 -->');
 		// Rebind the content now, we are done!
 		this.text = unbinder.rebind();
@@ -5050,19 +5050,19 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	addToImageComment: function(image, data) {
-		var image_re_string = Morebits.pageNameRegex(image);
-		var links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		var allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
-		for (var i = 0; i < allLinks.length; ++i) {
+		let image_re_string = Morebits.pageNameRegex(image);
+		let links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		let allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
+		for (let i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
-				var replacement = allLinks[i];
+				let replacement = allLinks[i];
 				// just put it at the end?
 				replacement = replacement.replace(/\]\]$/, '|' + data + ']]');
 				this.text = this.text.replace(allLinks[i], replacement);
 			}
 		}
-		var gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
-		var newtext = '$1|$2 ' + data;
+		let gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
+		let newtext = '$1|$2 ' + data;
 		this.text = this.text.replace(gallery_re, newtext);
 		return this;
 	},
@@ -5075,10 +5075,10 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeTemplate: function(template) {
-		var template_re_string = Morebits.pageNameRegex(template);
-		var links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
-		var allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
-		for (var i = 0; i < allTemplates.length; ++i) {
+		let template_re_string = Morebits.pageNameRegex(template);
+		let links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
+		let allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
+		for (let i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {
 				this.text = this.text.replace(allTemplates[i], '');
 			}
@@ -5200,18 +5200,18 @@ Morebits.userspaceLogger = function(logPageName) {
 	 * @returns {JQuery.Promise}
 	 */
 	this.log = function(logText, summaryText) {
-		var def = $.Deferred();
+		let def = $.Deferred();
 		if (!logText) {
 			return def.reject();
 		}
-		var page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
+		let page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
 			'Adding entry to userspace log'); // make this '... to ' + logPageName ?
 		page.load(function(pageobj) {
 			// add blurb if log page doesn't exist or is blank
-			var text = pageobj.getPageText() || this.initialText;
+			let text = pageobj.getPageText() || this.initialText;
 
 			// create monthly header if it doesn't exist already
-			var date = new Morebits.date(pageobj.getLoadTime());
+			let date = new Morebits.date(pageobj.getLoadTime());
 			if (!date.monthHeaderRegex().exec(text)) {
 				text += '\n\n' + date.monthHeader(this.headerLevel);
 			}
@@ -5415,7 +5415,7 @@ Morebits.status.error = function(text, status) {
  * @param {string} text
  */
 Morebits.status.actionCompleted = function(text) {
-	var node = document.createElement('div');
+	let node = document.createElement('div');
 	node.appendChild(document.createElement('b')).appendChild(document.createTextNode(text));
 	node.className = 'morebits_status_info morebits_action_complete';
 	if (Morebits.status.root) {
@@ -5432,9 +5432,9 @@ Morebits.status.actionCompleted = function(text) {
  * @param {string} message
  */
 Morebits.status.printUserText = function(comments, message) {
-	var p = document.createElement('p');
+	let p = document.createElement('p');
 	p.innerHTML = message;
-	var div = document.createElement('div');
+	let div = document.createElement('div');
 	div.className = 'morebits-usertext';
 	div.style.marginTop = '0';
 	div.style.whiteSpace = 'pre-wrap';
@@ -5454,7 +5454,7 @@ Morebits.status.printUserText = function(comments, message) {
  * @returns {HTMLElement}
  */
 Morebits.htmlNode = function (type, content, color) {
-	var node = document.createElement(type);
+	let node = document.createElement(type);
 	if (color) {
 		node.style.color = color;
 	}
@@ -5473,13 +5473,13 @@ Morebits.htmlNode = function (type, content, color) {
  * @param jQueryContext
  */
 Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
-	var lastCheckbox = null;
+	let lastCheckbox = null;
 
 	function clickHandler(event) {
-		var thisCb = this;
+		let thisCb = this;
 		if (event.shiftKey && lastCheckbox !== null) {
-			var cbs = $(jQuerySelector, jQueryContext); // can't cache them, obviously, if we want to support resorting
-			var index = -1, lastIndex = -1, i;
+			let cbs = $(jQuerySelector, jQueryContext); // can't cache them, obviously, if we want to support resorting
+			let index = -1, lastIndex = -1, i;
 			for (i = 0; i < cbs.length; i++) {
 				if (cbs[i] === thisCb) {
 					index = i;
@@ -5497,8 +5497,8 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
 
 			if (index > -1 && lastIndex > -1) {
 				// inspired by wikibits
-				var endState = thisCb.checked;
-				var start, finish;
+				let endState = thisCb.checked;
+				let start, finish;
 				if (index < lastIndex) {
 					start = index + 1;
 					finish = lastIndex;
@@ -5562,7 +5562,7 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
  * @param {string} [currentAction]
  */
 Morebits.batchOperation = function(currentAction) {
-	var ctx = {
+	let ctx = {
 		// backing fields for public properties
 		pageList: null,
 		options: {
@@ -5636,7 +5636,7 @@ Morebits.batchOperation = function(currentAction) {
 		ctx.currentChunkIndex = -1;
 		ctx.pageChunks = [];
 
-		var total = ctx.pageList.length;
+		let total = ctx.pageList.length;
 		if (!total) {
 			ctx.statusElement.info(msg('batch-no-pages', 'no pages specified'));
 			ctx.running = false;
@@ -5668,11 +5668,11 @@ Morebits.batchOperation = function(currentAction) {
 
 		if (arg instanceof Morebits.wiki.api || arg instanceof Morebits.wiki.page) {
 			// update or remove status line
-			var statelem = arg.getStatusElement();
+			let statelem = arg.getStatusElement();
 			if (ctx.options.preserveIndividualStatusLines) {
 				if (arg.getPageName || arg.pageName || (arg.query && arg.query.title)) {
 					// we know the page title - display a relevant message
-					var pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
+					let pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
 					statelem.info(msg('batch-done-page', pageName, 'completed ([[' + pageName + ']])'));
 				} else {
 					// we don't know the page title - just display a generic message
@@ -5697,10 +5697,10 @@ Morebits.batchOperation = function(currentAction) {
 
 	// private functions
 
-	var thisProxy = this;
+	let thisProxy = this;
 
 	var fnStartNewChunk = function() {
-		var chunk = ctx.pageChunks[++ctx.currentChunkIndex];
+		let chunk = ctx.pageChunks[++ctx.currentChunkIndex];
 		if (!chunk) {
 			return;  // done! yay
 		}
@@ -5716,9 +5716,9 @@ Morebits.batchOperation = function(currentAction) {
 		ctx.countFinished++;
 
 		// update overall status line
-		var total = ctx.pageList.length;
+		let total = ctx.pageList.length;
 		if (ctx.countFinished < total) {
-			var progress = Math.round(100 * ctx.countFinished / total);
+			let progress = Math.round(100 * ctx.countFinished / total);
 			ctx.statusElement.status(msg('percent', progress, progress + '%'));
 
 			// start a new chunk if we're close enough to the end of the previous chunk, and
@@ -5728,7 +5728,7 @@ Morebits.batchOperation = function(currentAction) {
 				fnStartNewChunk();
 			}
 		} else if (ctx.countFinished === total) {
-			var statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
+			let statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
 				'/' + ctx.countFinished + ' actions completed successfully)');
 			if (ctx.countFinishedSuccess < ctx.countFinished) {
 				ctx.statusElement.warn(statusString);
@@ -5781,7 +5781,7 @@ Morebits.taskManager = function(context) {
 	this.add = function(func, deps, onFailure) {
 		this.taskDependencyMap.set(func, deps);
 		this.failureCallbackMap.set(func, onFailure || function() {});
-		var deferred = $.Deferred();
+		let deferred = $.Deferred();
 		this.deferreds.set(func, deferred);
 	};
 
@@ -5791,13 +5791,13 @@ Morebits.taskManager = function(context) {
 	 * @returns {jQuery.Promise} - Resolved if all tasks succeed, rejected otherwise.
 	 */
 	this.execute = function() {
-		var self = this; // proxy for `this` for use inside functions where `this` is something else
+		let self = this; // proxy for `this` for use inside functions where `this` is something else
 		this.taskDependencyMap.forEach(function(deps, task) {
-			var dependencyPromisesArray = deps.map(function(dep) {
+			let dependencyPromisesArray = deps.map(function(dep) {
 				return self.deferreds.get(dep);
 			});
 			$.when.apply(self.context, dependencyPromisesArray).then(function() {
-				var result = task.apply(self.context, arguments);
+				let result = task.apply(self.context, arguments);
 				if (result === undefined) { // maybe the function threw, or it didn't return anything
 					mw.log.error('Morebits.taskManager: task returned undefined');
 					self.deferreds.get(task).reject.apply(self.context, arguments);
@@ -5828,7 +5828,7 @@ Morebits.taskManager = function(context) {
  * @param {number} height - The maximum allowable height for the content area.
  */
 Morebits.simpleWindow = function SimpleWindow(width, height) {
-	var content = document.createElement('div');
+	let content = document.createElement('div');
 	this.content = content;
 	content.className = 'morebits-dialog-content';
 	content.id = 'morebits-dialog-content-' + Math.round(Math.random() * 1e15);
@@ -5866,7 +5866,7 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 		}
 	});
 
-	var $widget = $(this.content).dialog('widget');
+	let $widget = $(this.content).dialog('widget');
 
 	// delete the placeholder button (it's only there so the buttonpane gets created)
 	$widget.find('button').each(function(key, value) {
@@ -5874,9 +5874,9 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 	});
 
 	// add container for the buttons we add, and the footer links (if any)
-	var buttonspan = document.createElement('span');
+	let buttonspan = document.createElement('span');
 	buttonspan.className = 'morebits-dialog-buttons';
-	var linksspan = document.createElement('span');
+	let linksspan = document.createElement('span');
 	linksspan.className = 'morebits-dialog-footerlinks';
 	$widget.find('.ui-dialog-buttonpane').append(buttonspan, linksspan);
 
@@ -5926,15 +5926,15 @@ Morebits.simpleWindow.prototype = {
 	 */
 	display: function() {
 		if (this.scriptName) {
-			var $widget = $(this.content).dialog('widget');
+			let $widget = $(this.content).dialog('widget');
 			$widget.find('.morebits-dialog-scriptname').remove();
-			var scriptnamespan = document.createElement('span');
+			let scriptnamespan = document.createElement('span');
 			scriptnamespan.className = 'morebits-dialog-scriptname';
 			scriptnamespan.textContent = this.scriptName + ' \u00B7 ';  // U+00B7 MIDDLE DOT = &middot;
 			$widget.find('.ui-dialog-title').prepend(scriptnamespan);
 		}
 
-		var dialog = $(this.content).dialog('open');
+		let dialog = $(this.content).dialog('open');
 		if (window.setupTooltips && window.pg && window.pg.re && window.pg.re.diff) {  // tie in with NAVPOP
 			dialog.parent()[0].ranSetupTooltipsAlready = false;
 			window.setupTooltips(dialog.parent()[0]);
@@ -6026,10 +6026,10 @@ Morebits.simpleWindow.prototype = {
 		this.content.appendChild(content);
 
 		// look for submit buttons in the content, hide them, and add a proxy button to the button pane
-		var thisproxy = this;
+		let thisproxy = this;
 		$(this.content).find('input[type="submit"], button[type="submit"]').each(function(key, value) {
 			value.style.display = 'none';
-			var button = document.createElement('button');
+			let button = document.createElement('button');
 
 			if (value.hasAttribute('value')) {
 				button.textContent = value.getAttribute('value');
@@ -6083,9 +6083,9 @@ Morebits.simpleWindow.prototype = {
 	 * @returns {Morebits.simpleWindow}
 	 */
 	addFooterLink: function(text, wikiPage, prep) {
-		var $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
+		let $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
-			var bullet = document.createElement('span');
+			let bullet = document.createElement('span');
 			bullet.textContent = msg('bullet-separator', ' \u2022 ');  // U+2022 BULLET
 			if (prep) {
 				$footerlinks.prepend(bullet);
@@ -6093,7 +6093,7 @@ Morebits.simpleWindow.prototype = {
 				$footerlinks.append(bullet);
 			}
 		}
-		var link = document.createElement('a');
+		let link = document.createElement('a');
 		link.setAttribute('href', mw.util.getUrl(wikiPage));
 		link.setAttribute('title', wikiPage);
 		link.setAttribute('target', '_blank');

--- a/morebits.js
+++ b/morebits.js
@@ -37,7 +37,7 @@
 (function (window, document, $) { // Wrap entire file with anonymous function
 
 /** @lends Morebits */
-let Morebits = {};
+const Morebits = {};
 window.Morebits = Morebits;  // allow global access
 
 /**
@@ -66,18 +66,18 @@ Morebits.i18n = {
 	 * @returns {string}
 	 */
 	getMessage: function () {
-		let args = Array.prototype.slice.call(arguments); // array of size `n`
+		const args = Array.prototype.slice.call(arguments); // array of size `n`
 		// 1st arg: message name
 		// 2nd to (n-1)th arg: message parameters
 		// nth arg: legacy English fallback
-		let msgName = args[0];
-		let fallback = args[args.length - 1];
+		const msgName = args[0];
+		const fallback = args[args.length - 1];
 		if (!Morebits.i18n.parser) {
 			return fallback;
 		}
 		// i18n libraries are generally invoked with variable number of arguments
 		// as msg(msgName, ...parameters)
-		let i18nMessage = Morebits.i18n.parser.get.apply(null, args.slice(0, -1));
+		const i18nMessage = Morebits.i18n.parser.get.apply(null, args.slice(0, -1));
 		// if no i18n message exists, i18n libraries generally give back the message name
 		if (i18nMessage === msgName) {
 			return fallback;
@@ -87,7 +87,7 @@ Morebits.i18n = {
 };
 
 // shortcut
-let msg = Morebits.i18n.getMessage;
+const msg = Morebits.i18n.getMessage;
 
 
 /**
@@ -110,12 +110,12 @@ Morebits.l10n = {
 	 */
 	signatureTimestampFormat: function (str) {
 		// HH:mm, DD Month YYYY (UTC)
-		let rgx = /(\d{2}):(\d{2}), (\d{1,2}) (\w+) (\d{4}) \(UTC\)/;
-		let match = rgx.exec(str);
+		const rgx = /(\d{2}):(\d{2}), (\d{1,2}) (\w+) (\d{4}) \(UTC\)/;
+		const match = rgx.exec(str);
 		if (!match) {
 			return null;
 		}
-		let month = Morebits.date.localeData.months.indexOf(match[4]);
+		const month = Morebits.date.localeData.months.indexOf(match[4]);
 		if (month === -1) {
 			return null;
 		}
@@ -189,7 +189,7 @@ Morebits.pageNameRegex = function(pageName) {
 	if (pageName === '') {
 		return '';
 	}
-	let firstChar = pageName[0],
+	const firstChar = pageName[0],
 		remainder = Morebits.string.escapeRegExp(pageName.slice(1));
 	if (mw.Title.phpCharToUpper(firstChar) !== firstChar.toLowerCase()) {
 		return '[' + mw.Title.phpCharToUpper(firstChar) + firstChar.toLowerCase() + ']' + remainder;
@@ -206,7 +206,7 @@ Morebits.pageNameRegex = function(pageName) {
  * @returns {DocumentFragment}
  */
 Morebits.createHtml = function(input) {
-	let fragment = document.createDocumentFragment();
+	const fragment = document.createDocumentFragment();
 	if (!input) {
 		return fragment;
 	}
@@ -231,7 +231,7 @@ Morebits.createHtml = function(input) {
  * @returns {*}
  */
 Morebits.createHtml.renderWikilinks = function (text) {
-	let ub = new Morebits.unbinder(text);
+	const ub = new Morebits.unbinder(text);
 	// Don't convert wikilinks within code tags as they're used for displaying wiki-code
 	ub.unbind('<code>', '</code>');
 	ub.content = ub.content.replace(
@@ -312,7 +312,7 @@ Morebits.quickForm = function QuickForm(event, eventType) {
  * @returns {HTMLElement}
  */
 Morebits.quickForm.prototype.render = function QuickFormRender() {
-	let ret = this.root.render();
+	const ret = this.root.render();
 	ret.names = {};
 	return ret;
 };
@@ -424,7 +424,7 @@ Morebits.quickForm.element.prototype.append = function QuickFormElementAppend(da
  * @returns {HTMLElement}
  */
 Morebits.quickForm.element.prototype.render = function QuickFormElementRender(internal_subgroup_id) {
-	let currentNode = this.compute(this.data, internal_subgroup_id);
+	const currentNode = this.compute(this.data, internal_subgroup_id);
 
 	for (let i = 0; i < this.childs.length; ++i) {
 		// do not pass internal_subgroup_id to recursive calls
@@ -439,7 +439,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 	let node;
 	let childContainer = null;
 	let label;
-	let id = (in_id ? in_id + '_' : '') + 'node_' + Morebits.quickForm.element.id++;
+	const id = (in_id ? in_id + '_' : '') + 'node_' + Morebits.quickForm.element.id++;
 	if (data.adminonly && !Morebits.userIsSysop) {
 		// hell hack alpha
 		data.type = 'hidden';
@@ -546,7 +546,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 			if (data.list) {
 				for (i = 0; i < data.list.length; ++i) {
-					let cur_id = id + '_' + i;
+					const cur_id = id + '_' + i;
 					current = data.list[i];
 					var cur_div;
 					if (current.type === 'header') {
@@ -604,7 +604,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							id: id + '_' + i + '_subgroup'
 						});
 						$.each(tmpgroup, function(idx, el) {
-							let newEl = $.extend({}, el);
+							const newEl = $.extend({}, el);
 							if (!newEl.type) {
 								newEl.type = data.type;
 							}
@@ -612,7 +612,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							subgroupRaw.append(newEl);
 						});
 
-						let subgroup = subgroupRaw.render(cur_id);
+						const subgroup = subgroupRaw.render(cur_id);
 						subgroup.className = 'quickformSubgroup';
 						subnode.subgroup = subgroup;
 						subnode.shown = false;
@@ -621,7 +621,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 							if (e.target.checked) {
 								e.target.parentNode.appendChild(e.target.subgroup);
 								if (e.target.type === 'radio') {
-									let name = e.target.name;
+									const name = e.target.name;
 									if (e.target.form.names[name] !== undefined) {
 										e.target.form.names[name].parentNode.removeChild(e.target.form.names[name].subgroup);
 									}
@@ -638,7 +638,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					} else if (data.type === 'radio') {
 						event = function(e) {
 							if (e.target.checked) {
-								let name = e.target.name;
+								const name = e.target.name;
 								if (e.target.form.names[name] !== undefined) {
 									e.target.form.names[name].parentNode.removeChild(e.target.form.names[name].subgroup);
 								}
@@ -717,7 +717,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				label: 'more',
 				disabled: min >= max,
 				event: function(e) {
-					let new_node = new Morebits.quickForm.element(e.target.sublist);
+					const new_node = new Morebits.quickForm.element(e.target.sublist);
 					e.target.area.appendChild(new_node.render());
 
 					if (++e.target.counter >= e.target.max) {
@@ -745,7 +745,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			};
 
 			for (i = 0; i < min; ++i) {
-				let elem = new Morebits.quickForm.element(sublist);
+				const elem = new Morebits.quickForm.element(sublist);
 				listNode.appendChild(elem.render());
 			}
 			sublist.remove = true;
@@ -761,17 +761,17 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 
 			data.inputs.forEach(function(subdata) {
-				let cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
+				const cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
 				node.appendChild(cell.render());
 			});
 			if (data.remove) {
-				let remove = this.compute({
+				const remove = this.compute({
 					type: 'button',
 					label: 'remove',
 					event: function(e) {
-						let list = e.target.listnode;
-						let node = e.target.inputnode;
-						let more = e.target.morebutton;
+						const list = e.target.listnode;
+						const node = e.target.inputnode;
+						const more = e.target.morebutton;
 
 						list.removeChild(node);
 						--more.counter;
@@ -780,7 +780,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 					}
 				});
 				node.appendChild(remove[0]);
-				let removeButton = remove[1];
+				const removeButton = remove[1];
 				removeButton.inputnode = node;
 				removeButton.listnode = data.listnode;
 				removeButton.morebutton = data.morebutton;
@@ -838,7 +838,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 				node.setAttribute('name', data.name);
 			}
 			if (data.label) {
-				let result = document.createElement('span');
+				const result = document.createElement('span');
 				result.className = 'quickformDescription';
 				result.appendChild(Morebits.createHtml(data.label));
 				node.appendChild(result);
@@ -876,7 +876,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node.setAttribute('id', 'div_' + id);
 			if (data.label) {
 				label = node.appendChild(document.createElement('h5'));
-				let labelElement = document.createElement('label');
+				const labelElement = document.createElement('label');
 				labelElement.appendChild(Morebits.createHtml(data.label));
 				labelElement.setAttribute('for', data.id || id);
 				label.appendChild(labelElement);
@@ -942,7 +942,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
  * @param {object} data - Tooltip-related configuration data.
  */
 Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTooltip(node, data) {
-	let tooltipButton = node.appendChild(document.createElement('span'));
+	const tooltipButton = node.appendChild(document.createElement('span'));
 	tooltipButton.className = 'morebits-tooltipButton';
 	tooltipButton.title = data.tooltip; // Provides the content for jQuery UI
 	tooltipButton.appendChild(document.createTextNode(msg('tooltip-mark', '?')));
@@ -966,10 +966,10 @@ Morebits.quickForm.element.generateTooltip = function QuickFormElementGenerateTo
  * @returns {object} With field names as keys, input data as values.
  */
 Morebits.quickForm.getInputData = function(form) {
-	let result = {};
+	const result = {};
 
 	for (let i = 0; i < form.elements.length; i++) {
-		let field = form.elements[i];
+		const field = form.elements[i];
 		if (field.disabled || !field.name || !field.type ||
 			field.type === 'submit' || field.type === 'button') {
 			continue;
@@ -977,7 +977,7 @@ Morebits.quickForm.getInputData = function(form) {
 
 		// For elements in subgroups, quickform prepends element names with
 		// name of the parent group followed by a period, get rid of that.
-		let fieldNameNorm = field.name.slice(field.name.indexOf('.') + 1);
+		const fieldNameNorm = field.name.slice(field.name.indexOf('.') + 1);
 
 		switch (field.type) {
 			case 'radio':
@@ -1027,7 +1027,7 @@ Morebits.quickForm.getInputData = function(form) {
  * @returns {HTMLElement[]} - Array of matching form elements.
  */
 Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) {
-	let $form = $(form);
+	const $form = $(form);
 	fieldName = $.escapeSelector(fieldName); // sanitize input
 	let $elements = $form.find('[name="' + fieldName + '"]');
 	if ($elements.length > 0) {
@@ -1047,7 +1047,7 @@ Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) 
  * @returns {HTMLInputElement}
  */
 Morebits.quickForm.getCheckboxOrRadio = function QuickFormGetCheckboxOrRadio(elementArray, value) {
-	let found = $.grep(elementArray, function(el) {
+	const found = $.grep(elementArray, function(el) {
 		return el.value === value;
 	});
 	if (found.length > 0) {
@@ -1107,7 +1107,7 @@ Morebits.quickForm.getElementLabelObject = function QuickFormGetElementLabelObje
  * @returns {string}
  */
 Morebits.quickForm.getElementLabel = function QuickFormGetElementLabel(element) {
-	let labelElement = Morebits.quickForm.getElementLabelObject(element);
+	const labelElement = Morebits.quickForm.getElementLabelObject(element);
 
 	if (!labelElement) {
 		return null;
@@ -1124,7 +1124,7 @@ Morebits.quickForm.getElementLabel = function QuickFormGetElementLabel(element) 
  * @returns {boolean} True if succeeded, false if the label element is unavailable.
  */
 Morebits.quickForm.setElementLabel = function QuickFormSetElementLabel(element, labelText) {
-	let labelElement = Morebits.quickForm.getElementLabelObject(element);
+	const labelElement = Morebits.quickForm.getElementLabelObject(element);
 
 	if (!labelElement) {
 		return false;
@@ -1202,14 +1202,14 @@ Morebits.quickForm.setElementTooltipVisibility = function QuickFormSetElementToo
  * checked property set to true.
  */
 HTMLFormElement.prototype.getChecked = function(name, type) {
-	let elements = this.elements[name];
+	const elements = this.elements[name];
 	if (!elements) {
 		return [];
 	}
-	let return_array = [];
+	const return_array = [];
 	let i;
 	if (elements instanceof HTMLSelectElement) {
-		let options = elements.options;
+		const options = elements.options;
 		for (i = 0; i < options.length; ++i) {
 			if (options[i].selected) {
 				if (options[i].values) {
@@ -1256,14 +1256,14 @@ HTMLFormElement.prototype.getChecked = function(name, type) {
  * checked property set to true.
  */
 HTMLFormElement.prototype.getUnchecked = function(name, type) {
-	let elements = this.elements[name];
+	const elements = this.elements[name];
 	if (!elements) {
 		return [];
 	}
-	let return_array = [];
+	const return_array = [];
 	let i;
 	if (elements instanceof HTMLSelectElement) {
-		let options = elements.options;
+		const options = elements.options;
 		for (i = 0; i < options.length; ++i) {
 			if (!options[i].selected) {
 				if (options[i].values) {
@@ -1324,12 +1324,12 @@ Morebits.ip = {
 		// Remove any whitespaces, convert to upper case
 		address = address.toUpperCase();
 		// Expand zero abbreviations
-		let abbrevPos = address.indexOf('::');
+		const abbrevPos = address.indexOf('::');
 		if (abbrevPos > -1) {
 			// We know this is valid IPv6. Find the last index of the
 			// address before any CIDR number (e.g. "a:b:c::/24").
-			let CIDRStart = address.indexOf('/');
-			let addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
+			const CIDRStart = address.indexOf('/');
+			const addressEnd = CIDRStart !== -1 ? CIDRStart - 1 : address.length - 1;
 			// If the '::' is at the beginning...
 			let repeat, extra, pad;
 			if (abbrevPos === 0) {
@@ -1380,7 +1380,7 @@ Morebits.ip = {
 	 */
 	validCIDR: function (ip) {
 		if (Morebits.ip.isRange(ip)) {
-			let subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
+			const subnet = parseInt(ip.match(/\/(\d{1,3})$/)[1], 10);
 			if (subnet) { // Should be redundant
 				if (mw.util.isIPv6Address(ip, true)) {
 					if (subnet >= 32) {
@@ -1407,12 +1407,12 @@ Morebits.ip = {
 		if (!ipv6 || !mw.util.isIPv6Address(ipv6, true)) {
 			return false;
 		}
-		let subnetMatch = ipv6.match(/\/(\d{1,3})$/);
+		const subnetMatch = ipv6.match(/\/(\d{1,3})$/);
 		if (subnetMatch && parseInt(subnetMatch[1], 10) < 64) {
 			return false;
 		}
 		ipv6 = Morebits.ip.sanitizeIPv6(ipv6);
-		let ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
+		const ip_re = /^((?:[0-9A-F]{1,4}:){4})(?:[0-9A-F]{1,4}:){3}[0-9A-F]{1,4}(?:\/\d{1,3})?$/;
 		return ipv6.replace(ip_re, '$1' + '0:0:0:0/64');
 	}
 };
@@ -1461,7 +1461,7 @@ Morebits.string = {
 		}
 		let level = 0;
 		let initial = null;
-		let result = [];
+		const result = [];
 		if (!Array.isArray(skiplist)) {
 			if (skiplist === undefined) {
 				skiplist = [];
@@ -1509,12 +1509,12 @@ Morebits.string = {
 	 */
 	formatReasonText: function(str, addSig) {
 		let reason = (str || '').toString().trim();
-		let unbinder = new Morebits.unbinder(reason);
+		const unbinder = new Morebits.unbinder(reason);
 		unbinder.unbind('<no' + 'wiki>', '</no' + 'wiki>');
 		unbinder.content = unbinder.content.replace(/\|/g, '{{subst:!}}');
 		reason = unbinder.rebind();
 		if (addSig) {
-			let sig = '~~~~', sigIndex = reason.lastIndexOf(sig);
+			const sig = '~~~~', sigIndex = reason.lastIndexOf(sig);
 			if (sigIndex === -1 || sigIndex !== reason.length - sig.length) {
 				reason += ' ' + sig;
 			}
@@ -1636,8 +1636,8 @@ Morebits.array = {
 		if (typeof size !== 'number' || size <= 0) { // pretty impossible to do anything :)
 			return [ arr ]; // we return an array consisting of this array.
 		}
-		let numChunks = Math.ceil(arr.length / size);
-		let result = new Array(numChunks);
+		const numChunks = Math.ceil(arr.length / size);
+		const result = new Array(numChunks);
 		for (let i = 0; i < numChunks; i++) {
 			result[i] = arr.slice(i * size, (i + 1) * size);
 		}
@@ -1662,8 +1662,8 @@ Morebits.select2 = {
 		 * group are shown, like in jquery.chosen.
 		 */
 		optgroupFull: function(params, data) {
-			let originalMatcher = $.fn.select2.defaults.defaults.matcher;
-			let result = originalMatcher(params, data);
+			const originalMatcher = $.fn.select2.defaults.defaults.matcher;
+			const result = originalMatcher(params, data);
 
 			if (result && params.term &&
 				data.text.toUpperCase().indexOf(params.term.toUpperCase()) !== -1) {
@@ -1674,8 +1674,8 @@ Morebits.select2 = {
 
 		/** Custom matcher that matches from the beginning of words only. */
 		wordBeginning: function(params, data) {
-			let originalMatcher = $.fn.select2.defaults.defaults.matcher;
-			let result = originalMatcher(params, data);
+			const originalMatcher = $.fn.select2.defaults.defaults.matcher;
+			const result = originalMatcher(params, data);
 			if (!params.term || (result &&
 				new RegExp('\\b' + mw.util.escapeRegExp(params.term), 'i').test(result.text))) {
 				return result;
@@ -1686,11 +1686,11 @@ Morebits.select2 = {
 
 	/** Underline matched part of options. */
 	highlightSearchMatches: function(data) {
-		let searchTerm = Morebits.select2SearchQuery;
+		const searchTerm = Morebits.select2SearchQuery;
 		if (!searchTerm || data.loading) {
 			return data.text;
 		}
-		let idx = data.text.toUpperCase().indexOf(searchTerm.toUpperCase());
+		const idx = data.text.toUpperCase().indexOf(searchTerm.toUpperCase());
 		if (idx < 0) {
 			return data.text;
 		}
@@ -1723,7 +1723,7 @@ Morebits.select2 = {
 		}
 		target = target.prev();
 		target.select2('open');
-		let search = target.data('select2').dropdown.$search ||
+		const search = target.data('select2').dropdown.$search ||
 			target.data('select2').selection.$search;
 		// Use DOM .focus() to work around a jQuery 3.6.0 regression (https://github.com/select2/select2/issues/5993)
 		search[0].focus();
@@ -1770,7 +1770,7 @@ Morebits.unbinder.prototype = {
 		if (!prefix || !postfix) {
 			throw new Error('Both prefix and postfix must be provided');
 		}
-		let re = new RegExp(prefix + '([\\s\\S]*?)' + postfix, 'g');
+		const re = new RegExp(prefix + '([\\s\\S]*?)' + postfix, 'g');
 		this.content = this.content.replace(re, Morebits.unbinder.getCallback(this));
 	},
 
@@ -1782,7 +1782,7 @@ Morebits.unbinder.prototype = {
 	rebind: function UnbinderRebind() {
 		let content = this.content;
 		content.self = this;
-		for (let current in this.history) {
+		for (const current in this.history) {
 			if (Object.prototype.hasOwnProperty.call(this.history, current)) {
 				content = content.replace(current, this.history[current]);
 			}
@@ -1798,7 +1798,7 @@ Morebits.unbinder.prototype = {
 /** @memberof Morebits.unbinder */
 Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
 	return function UnbinderCallback(match) {
-		let current = self.prefix + self.counter + self.postfix;
+		const current = self.prefix + self.counter + self.postfix;
 		self.history[current] = match;
 		++self.counter;
 		return current;
@@ -1817,24 +1817,24 @@ Morebits.unbinder.getCallback = function UnbinderGetCallback(self) {
  * @class
  */
 Morebits.date = function() {
-	let args = Array.prototype.slice.call(arguments);
+	const args = Array.prototype.slice.call(arguments);
 
 	// Check MediaWiki formats
 	// Must be first since firefox erroneously accepts the timestamp
 	// format, sans timezone (See also: #921, #936, #1174, #1187), and the
 	// 14-digit string will be interpreted differently.
 	if (args.length === 1) {
-		let param = args[0];
+		const param = args[0];
 		if (/^\d{14}$/.test(param)) {
 			// YYYYMMDDHHmmss
-			let digitMatch = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(param);
+			const digitMatch = /(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/.exec(param);
 			if (digitMatch) {
 				// ..... year ... month .. date ... hour .... minute ..... second
 				this._d = new Date(Date.UTC.apply(null, [digitMatch[1], digitMatch[2] - 1, digitMatch[3], digitMatch[4], digitMatch[5], digitMatch[6]]));
 			}
 		} else if (typeof param === 'string') {
 			// Wikitext signature timestamp
-			let dateParts = Morebits.l10n.signatureTimestampFormat(param);
+			const dateParts = Morebits.l10n.signatureTimestampFormat(param);
 			if (dateParts) {
 				this._d = new Date(Date.UTC.apply(null, dateParts));
 			}
@@ -1984,7 +1984,7 @@ Morebits.date.prototype = {
 			throw new Error('Invalid number "' + number + '" provided.');
 		}
 		unit = unit.toLowerCase(); // normalize
-		let unitMap = Morebits.date.unitMap;
+		const unitMap = Morebits.date.unitMap;
 		let unitNorm = unitMap[unit] || unitMap[unit + 's']; // so that both singular and  plural forms work
 		if (unitNorm) {
 			// No built-in week functions, so rather than build out ISO's getWeek/setWeek, just multiply
@@ -2065,14 +2065,14 @@ Morebits.date.prototype = {
 			return udate.toISOString();
 		}
 
-		let pad = function(num, len) {
+		const pad = function(num, len) {
 			len = len || 2; // Up to length of 00 + 1
 			return ('00' + num).toString().slice(0 - len);
 		};
-		let h24 = udate.getHours(), m = udate.getMinutes(), s = udate.getSeconds(), ms = udate.getMilliseconds();
-		let D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
-		let h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? msg('period-pm', 'PM') : msg('period-am', 'AM');
-		let replacementMap = {
+		const h24 = udate.getHours(), m = udate.getMinutes(), s = udate.getSeconds(), ms = udate.getMilliseconds();
+		const D = udate.getDate(), M = udate.getMonth() + 1, Y = udate.getFullYear();
+		const h12 = h24 % 12 || 12, amOrPm = h24 >= 12 ? msg('period-pm', 'PM') : msg('period-am', 'AM');
+		const replacementMap = {
 			HH: pad(h24), H: h24, hh: pad(h12), h: h12, A: amOrPm,
 			mm: pad(m), m: m,
 			ss: pad(s), s: s,
@@ -2083,7 +2083,7 @@ Morebits.date.prototype = {
 			YYYY: Y, YY: pad(Y % 100), Y: Y
 		};
 
-		let unbinder = new Morebits.unbinder(formatstr); // escape stuff between [...]
+		const unbinder = new Morebits.unbinder(formatstr); // escape stuff between [...]
 		unbinder.unbind('\\[', '\\]');
 		unbinder.content = unbinder.content.replace(
 			/* Regex notes:
@@ -2109,7 +2109,7 @@ Morebits.date.prototype = {
 	calendar: function(zone) {
 		// Zero out the hours, minutes, seconds and milliseconds - keeping only the date;
 		// find the difference. Note that setHours() returns the same thing as getTime().
-		let dateDiff = (new Date().setHours(0, 0, 0, 0) -
+		const dateDiff = (new Date().setHours(0, 0, 0, 0) -
 			new Date(this).setHours(0, 0, 0, 0)) / 8.64e7;
 		switch (true) {
 			case dateDiff === 0:
@@ -2150,8 +2150,8 @@ Morebits.date.prototype = {
 		level = parseInt(level, 10);
 		level = isNaN(level) ? 2 : level;
 
-		let header = '='.repeat(level);
-		let text = this.getUTCMonthName() + ' ' + this.getUTCFullYear();
+		const header = '='.repeat(level);
+		const text = this.getUTCMonthName() + ' ' + this.getUTCFullYear();
 
 		if (header.length) { // wikitext-formatted header
 			return header + ' ' + text + ' ' + header;
@@ -2377,7 +2377,7 @@ Morebits.wiki.api.prototype = {
 
 		++Morebits.wiki.numberOfActionsLeft;
 
-		let queryString = $.map(this.query, function(val, i) {
+		const queryString = $.map(this.query, function(val, i) {
 			if (Array.isArray(val)) {
 				return encodeURIComponent(i) + '=' + val.map(encodeURIComponent).join('|');
 			} else if (val !== undefined) {
@@ -2386,7 +2386,7 @@ Morebits.wiki.api.prototype = {
 		}).join('&').replace(/^(.*?)(\btoken=[^&]*)&(.*)/, '$1$3&$2');
 		// token should always be the last item in the query string (bug TW-B-0013)
 
-		let ajaxparams = $.extend({}, {
+		const ajaxparams = $.extend({}, {
 			context: this,
 			type: this.query.action === 'query' ? 'GET' : 'POST',
 			url: mw.util.wikiScript('api'),
@@ -2496,7 +2496,7 @@ Morebits.wiki.api.prototype = {
 
 /** Retrieves wikitext from a page. Caching enabled, duration 1 day. */
 Morebits.wiki.getCachedJson = function(title) {
-	let query = {
+	const query = {
 		action: 'query',
 		prop: 'revisions',
 		titles: title,
@@ -2508,8 +2508,8 @@ Morebits.wiki.getCachedJson = function(title) {
 	};
 	return new Morebits.wiki.api('', query).post().then(function(apiobj) {
 		apiobj.getStatusElement().unlink();
-		let response = apiobj.getResponse();
-		let wikitext = response.query.pages[0].revisions[0].slots.main.content;
+		const response = apiobj.getResponse();
+		const wikitext = response.query.pages[0].revisions[0].slots.main.content;
 		return JSON.parse(wikitext);
 	});
 };
@@ -2552,7 +2552,7 @@ var morebitsWikiChangeTag = '';
  * @returns {string} MediaWiki CSRF token.
  */
 Morebits.wiki.api.getToken = function() {
-	let tokenApi = new Morebits.wiki.api(msg('getting-token', 'Getting token'), {
+	const tokenApi = new Morebits.wiki.api(msg('getting-token', 'Getting token'), {
 		action: 'query',
 		meta: 'tokens',
 		type: 'csrf',
@@ -2626,7 +2626,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 *
 	 * @private
 	 */
-	let ctx = {
+	const ctx = {
 		// backing fields for public properties
 		pageName: pageName,
 		pageExists: false,
@@ -2738,7 +2738,7 @@ Morebits.wiki.page = function(pageName, status) {
 		stabilizeProcessApi: null
 	};
 
-	let emptyFunction = function() { };
+	const emptyFunction = function() { };
 
 	/**
 	 * Loads the text for the page.
@@ -2811,7 +2811,7 @@ Morebits.wiki.page = function(pageName, status) {
 		ctx.onSaveFailure = onFailure || emptyFunction;
 
 		// are we getting our editing token from mw.user.tokens?
-		let canUseMwUserToken = fnCanUseMwUserToken('edit');
+		const canUseMwUserToken = fnCanUseMwUserToken('edit');
 
 		if (!ctx.pageLoaded && !canUseMwUserToken) {
 			ctx.statusElement.error('Internal error: attempt to save a page that has not been loaded!');
@@ -2851,7 +2851,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		ctx.retries = 0;
 
-		let query = {
+		const query = {
 			action: 'edit',
 			title: ctx.pageName,
 			summary: ctx.editSummary,
@@ -3487,7 +3487,7 @@ Morebits.wiki.page = function(pageName, status) {
 			return;
 		}
 
-		let query = {
+		const query = {
 			action: 'query',
 			prop: 'revisions',
 			titles: ctx.pageName,
@@ -3559,7 +3559,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('move')) {
 			fnProcessMove.call(this, this);
 		} else {
-			let query = fnNeedTokenInfoQuery('move');
+			const query = fnNeedTokenInfoQuery('move');
 
 			ctx.moveApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessMove, ctx.statusElement, ctx.onMoveFailure);
 			ctx.moveApi.setParent(this);
@@ -3583,11 +3583,11 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// If a link is present, don't need to check if it's patrolled
 		if ($('.patrollink').length) {
-			let patrolhref = $('.patrollink a').attr('href');
+			const patrolhref = $('.patrollink a').attr('href');
 			ctx.rcid = mw.util.getParamValue('rcid', patrolhref);
 			fnProcessPatrol(this, this);
 		} else {
-			let patrolQuery = {
+			const patrolQuery = {
 				action: 'query',
 				prop: 'info',
 				meta: 'tokens',
@@ -3637,7 +3637,7 @@ Morebits.wiki.page = function(pageName, status) {
 				ctx.pageID = mw.config.get('wgArticleId');
 				fnProcessTriageList(this, this);
 			} else {
-				let query = fnNeedTokenInfoQuery('triage');
+				const query = fnNeedTokenInfoQuery('triage');
 
 				ctx.triageApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessTriageList);
 				ctx.triageApi.setParent(this);
@@ -3664,7 +3664,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('delete')) {
 			fnProcessDelete.call(this, this);
 		} else {
-			let query = fnNeedTokenInfoQuery('delete');
+			const query = fnNeedTokenInfoQuery('delete');
 
 			ctx.deleteApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessDelete, ctx.statusElement, ctx.onDeleteFailure);
 			ctx.deleteApi.setParent(this);
@@ -3689,7 +3689,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('undelete')) {
 			fnProcessUndelete.call(this, this);
 		} else {
-			let query = fnNeedTokenInfoQuery('undelete');
+			const query = fnNeedTokenInfoQuery('undelete');
 
 			ctx.undeleteApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessUndelete, ctx.statusElement, ctx.onUndeleteFailure);
 			ctx.undeleteApi.setParent(this);
@@ -3720,7 +3720,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// because of the way MW API interprets protection levels
 		// (absolute, not differential), we always need to request
 		// protection levels from the server
-		let query = fnNeedTokenInfoQuery('protect');
+		const query = fnNeedTokenInfoQuery('protect');
 
 		ctx.protectApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessProtect, ctx.statusElement, ctx.onProtectFailure);
 		ctx.protectApi.setParent(this);
@@ -3755,7 +3755,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (fnCanUseMwUserToken('stabilize')) {
 			fnProcessStabilize.call(this, this);
 		} else {
-			let query = fnNeedTokenInfoQuery('stabilize');
+			const query = fnNeedTokenInfoQuery('stabilize');
 
 			ctx.stabilizeApi = new Morebits.wiki.api(msg('getting-token', 'retrieving token...'), query, fnProcessStabilize, ctx.statusElement, ctx.onStabilizeFailure);
 			ctx.stabilizeApi.setParent(this);
@@ -3808,7 +3808,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 			// wgRestrictionEdit is null on non-existent pages,
 			// so this neatly handles nonexistent pages
-			let editRestriction = mw.config.get('wgRestrictionEdit');
+			const editRestriction = mw.config.get('wgRestrictionEdit');
 			if (!editRestriction || editRestriction.indexOf('sysop') !== -1) {
 				return false;
 			}
@@ -3833,7 +3833,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 * @returns {object} Appropriate query.
 	 */
 	var fnNeedTokenInfoQuery = function(action) {
-		let query = {
+		const query = {
 			action: 'query',
 			meta: 'tokens',
 			type: 'csrf',
@@ -3859,7 +3859,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from loadApi.post()
 	var fnLoadSuccess = function() {
-		let response = ctx.loadApi.getResponse().query;
+		const response = ctx.loadApi.getResponse().query;
 
 		if (!fnCheckPageName(response, ctx.onLoadFailure)) {
 			return; // abort
@@ -3895,7 +3895,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info, to alert admins when they are about to edit a protected page
 		// Includes cascading protection
 		if (Morebits.userIsSysop) {
-			let editProt = page.protection.filter(function(pr) {
+			const editProt = page.protection.filter(function(pr) {
 				return pr.type === 'edit' && pr.level === 'sysop';
 			}).pop();
 			if (editProt) {
@@ -3907,7 +3907,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		ctx.revertCurID = page.lastrevid;
 
-		let testactions = page.actions;
+		const testactions = page.actions;
 		ctx.testActions = []; // was null
 		Object.keys(testactions).forEach(function(action) {
 			if (testactions[action]) {
@@ -3948,7 +3948,7 @@ Morebits.wiki.page = function(pageName, status) {
 			onFailure = emptyFunction;
 		}
 
-		let page = response.pages && response.pages[0];
+		const page = response.pages && response.pages[0];
 		if (page) {
 			// check for invalid titles
 			if (page.invalid) {
@@ -3958,12 +3958,12 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 
 			// retrieve actual title of the page after normalization and redirects
-			let resolvedName = page.title;
+			const resolvedName = page.title;
 
 			if (response.redirects) {
 				// check for cross-namespace redirect:
-				let origNs = new mw.Title(ctx.pageName).namespace;
-				let newNs = new mw.Title(resolvedName).namespace;
+				const origNs = new mw.Title(ctx.pageName).namespace;
+				const newNs = new mw.Title(resolvedName).namespace;
 				if (origNs !== newNs && !ctx.followCrossNsRedirect) {
 					ctx.statusElement.error(msg('cross-redirect-abort', ctx.pageName, resolvedName, ctx.pageName + ' is a cross-namespace redirect to ' + resolvedName + ', aborted'));
 					onFailure(this);
@@ -4007,7 +4007,7 @@ Morebits.wiki.page = function(pageName, status) {
 				let newExpiry;
 				// Attempt to determine if the new expiry is a
 				// relative (e.g. `1 month`) or absolute datetime
-				let rel = ctx.watchlistExpiry.split(' ');
+				const rel = ctx.watchlistExpiry.split(' ');
 				try {
 					newExpiry = new Morebits.date().add(rel[0], rel[1]);
 				} catch (e) {
@@ -4033,14 +4033,14 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from saveApi.post()
 	var fnSaveSuccess = function() {
 		ctx.editMode = 'all';  // cancel append/prepend/newSection/revert modes
-		let response = ctx.saveApi.getResponse();
+		const response = ctx.saveApi.getResponse();
 
 		// see if the API thinks we were successful
 		if (response.edit.result === 'Success') {
 
 			// real success
 			// default on success action - display link for edited page
-			let link = document.createElement('a');
+			const link = document.createElement('a');
 			link.setAttribute('href', mw.util.getUrl(ctx.pageName));
 			link.appendChild(document.createTextNode(ctx.pageName));
 			ctx.statusElement.info(['completed (', link, ')']);
@@ -4066,18 +4066,18 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from saveApi.post()
 	var fnSaveError = function() {
-		let errorCode = ctx.saveApi.getErrorCode();
+		const errorCode = ctx.saveApi.getErrorCode();
 
 		// check for edit conflict
 		if (errorCode === 'editconflict' && ctx.conflictRetries++ < ctx.maxConflictRetries) {
 
 			// edit conflicts can occur when the page needs to be purged from the server cache
-			let purgeQuery = {
+			const purgeQuery = {
 				action: 'purge',
 				titles: ctx.pageName  // redirects are already resolved
 			};
 
-			let purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, function() {
+			const purgeApi = new Morebits.wiki.api(msg('editconflict-purging', 'Edit conflict detected, purging server cache'), purgeQuery, function() {
 				--Morebits.wiki.numberOfActionsLeft;  // allow for normal completion if retry succeeds
 
 				ctx.statusElement.info(msg('editconflict-retrying', 'Edit conflict detected, reapplying edit'));
@@ -4103,8 +4103,8 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// hard error, give up
 		} else {
-			let response = ctx.saveApi.getResponse();
-			let errorData = response.error || // bc error format
+			const response = ctx.saveApi.getResponse();
+			const errorData = response.error || // bc error format
 				response.errors[0].data; // html/wikitext/plaintext error format
 
 			switch (errorCode) {
@@ -4141,7 +4141,7 @@ Morebits.wiki.page = function(pageName, status) {
 		}
 	};
 
-	let isTextRedirect = function(text) {
+	const isTextRedirect = function(text) {
 		if (!text) { // no text - content empty or inaccessible (revdelled or suppressed)
 			return false;
 		}
@@ -4151,13 +4151,13 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnLookupCreationSuccess = function() {
-		let response = ctx.lookupCreationApi.getResponse().query;
+		const response = ctx.lookupCreationApi.getResponse().query;
 
 		if (!fnCheckPageName(response, ctx.onLookupCreationFailure)) {
 			return; // abort
 		}
 
-		let rev = response.pages[0].revisions && response.pages[0].revisions[0];
+		const rev = response.pages[0].revisions && response.pages[0].revisions[0];
 		if (!rev) {
 			ctx.statusElement.error('Could not find any revisions of ' + ctx.pageName);
 			ctx.onLookupCreationFailure(this);
@@ -4194,8 +4194,8 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnLookupNonRedirectCreator = function() {
-		let response = ctx.lookupCreationApi.getResponse().query;
-		let revs = response.pages[0].revisions;
+		const response = ctx.lookupCreationApi.getResponse().query;
+		const revs = response.pages[0].revisions;
 
 		for (let i = 0; i < revs.length; i++) {
 
@@ -4261,13 +4261,13 @@ Morebits.wiki.page = function(pageName, status) {
 	 * @param {string} response - The response document from the API call.
 	 * @returns {boolean}
 	 */
-	let fnProcessChecks = function(action, onFailure, response) {
-		let missing = response.pages[0].missing;
+	const fnProcessChecks = function(action, onFailure, response) {
+		const missing = response.pages[0].missing;
 
 		// No undelete as an existing page could have deleted revisions
-		let actionMissing = missing && ['delete', 'stabilize', 'move'].indexOf(action) !== -1;
-		let protectMissing = action === 'protect' && missing && (ctx.protectEdit || ctx.protectMove);
-		let saltMissing = action === 'protect' && !missing && ctx.protectCreate;
+		const actionMissing = missing && ['delete', 'stabilize', 'move'].indexOf(action) !== -1;
+		const protectMissing = action === 'protect' && missing && (ctx.protectEdit || ctx.protectMove);
+		const saltMissing = action === 'protect' && !missing && ctx.protectCreate;
 
 		if (actionMissing || protectMissing || saltMissing) {
 			ctx.statusElement.error('Cannot ' + action + ' the page because it ' + (missing ? 'no longer' : 'already') + ' exists');
@@ -4311,19 +4311,19 @@ Morebits.wiki.page = function(pageName, status) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			let response = ctx.moveApi.getResponse().query;
+			const response = ctx.moveApi.getResponse().query;
 
 			if (!fnProcessChecks('move', ctx.onMoveFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			let page = response.pages[0];
+			const page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		let query = {
+		const query = {
 			action: 'move',
 			from: pageTitle,
 			to: ctx.moveDestination,
@@ -4355,7 +4355,7 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessPatrol = function() {
-		let query = {
+		const query = {
 			action: 'patrol',
 			format: 'json'
 		};
@@ -4365,20 +4365,20 @@ Morebits.wiki.page = function(pageName, status) {
 			query.rcid = ctx.rcid;
 			query.token = mw.user.tokens.get('patrolToken');
 		} else {
-			let response = ctx.patrolApi.getResponse().query;
+			const response = ctx.patrolApi.getResponse().query;
 
 			// Don't patrol if not unpatrolled
 			if (!response.recentchanges[0].unpatrolled) {
 				return;
 			}
 
-			let lastrevid = response.pages[0].lastrevid;
+			const lastrevid = response.pages[0].lastrevid;
 			if (!lastrevid) {
 				return;
 			}
 			query.revid = lastrevid;
 
-			let token = response.tokens.csrftoken;
+			const token = response.tokens.csrftoken;
 			if (!token) {
 				return;
 			}
@@ -4388,7 +4388,7 @@ Morebits.wiki.page = function(pageName, status) {
 			query.tags = ctx.changeTags;
 		}
 
-		let patrolStat = new Morebits.status('Marking page as patrolled');
+		const patrolStat = new Morebits.status('Marking page as patrolled');
 
 		ctx.patrolProcessApi = new Morebits.wiki.api('patrolling page...', query, null, patrolStat);
 		ctx.patrolProcessApi.setParent(this);
@@ -4400,7 +4400,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (ctx.pageID) {
 			ctx.csrfToken = mw.user.tokens.get('csrfToken');
 		} else {
-			let response = ctx.triageApi.getResponse().query;
+			const response = ctx.triageApi.getResponse().query;
 
 			ctx.pageID = response.pages[0].pageid;
 			if (!ctx.pageID) {
@@ -4413,7 +4413,7 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 		}
 
-		let query = {
+		const query = {
 			action: 'pagetriagelist',
 			page_id: ctx.pageID,
 			format: 'json'
@@ -4426,15 +4426,15 @@ Morebits.wiki.page = function(pageName, status) {
 
 	// callback from triageProcessListApi.post()
 	var fnProcessTriage = function() {
-		let responseList = ctx.triageProcessListApi.getResponse().pagetriagelist;
+		const responseList = ctx.triageProcessListApi.getResponse().pagetriagelist;
 		// Exit if not in the queue
 		if (!responseList || responseList.result !== 'success') {
 			return;
 		}
-		let page = responseList.pages && responseList.pages[0];
+		const page = responseList.pages && responseList.pages[0];
 		// Do nothing if page already triaged/patrolled
 		if (!page || !parseInt(page.patrol_status, 10)) {
-			let query = {
+			const query = {
 				action: 'pagetriageaction',
 				pageid: ctx.pageID,
 				reviewed: 1,
@@ -4444,7 +4444,7 @@ Morebits.wiki.page = function(pageName, status) {
 				token: ctx.csrfToken,
 				format: 'json'
 			};
-			let triageStat = new Morebits.status('Marking page as curated');
+			const triageStat = new Morebits.status('Marking page as curated');
 			ctx.triageProcessApi = new Morebits.wiki.api('curating page...', query, null, triageStat);
 			ctx.triageProcessApi.setParent(this);
 			ctx.triageProcessApi.post();
@@ -4458,19 +4458,19 @@ Morebits.wiki.page = function(pageName, status) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			let response = ctx.deleteApi.getResponse().query;
+			const response = ctx.deleteApi.getResponse().query;
 
 			if (!fnProcessChecks('delete', ctx.onDeleteFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			let page = response.pages[0];
+			const page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		let query = {
+		const query = {
 			action: 'delete',
 			title: pageTitle,
 			token: token,
@@ -4497,7 +4497,7 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from deleteProcessApi.post()
 	var fnProcessDeleteError = function() {
 
-		let errorCode = ctx.deleteProcessApi.getErrorCode();
+		const errorCode = ctx.deleteProcessApi.getErrorCode();
 
 		// check for "Database query error"
 		if (errorCode === 'internal_api_error_DBQueryError' && ctx.retries++ < ctx.maxRetries) {
@@ -4526,19 +4526,19 @@ Morebits.wiki.page = function(pageName, status) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			let response = ctx.undeleteApi.getResponse().query;
+			const response = ctx.undeleteApi.getResponse().query;
 
 			if (!fnProcessChecks('undelete', ctx.onUndeleteFailure, response)) {
 				return; // abort
 			}
 
 			token = response.tokens.csrftoken;
-			let page = response.pages[0];
+			const page = response.pages[0];
 			pageTitle = page.title;
 			ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		let query = {
+		const query = {
 			action: 'undelete',
 			title: pageTitle,
 			token: token,
@@ -4565,7 +4565,7 @@ Morebits.wiki.page = function(pageName, status) {
 	// callback from undeleteProcessApi.post()
 	var fnProcessUndeleteError = function() {
 
-		let errorCode = ctx.undeleteProcessApi.getErrorCode();
+		const errorCode = ctx.undeleteProcessApi.getErrorCode();
 
 		// check for "Database query error"
 		if (errorCode === 'internal_api_error_DBQueryError') {
@@ -4594,19 +4594,19 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var fnProcessProtect = function() {
-		let response = ctx.protectApi.getResponse().query;
+		const response = ctx.protectApi.getResponse().query;
 
 		if (!fnProcessChecks('protect', ctx.onProtectFailure, response)) {
 			return; // abort
 		}
 
-		let token = response.tokens.csrftoken;
-		let page = response.pages[0];
-		let pageTitle = page.title;
+		const token = response.tokens.csrftoken;
+		const page = response.pages[0];
+		const pageTitle = page.title;
 		ctx.watched = page.watchlistexpiry || page.watched;
 
 		// Fetch existing protection levels
-		let prs = response.pages[0].protection;
+		const prs = response.pages[0].protection;
 		let editprot, moveprot, createprot;
 		prs.forEach(function(pr) {
 			// Filter out protection from cascading
@@ -4657,7 +4657,7 @@ Morebits.wiki.page = function(pageName, status) {
 		}
 
 		// Build protection levels and expirys (expiries?) for query
-		let protections = [], expirys = [];
+		const protections = [], expirys = [];
 		if (ctx.protectEdit) {
 			protections.push('edit=' + ctx.protectEdit.level);
 			expirys.push(ctx.protectEdit.expiry);
@@ -4673,7 +4673,7 @@ Morebits.wiki.page = function(pageName, status) {
 			expirys.push(ctx.protectCreate.expiry);
 		}
 
-		let query = {
+		const query = {
 			action: 'protect',
 			title: pageTitle,
 			token: token,
@@ -4707,7 +4707,7 @@ Morebits.wiki.page = function(pageName, status) {
 			token = mw.user.tokens.get('csrfToken');
 			pageTitle = ctx.pageName;
 		} else {
-			let response = ctx.stabilizeApi.getResponse().query;
+			const response = ctx.stabilizeApi.getResponse().query;
 
 			// 'stabilize' as a verb not necessarily well understood
 			if (!fnProcessChecks('stabilize', ctx.onStabilizeFailure, response)) {
@@ -4715,13 +4715,13 @@ Morebits.wiki.page = function(pageName, status) {
 			}
 
 			token = response.tokens.csrftoken;
-			let page = response.pages[0];
+			const page = response.pages[0];
 			pageTitle = page.title;
 			// Doesn't support watchlist expiry [[phab:T263336]]
 			// ctx.watched = page.watchlistexpiry || page.watched;
 		}
 
-		let query = {
+		const query = {
 			action: 'stabilize',
 			title: pageTitle,
 			token: token,
@@ -4745,7 +4745,7 @@ Morebits.wiki.page = function(pageName, status) {
 	};
 
 	var sleep = function(milliseconds) {
-		let deferred = $.Deferred();
+		const deferred = $.Deferred();
 		setTimeout(deferred.resolve, milliseconds);
 		return deferred;
 	};
@@ -4791,11 +4791,11 @@ Morebits.wiki.preview = function(previewbox) {
 	this.beginRender = function(wikitext, pageTitle, sectionTitle) {
 		$(previewbox).show();
 
-		let statusspan = document.createElement('span');
+		const statusspan = document.createElement('span');
 		previewbox.appendChild(statusspan);
 		Morebits.status.init(statusspan);
 
-		let query = {
+		const query = {
 			action: 'parse',
 			prop: ['text', 'modules'],
 			pst: true,  // PST = pre-save transform; this makes substitution work properly
@@ -4810,13 +4810,13 @@ Morebits.wiki.preview = function(previewbox) {
 			query.section = 'new';
 			query.sectiontitle = sectionTitle;
 		}
-		let renderApi = new Morebits.wiki.api('loading...', query, fnRenderSuccess, new Morebits.status('Preview'));
+		const renderApi = new Morebits.wiki.api('loading...', query, fnRenderSuccess, new Morebits.status('Preview'));
 		return renderApi.post();
 	};
 
 	var fnRenderSuccess = function(apiobj) {
-		let response = apiobj.getResponse();
-		let html = response.parse.text;
+		const response = apiobj.getResponse();
+		const html = response.parse.text;
 		if (!html) {
 			apiobj.statelem.error('failed to retrieve preview, or template was blanked');
 			return;
@@ -4857,12 +4857,12 @@ Morebits.wikitext = {};
 Morebits.wikitext.parseTemplate = function(text, start) {
 	start = start || 0;
 
-	let level = []; // Track of how deep we are ({{, {{{, or [[)
+	const level = []; // Track of how deep we are ({{, {{{, or [[)
 	let count = -1;  // Number of parameters found
 	let unnamed = 0; // Keep track of what number an unnamed parameter should receive
 	let equals = -1; // After finding "=" before a parameter, the index; otherwise, -1
 	let current = '';
-	let result = {
+	const result = {
 		name: '',
 		parameters: {}
 	};
@@ -4889,7 +4889,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 				equals = -1;
 			} else {
 				// No equals, so it must be unnamed; no trim since whitespace allowed
-				let param = final ? current.substring(equals + 1, current.length - 2) : current;
+				const param = final ? current.substring(equals + 1, current.length - 2) : current;
 				if (param) {
 					result.parameters[++unnamed] = param;
 					++count;
@@ -4899,7 +4899,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 	}
 
 	for (let i = start; i < text.length; ++i) {
-		let test3 = text.substr(i, 3);
+		const test3 = text.substr(i, 3);
 		if (test3 === '{{{' || (test3 === '}}}' && level[level.length - 1] === 3)) {
 			current += test3;
 			i += 2;
@@ -4910,7 +4910,7 @@ Morebits.wikitext.parseTemplate = function(text, start) {
 			}
 			continue;
 		}
-		let test2 = text.substr(i, 2);
+		const test2 = text.substr(i, 2);
 		// Entering a template (or link)
 		if (test2 === '{{' || test2 === '[[') {
 			current += test2;
@@ -4975,9 +4975,9 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeLink: function(link_target) {
-		let mwTitle = mw.Title.newFromText(link_target);
-		let namespaceID = mwTitle.getNamespaceId();
-		let title = mwTitle.getMainText();
+		const mwTitle = mw.Title.newFromText(link_target);
+		const namespaceID = mwTitle.getNamespaceId();
+		const title = mwTitle.getMainText();
 
 		let link_regex_string = '';
 		if (namespaceID !== 0) {
@@ -4987,11 +4987,11 @@ Morebits.wikitext.page.prototype = {
 
 		// For most namespaces, unlink both [[User:Test]] and [[:User:Test]]
 		// For files and categories, only unlink [[:Category:Test]]. Do not unlink [[Category:Test]]
-		let isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
-		let colon = isFileOrCategory ? ':' : ':?';
+		const isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
+		const colon = isFileOrCategory ? ':' : ':?';
 
-		let simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
-		let piped_link_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
+		const simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');
+		const piped_link_regex = new RegExp('\\[\\[' + colon + link_regex_string + '\\|(.+?)\\]\\]', 'g');
 		this.text = this.text.replace(simple_link_regex, '$1').replace(piped_link_regex, '$1');
 		return this;
 	},
@@ -5005,19 +5005,19 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	commentOutImage: function(image, reason) {
-		let unbinder = new Morebits.unbinder(this.text);
+		const unbinder = new Morebits.unbinder(this.text);
 		unbinder.unbind('<!--', '-->');
 
 		reason = reason ? reason + ': ' : '';
-		let image_re_string = Morebits.pageNameRegex(image);
+		const image_re_string = Morebits.pageNameRegex(image);
 
 		// Check for normal image links, i.e. [[File:Foobar.png|...]]
 		// Will eat the whole link
-		let links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		let allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
+		const links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		const allLinks = Morebits.string.splitWeightedByKeys(unbinder.content, '[[', ']]');
 		for (let i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
-				let replacement = '<!-- ' + reason + allLinks[i] + ' -->';
+				const replacement = '<!-- ' + reason + allLinks[i] + ' -->';
 				unbinder.content = unbinder.content.replace(allLinks[i], replacement);
 				// unbind the newly created comments
 				unbinder.unbind('<!--', '-->');
@@ -5027,7 +5027,7 @@ Morebits.wikitext.page.prototype = {
 		// Check for gallery images, i.e. instances that must start on a new line,
 		// eventually preceded with some space, and must include File: prefix
 		// Will eat the whole line.
-		let gallery_image_re = new RegExp('(^\\s*' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
+		const gallery_image_re = new RegExp('(^\\s*' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*(?:\\|.*?$|$))', 'mg');
 		unbinder.content = unbinder.content.replace(gallery_image_re, '<!-- ' + reason + '$1 -->');
 
 		// unbind the newly created comments
@@ -5035,7 +5035,7 @@ Morebits.wikitext.page.prototype = {
 
 		// Check free image usages, for example as template arguments, might have the File: prefix excluded, but must be preceded by an |
 		// Will only eat the image name and the preceding bar and an eventual named parameter
-		let free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:' + Morebits.namespaceRegex(6) + ':\\s*)?' + image_re_string + ')', 'mg');
+		const free_image_re = new RegExp('(\\|\\s*(?:[\\w\\s]+\\=)?\\s*(?:' + Morebits.namespaceRegex(6) + ':\\s*)?' + image_re_string + ')', 'mg');
 		unbinder.content = unbinder.content.replace(free_image_re, '<!-- ' + reason + '$1 -->');
 		// Rebind the content now, we are done!
 		this.text = unbinder.rebind();
@@ -5050,9 +5050,9 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	addToImageComment: function(image, data) {
-		let image_re_string = Morebits.pageNameRegex(image);
-		let links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
-		let allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
+		const image_re_string = Morebits.pageNameRegex(image);
+		const links_re = new RegExp('\\[\\[' + Morebits.namespaceRegex(6) + ':\\s*' + image_re_string + '\\s*[\\|(?:\\]\\])]');
+		const allLinks = Morebits.string.splitWeightedByKeys(this.text, '[[', ']]');
 		for (let i = 0; i < allLinks.length; ++i) {
 			if (links_re.test(allLinks[i])) {
 				let replacement = allLinks[i];
@@ -5061,8 +5061,8 @@ Morebits.wikitext.page.prototype = {
 				this.text = this.text.replace(allLinks[i], replacement);
 			}
 		}
-		let gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
-		let newtext = '$1|$2 ' + data;
+		const gallery_re = new RegExp('^(\\s*' + image_re_string + '.*?)\\|?(.*?)$', 'mg');
+		const newtext = '$1|$2 ' + data;
 		this.text = this.text.replace(gallery_re, newtext);
 		return this;
 	},
@@ -5075,9 +5075,9 @@ Morebits.wikitext.page.prototype = {
 	 * @returns {Morebits.wikitext.page}
 	 */
 	removeTemplate: function(template) {
-		let template_re_string = Morebits.pageNameRegex(template);
-		let links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
-		let allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
+		const template_re_string = Morebits.pageNameRegex(template);
+		const links_re = new RegExp('\\{\\{(?:' + Morebits.namespaceRegex(10) + ':)?\\s*' + template_re_string + '\\s*[\\|(?:\\}\\})]');
+		const allTemplates = Morebits.string.splitWeightedByKeys(this.text, '{{', '}}', [ '{{{', '}}}' ]);
 		for (let i = 0; i < allTemplates.length; ++i) {
 			if (links_re.test(allTemplates[i])) {
 				this.text = this.text.replace(allTemplates[i], '');
@@ -5200,18 +5200,18 @@ Morebits.userspaceLogger = function(logPageName) {
 	 * @returns {JQuery.Promise}
 	 */
 	this.log = function(logText, summaryText) {
-		let def = $.Deferred();
+		const def = $.Deferred();
 		if (!logText) {
 			return def.reject();
 		}
-		let page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
+		const page = new Morebits.wiki.page('User:' + mw.config.get('wgUserName') + '/' + logPageName,
 			'Adding entry to userspace log'); // make this '... to ' + logPageName ?
 		page.load(function(pageobj) {
 			// add blurb if log page doesn't exist or is blank
 			let text = pageobj.getPageText() || this.initialText;
 
 			// create monthly header if it doesn't exist already
-			let date = new Morebits.date(pageobj.getLoadTime());
+			const date = new Morebits.date(pageobj.getLoadTime());
 			if (!date.monthHeaderRegex().exec(text)) {
 				text += '\n\n' + date.monthHeader(this.headerLevel);
 			}
@@ -5415,7 +5415,7 @@ Morebits.status.error = function(text, status) {
  * @param {string} text
  */
 Morebits.status.actionCompleted = function(text) {
-	let node = document.createElement('div');
+	const node = document.createElement('div');
 	node.appendChild(document.createElement('b')).appendChild(document.createTextNode(text));
 	node.className = 'morebits_status_info morebits_action_complete';
 	if (Morebits.status.root) {
@@ -5432,9 +5432,9 @@ Morebits.status.actionCompleted = function(text) {
  * @param {string} message
  */
 Morebits.status.printUserText = function(comments, message) {
-	let p = document.createElement('p');
+	const p = document.createElement('p');
 	p.innerHTML = message;
-	let div = document.createElement('div');
+	const div = document.createElement('div');
 	div.className = 'morebits-usertext';
 	div.style.marginTop = '0';
 	div.style.whiteSpace = 'pre-wrap';
@@ -5454,7 +5454,7 @@ Morebits.status.printUserText = function(comments, message) {
  * @returns {HTMLElement}
  */
 Morebits.htmlNode = function (type, content, color) {
-	let node = document.createElement(type);
+	const node = document.createElement(type);
 	if (color) {
 		node.style.color = color;
 	}
@@ -5476,9 +5476,9 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
 	let lastCheckbox = null;
 
 	function clickHandler(event) {
-		let thisCb = this;
+		const thisCb = this;
 		if (event.shiftKey && lastCheckbox !== null) {
-			let cbs = $(jQuerySelector, jQueryContext); // can't cache them, obviously, if we want to support resorting
+			const cbs = $(jQuerySelector, jQueryContext); // can't cache them, obviously, if we want to support resorting
 			let index = -1, lastIndex = -1, i;
 			for (i = 0; i < cbs.length; i++) {
 				if (cbs[i] === thisCb) {
@@ -5497,7 +5497,7 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
 
 			if (index > -1 && lastIndex > -1) {
 				// inspired by wikibits
-				let endState = thisCb.checked;
+				const endState = thisCb.checked;
 				let start, finish;
 				if (index < lastIndex) {
 					start = index + 1;
@@ -5562,7 +5562,7 @@ Morebits.checkboxShiftClickSupport = function (jQuerySelector, jQueryContext) {
  * @param {string} [currentAction]
  */
 Morebits.batchOperation = function(currentAction) {
-	let ctx = {
+	const ctx = {
 		// backing fields for public properties
 		pageList: null,
 		options: {
@@ -5636,7 +5636,7 @@ Morebits.batchOperation = function(currentAction) {
 		ctx.currentChunkIndex = -1;
 		ctx.pageChunks = [];
 
-		let total = ctx.pageList.length;
+		const total = ctx.pageList.length;
 		if (!total) {
 			ctx.statusElement.info(msg('batch-no-pages', 'no pages specified'));
 			ctx.running = false;
@@ -5668,11 +5668,11 @@ Morebits.batchOperation = function(currentAction) {
 
 		if (arg instanceof Morebits.wiki.api || arg instanceof Morebits.wiki.page) {
 			// update or remove status line
-			let statelem = arg.getStatusElement();
+			const statelem = arg.getStatusElement();
 			if (ctx.options.preserveIndividualStatusLines) {
 				if (arg.getPageName || arg.pageName || (arg.query && arg.query.title)) {
 					// we know the page title - display a relevant message
-					let pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
+					const pageName = arg.getPageName ? arg.getPageName() : arg.pageName || arg.query.title;
 					statelem.info(msg('batch-done-page', pageName, 'completed ([[' + pageName + ']])'));
 				} else {
 					// we don't know the page title - just display a generic message
@@ -5697,10 +5697,10 @@ Morebits.batchOperation = function(currentAction) {
 
 	// private functions
 
-	let thisProxy = this;
+	const thisProxy = this;
 
 	var fnStartNewChunk = function() {
-		let chunk = ctx.pageChunks[++ctx.currentChunkIndex];
+		const chunk = ctx.pageChunks[++ctx.currentChunkIndex];
 		if (!chunk) {
 			return;  // done! yay
 		}
@@ -5716,9 +5716,9 @@ Morebits.batchOperation = function(currentAction) {
 		ctx.countFinished++;
 
 		// update overall status line
-		let total = ctx.pageList.length;
+		const total = ctx.pageList.length;
 		if (ctx.countFinished < total) {
-			let progress = Math.round(100 * ctx.countFinished / total);
+			const progress = Math.round(100 * ctx.countFinished / total);
 			ctx.statusElement.status(msg('percent', progress, progress + '%'));
 
 			// start a new chunk if we're close enough to the end of the previous chunk, and
@@ -5728,7 +5728,7 @@ Morebits.batchOperation = function(currentAction) {
 				fnStartNewChunk();
 			}
 		} else if (ctx.countFinished === total) {
-			let statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
+			const statusString = msg('batch-progress', ctx.countFinishedSuccess, ctx.countFinished, 'Done (' + ctx.countFinishedSuccess +
 				'/' + ctx.countFinished + ' actions completed successfully)');
 			if (ctx.countFinishedSuccess < ctx.countFinished) {
 				ctx.statusElement.warn(statusString);
@@ -5781,7 +5781,7 @@ Morebits.taskManager = function(context) {
 	this.add = function(func, deps, onFailure) {
 		this.taskDependencyMap.set(func, deps);
 		this.failureCallbackMap.set(func, onFailure || function() {});
-		let deferred = $.Deferred();
+		const deferred = $.Deferred();
 		this.deferreds.set(func, deferred);
 	};
 
@@ -5791,13 +5791,13 @@ Morebits.taskManager = function(context) {
 	 * @returns {jQuery.Promise} - Resolved if all tasks succeed, rejected otherwise.
 	 */
 	this.execute = function() {
-		let self = this; // proxy for `this` for use inside functions where `this` is something else
+		const self = this; // proxy for `this` for use inside functions where `this` is something else
 		this.taskDependencyMap.forEach(function(deps, task) {
-			let dependencyPromisesArray = deps.map(function(dep) {
+			const dependencyPromisesArray = deps.map(function(dep) {
 				return self.deferreds.get(dep);
 			});
 			$.when.apply(self.context, dependencyPromisesArray).then(function() {
-				let result = task.apply(self.context, arguments);
+				const result = task.apply(self.context, arguments);
 				if (result === undefined) { // maybe the function threw, or it didn't return anything
 					mw.log.error('Morebits.taskManager: task returned undefined');
 					self.deferreds.get(task).reject.apply(self.context, arguments);
@@ -5828,7 +5828,7 @@ Morebits.taskManager = function(context) {
  * @param {number} height - The maximum allowable height for the content area.
  */
 Morebits.simpleWindow = function SimpleWindow(width, height) {
-	let content = document.createElement('div');
+	const content = document.createElement('div');
 	this.content = content;
 	content.className = 'morebits-dialog-content';
 	content.id = 'morebits-dialog-content-' + Math.round(Math.random() * 1e15);
@@ -5866,7 +5866,7 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 		}
 	});
 
-	let $widget = $(this.content).dialog('widget');
+	const $widget = $(this.content).dialog('widget');
 
 	// delete the placeholder button (it's only there so the buttonpane gets created)
 	$widget.find('button').each(function(key, value) {
@@ -5874,9 +5874,9 @@ Morebits.simpleWindow = function SimpleWindow(width, height) {
 	});
 
 	// add container for the buttons we add, and the footer links (if any)
-	let buttonspan = document.createElement('span');
+	const buttonspan = document.createElement('span');
 	buttonspan.className = 'morebits-dialog-buttons';
-	let linksspan = document.createElement('span');
+	const linksspan = document.createElement('span');
 	linksspan.className = 'morebits-dialog-footerlinks';
 	$widget.find('.ui-dialog-buttonpane').append(buttonspan, linksspan);
 
@@ -5926,15 +5926,15 @@ Morebits.simpleWindow.prototype = {
 	 */
 	display: function() {
 		if (this.scriptName) {
-			let $widget = $(this.content).dialog('widget');
+			const $widget = $(this.content).dialog('widget');
 			$widget.find('.morebits-dialog-scriptname').remove();
-			let scriptnamespan = document.createElement('span');
+			const scriptnamespan = document.createElement('span');
 			scriptnamespan.className = 'morebits-dialog-scriptname';
 			scriptnamespan.textContent = this.scriptName + ' \u00B7 ';  // U+00B7 MIDDLE DOT = &middot;
 			$widget.find('.ui-dialog-title').prepend(scriptnamespan);
 		}
 
-		let dialog = $(this.content).dialog('open');
+		const dialog = $(this.content).dialog('open');
 		if (window.setupTooltips && window.pg && window.pg.re && window.pg.re.diff) {  // tie in with NAVPOP
 			dialog.parent()[0].ranSetupTooltipsAlready = false;
 			window.setupTooltips(dialog.parent()[0]);
@@ -6026,10 +6026,10 @@ Morebits.simpleWindow.prototype = {
 		this.content.appendChild(content);
 
 		// look for submit buttons in the content, hide them, and add a proxy button to the button pane
-		let thisproxy = this;
+		const thisproxy = this;
 		$(this.content).find('input[type="submit"], button[type="submit"]').each(function(key, value) {
 			value.style.display = 'none';
-			let button = document.createElement('button');
+			const button = document.createElement('button');
 
 			if (value.hasAttribute('value')) {
 				button.textContent = value.getAttribute('value');
@@ -6083,9 +6083,9 @@ Morebits.simpleWindow.prototype = {
 	 * @returns {Morebits.simpleWindow}
 	 */
 	addFooterLink: function(text, wikiPage, prep) {
-		let $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
+		const $footerlinks = $(this.content).dialog('widget').find('.morebits-dialog-footerlinks');
 		if (this.hasFooterLinks) {
-			let bullet = document.createElement('span');
+			const bullet = document.createElement('span');
 			bullet.textContent = msg('bullet-separator', ' \u2022 ');  // U+2022 BULLET
 			if (prep) {
 				$footerlinks.prepend(bullet);
@@ -6093,7 +6093,7 @@ Morebits.simpleWindow.prototype = {
 				$footerlinks.append(bullet);
 			}
 		}
-		let link = document.createElement('a');
+		const link = document.createElement('a');
 		link.setAttribute('href', mw.util.getUrl(wikiPage));
 		link.setAttribute('title', wikiPage);
 		link.setAttribute('target', '_blank');

--- a/morebits.js
+++ b/morebits.js
@@ -271,9 +271,7 @@ Morebits.namespaceRegex = function(namespaces) {
 			// Namespaces are completely agnostic as to case,
 			// and a regex string is more useful/compatible than a RegExp object,
 			// so we accept any casing for any letter.
-			aliases.push(name.split('').map((char) => {
-				return Morebits.pageNameRegex(char);
-			}).join(''));
+			aliases.push(name.split('').map((char) => Morebits.pageNameRegex(char)).join(''));
 		}
 	});
 	switch (aliases.length) {
@@ -1047,9 +1045,7 @@ Morebits.quickForm.getElements = function QuickFormGetElements(form, fieldName) 
  * @returns {HTMLInputElement}
  */
 Morebits.quickForm.getCheckboxOrRadio = function QuickFormGetCheckboxOrRadio(elementArray, value) {
-	const found = $.grep(elementArray, (el) => {
-		return el.value === value;
-	});
+	const found = $.grep(elementArray, (el) => el.value === value);
 	if (found.length > 0) {
 		return found[0];
 	}
@@ -1598,9 +1594,7 @@ Morebits.array = {
 		if (!Array.isArray(arr)) {
 			throw 'A non-array object passed to Morebits.array.uniq';
 		}
-		return arr.filter((item, idx) => {
-			return arr.indexOf(item) === idx;
-		});
+		return arr.filter((item, idx) => arr.indexOf(item) === idx);
 	},
 
 	/**
@@ -1615,9 +1609,7 @@ Morebits.array = {
 		if (!Array.isArray(arr)) {
 			throw 'A non-array object passed to Morebits.array.dups';
 		}
-		return arr.filter((item, idx) => {
-			return arr.indexOf(item) !== idx;
-		});
+		return arr.filter((item, idx) => arr.indexOf(item) !== idx);
 	},
 
 
@@ -2091,9 +2083,7 @@ Morebits.date.prototype = {
 			 * Y{1,2}(Y{2})? matches exactly 1, 2 or 4 occurrences of 'Y'
 			 */
 			/H{1,2}|h{1,2}|m{1,2}|s{1,2}|SSS|d(d{2,3})?|D{1,2}|M{1,4}|Y{1,2}(Y{2})?|A/g,
-			(match) => {
-				return replacementMap[match];
-			}
+			(match) => replacementMap[match]
 		);
 		return unbinder.rebind().replace(/\[(.*?)\]/g, '$1');
 	},
@@ -2558,9 +2548,7 @@ Morebits.wiki.api.getToken = function() {
 		type: 'csrf',
 		format: 'json'
 	});
-	return tokenApi.post().then((apiobj) => {
-		return apiobj.response.query.tokens.csrftoken;
-	});
+	return tokenApi.post().then((apiobj) => apiobj.response.query.tokens.csrftoken);
 };
 
 
@@ -3895,9 +3883,7 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info, to alert admins when they are about to edit a protected page
 		// Includes cascading protection
 		if (Morebits.userIsSysop) {
-			const editProt = page.protection.filter((pr) => {
-				return pr.type === 'edit' && pr.level === 'sysop';
-			}).pop();
+			const editProt = page.protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 			if (editProt) {
 				ctx.fullyProtected = editProt.expiry;
 			} else {
@@ -4145,9 +4131,7 @@ Morebits.wiki.page = function(pageName, status) {
 		if (!text) { // no text - content empty or inaccessible (revdelled or suppressed)
 			return false;
 		}
-		return Morebits.l10n.redirectTagAliases.some((tag) => {
-			return new RegExp('^\\s*' + tag + '\\W', 'i').test(text);
-		});
+		return Morebits.l10n.redirectTagAliases.some((tag) => new RegExp('^\\s*' + tag + '\\W', 'i').test(text));
 	};
 
 	var fnLookupCreationSuccess = function() {
@@ -4279,13 +4263,9 @@ Morebits.wiki.page = function(pageName, status) {
 		// extract protection info
 		let editprot;
 		if (action === 'undelete') {
-			editprot = response.pages[0].protection.filter((pr) => {
-				return pr.type === 'create' && pr.level === 'sysop';
-			}).pop();
+			editprot = response.pages[0].protection.filter((pr) => pr.type === 'create' && pr.level === 'sysop').pop();
 		} else if (action === 'delete' || action === 'move') {
-			editprot = response.pages[0].protection.filter((pr) => {
-				return pr.type === 'edit' && pr.level === 'sysop';
-			}).pop();
+			editprot = response.pages[0].protection.filter((pr) => pr.type === 'edit' && pr.level === 'sysop').pop();
 		}
 		if (editprot && !ctx.suppressProtectWarning &&
 			!confirm('You are about to ' + action + ' the fully protected page "' + ctx.pageName +
@@ -4633,9 +4613,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 		// Default to pre-existing cascading protection if unchanged (similar to above)
 		if (ctx.protectCascade === null) {
-			ctx.protectCascade = !!prs.filter((pr) => {
-				return pr.cascade;
-			}).length;
+			ctx.protectCascade = !!prs.filter((pr) => pr.cascade).length;
 		}
 		// Warn if cascading protection being applied with an invalid protection level,
 		// which for edit protection will cause cascading to be silently stripped
@@ -5793,9 +5771,7 @@ Morebits.taskManager = function(context) {
 	this.execute = function() {
 		const self = this; // proxy for `this` for use inside functions where `this` is something else
 		this.taskDependencyMap.forEach((deps, task) => {
-			const dependencyPromisesArray = deps.map((dep) => {
-				return self.deferreds.get(dep);
-			});
+			const dependencyPromisesArray = deps.map((dep) => self.deferreds.get(dep));
 			$.when.apply(self.context, dependencyPromisesArray).then(function() {
 				const result = task.apply(self.context, arguments);
 				if (result === undefined) { // maybe the function threw, or it didn't return anything

--- a/twinkle.js
+++ b/twinkle.js
@@ -24,7 +24,7 @@ if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirm
 	return;
 }
 
-let Twinkle = {};
+const Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
 
 Twinkle.initCallbacks = [];
@@ -233,13 +233,13 @@ Twinkle.addPortlet = function() {
 	}
 
 	// make sure navigation is a valid CSS selector
-	let root = document.querySelector(navigation);
+	const root = document.querySelector(navigation);
 	if (!root) {
 		return id;
 	}
 
 	// if we already created the portlet, return early. we don't want to create it again.
-	let item = document.getElementById(id);
+	const item = document.getElementById(id);
 	if (item) {
 		return id;
 	}
@@ -250,7 +250,7 @@ Twinkle.addPortlet = function() {
 	if (mw.config.get('skin') === 'vector') {
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		let $landmark = $('#right-navigation > .vector-page-tools-landmark');
+		const $landmark = $('#right-navigation > .vector-page-tools-landmark');
 		$('#p-twinkle-dropdown').insertAfter($landmark);
 
 		// .vector-page-tools-landmark is unstable and could change. If so, log it to console, to hopefully get someone's attention.
@@ -272,7 +272,7 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
 	const portletId = Twinkle.addPortlet();
 
 	// Create a portlet link and add it to the portlet.
-	let link = mw.util.addPortletLink(portletId, typeof task === 'string' ? task : '#', text, id, tooltip);
+	const link = mw.util.addPortletLink(portletId, typeof task === 'string' ? task : '#', text, id, tooltip);
 
 	// Related to the hidden peer gadget that prevents jumpiness when the page first loads
 	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
@@ -299,7 +299,7 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
  * **************** General initialization code ****************
  */
 
-let scriptpathbefore = mw.util.wikiScript('index') + '?title=',
+const scriptpathbefore = mw.util.wikiScript('index') + '?title=',
 	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
 
 // Retrieve the user's Twinkle preferences
@@ -326,7 +326,7 @@ $.ajax({
 		}
 
 		try {
-			let options = JSON.parse(optionsText);
+			const options = JSON.parse(optionsText);
 			if (options) {
 				if (options.twinkle || options.friendly) { // Old preferences format
 					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
@@ -388,13 +388,13 @@ Twinkle.load = function () {
 	}
 
 	// Hide the lingering space if the TW menu is empty
-	let isVector = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022';
+	const isVector = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022';
 	if (isVector && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
 		$('#p-cactions').css('margin-right', 'initial');
 	}
 
 	// If using a skin with space for lots of modules, display a link to Twinkle Preferences
-	let usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
+	const usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
 	if (usingSkinWithDropDownMenu) {
 		Twinkle.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
 	}
@@ -441,7 +441,7 @@ Twinkle.makeFindSourcesDiv = function makeSourcesDiv(divID) {
 		return;
 	}
 	if (!Twinkle.findSources) {
-		let parser = new Morebits.wiki.preview($(divID)[0]);
+		const parser = new Morebits.wiki.preview($(divID)[0]);
 		parser.beginRender('({{Find sources|' + Morebits.pageNameNorm + '}})', 'WP:AFD').then(function() {
 			// Save for second-time around
 			Twinkle.findSources = parser.previewbox.innerHTML;
@@ -461,7 +461,7 @@ Twinkle.sortByNamespace = function(first, second) {
 
 // Used in batch listings to link to the page in question with >
 Twinkle.generateArrowLinks = function (checkbox) {
-	let link = Morebits.htmlNode('a', ' >');
+	const link = Morebits.htmlNode('a', ' >');
 	link.setAttribute('class', 'tw-arrowpage-link');
 	link.setAttribute('href', mw.util.getUrl(checkbox.value));
 	link.setAttribute('target', '_blank');
@@ -470,8 +470,8 @@ Twinkle.generateArrowLinks = function (checkbox) {
 
 // Used in deprod and unlink listings to link the page title
 Twinkle.generateBatchPageLinks = function (checkbox) {
-	let $checkbox = $(checkbox);
-	let link = Morebits.htmlNode('a', $checkbox.val());
+	const $checkbox = $(checkbox);
+	const link = Morebits.htmlNode('a', $checkbox.val());
 	link.setAttribute('class', 'tw-batchpage-link');
 	link.setAttribute('href', mw.util.getUrl($checkbox.val()));
 	link.setAttribute('target', '_blank');

--- a/twinkle.js
+++ b/twinkle.js
@@ -24,7 +24,7 @@ if (!Morebits.userIsInGroup('autoconfirmed') && !Morebits.userIsInGroup('confirm
 	return;
 }
 
-var Twinkle = {};
+let Twinkle = {};
 window.Twinkle = Twinkle;  // allow global access
 
 Twinkle.initCallbacks = [];
@@ -233,13 +233,13 @@ Twinkle.addPortlet = function() {
 	}
 
 	// make sure navigation is a valid CSS selector
-	var root = document.querySelector(navigation);
+	let root = document.querySelector(navigation);
 	if (!root) {
 		return id;
 	}
 
 	// if we already created the portlet, return early. we don't want to create it again.
-	var item = document.getElementById(id);
+	let item = document.getElementById(id);
 	if (item) {
 		return id;
 	}
@@ -250,7 +250,7 @@ Twinkle.addPortlet = function() {
 	if (mw.config.get('skin') === 'vector') {
 		$('#p-twinkle').insertAfter('#p-cactions');
 	} else if (mw.config.get('skin') === 'vector-2022') {
-		var $landmark = $('#right-navigation > .vector-page-tools-landmark');
+		let $landmark = $('#right-navigation > .vector-page-tools-landmark');
 		$('#p-twinkle-dropdown').insertAfter($landmark);
 
 		// .vector-page-tools-landmark is unstable and could change. If so, log it to console, to hopefully get someone's attention.
@@ -272,7 +272,7 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
 	const portletId = Twinkle.addPortlet();
 
 	// Create a portlet link and add it to the portlet.
-	var link = mw.util.addPortletLink(portletId, typeof task === 'string' ? task : '#', text, id, tooltip);
+	let link = mw.util.addPortletLink(portletId, typeof task === 'string' ? task : '#', text, id, tooltip);
 
 	// Related to the hidden peer gadget that prevents jumpiness when the page first loads
 	$('.client-js .skin-vector #p-cactions').css('margin-right', 'initial');
@@ -299,7 +299,7 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
  * **************** General initialization code ****************
  */
 
-var scriptpathbefore = mw.util.wikiScript('index') + '?title=',
+let scriptpathbefore = mw.util.wikiScript('index') + '?title=',
 	scriptpathafter = '&action=raw&ctype=text/javascript&happy=yes';
 
 // Retrieve the user's Twinkle preferences
@@ -326,7 +326,7 @@ $.ajax({
 		}
 
 		try {
-			var options = JSON.parse(optionsText);
+			let options = JSON.parse(optionsText);
 			if (options) {
 				if (options.twinkle || options.friendly) { // Old preferences format
 					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
@@ -350,7 +350,7 @@ $.ajax({
 Twinkle.load = function () {
 	// Don't activate on special pages other than those listed here, so
 	// that others load faster, especially the watchlist.
-	var activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
+	let activeSpecialPageList = [ 'Block', 'Contributions', 'Recentchanges', 'Recentchangeslinked' ]; // wgRelevantUserName defined for non-sysops on Special:Block
 	if (Morebits.userIsSysop) {
 		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}
@@ -388,13 +388,13 @@ Twinkle.load = function () {
 	}
 
 	// Hide the lingering space if the TW menu is empty
-	var isVector = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022';
+	let isVector = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022';
 	if (isVector && Twinkle.getPref('portletType') === 'menu' && $('#p-twinkle').length === 0) {
 		$('#p-cactions').css('margin-right', 'initial');
 	}
 
 	// If using a skin with space for lots of modules, display a link to Twinkle Preferences
-	var usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
+	let usingSkinWithDropDownMenu = mw.config.get('skin') === 'vector' || mw.config.get('skin') === 'vector-2022' || mw.config.get('skin') === 'timeless';
 	if (usingSkinWithDropDownMenu) {
 		Twinkle.addPortletLink(mw.util.getUrl('Wikipedia:Twinkle/Preferences'), 'Config', 'tw-config', 'Open Twinkle preferences page');
 	}
@@ -441,7 +441,7 @@ Twinkle.makeFindSourcesDiv = function makeSourcesDiv(divID) {
 		return;
 	}
 	if (!Twinkle.findSources) {
-		var parser = new Morebits.wiki.preview($(divID)[0]);
+		let parser = new Morebits.wiki.preview($(divID)[0]);
 		parser.beginRender('({{Find sources|' + Morebits.pageNameNorm + '}})', 'WP:AFD').then(function() {
 			// Save for second-time around
 			Twinkle.findSources = parser.previewbox.innerHTML;
@@ -461,7 +461,7 @@ Twinkle.sortByNamespace = function(first, second) {
 
 // Used in batch listings to link to the page in question with >
 Twinkle.generateArrowLinks = function (checkbox) {
-	var link = Morebits.htmlNode('a', ' >');
+	let link = Morebits.htmlNode('a', ' >');
 	link.setAttribute('class', 'tw-arrowpage-link');
 	link.setAttribute('href', mw.util.getUrl(checkbox.value));
 	link.setAttribute('target', '_blank');
@@ -470,8 +470,8 @@ Twinkle.generateArrowLinks = function (checkbox) {
 
 // Used in deprod and unlink listings to link the page title
 Twinkle.generateBatchPageLinks = function (checkbox) {
-	var $checkbox = $(checkbox);
-	var link = Morebits.htmlNode('a', $checkbox.val());
+	let $checkbox = $(checkbox);
+	let link = Morebits.htmlNode('a', $checkbox.val());
 	link.setAttribute('class', 'tw-batchpage-link');
 	link.setAttribute('href', mw.util.getUrl($checkbox.val()));
 	link.setAttribute('target', '_blank');

--- a/twinkle.js
+++ b/twinkle.js
@@ -279,7 +279,7 @@ Twinkle.addPortletLink = function(task, text, id, tooltip) {
 
 	// Add a click listener for the portlet link
 	if (typeof task === 'function') {
-		$(link).click(function (ev) {
+		$(link).click((ev) => {
 			task();
 			ev.preventDefault();
 		});
@@ -307,10 +307,10 @@ $.ajax({
 	url: scriptpathbefore + 'User:' + encodeURIComponent(mw.config.get('wgUserName')) + '/twinkleoptions.js' + scriptpathafter,
 	dataType: 'text'
 })
-	.fail(function () {
+	.fail(() => {
 		console.log('Could not load your Twinkle preferences, resorting to default preferences'); // eslint-disable-line no-console
 	})
-	.done(function (optionsText) {
+	.done((optionsText) => {
 
 		// Quick pass if user has no options
 		if (optionsText === '') {
@@ -340,7 +340,7 @@ $.ajax({
 			mw.notify('Could not parse your Twinkle preferences', {type: 'error'});
 		}
 	})
-	.always(function () {
+	.always(() => {
 		$(Twinkle.load);
 	});
 
@@ -377,7 +377,7 @@ Twinkle.load = function () {
 		}
 	};
 	// Initialise modules that were saved in initCallbacks array
-	Twinkle.initCallbacks.forEach(function(module) {
+	Twinkle.initCallbacks.forEach((module) => {
 		Twinkle.addInitCallback(module.func, module.name);
 	});
 
@@ -442,7 +442,7 @@ Twinkle.makeFindSourcesDiv = function makeSourcesDiv(divID) {
 	}
 	if (!Twinkle.findSources) {
 		const parser = new Morebits.wiki.preview($(divID)[0]);
-		parser.beginRender('({{Find sources|' + Morebits.pageNameNorm + '}})', 'WP:AFD').then(function() {
+		parser.beginRender('({{Find sources|' + Morebits.pageNameNorm + '}})', 'WP:AFD').then(() => {
 			// Save for second-time around
 			Twinkle.findSources = parser.previewbox.innerHTML;
 			$(divID).removeClass('morebits-previewbox');


### PR DESCRIPTION
I made it one autofix per commit, to make the diffs easier to read.

`npx eslint --no-eslintrc --fix --rule '{wrap-iife: error}' --env 'es6' .`

I have found eslint autofixes to be extremely reliable. I have never encountered a bug with them that has broken the program. I have seen them mess with code formatting in unexpected ways though, so for that reason I am still spot checking each diff.

This will probably be the first of several patches. Doing all the autofixes in one patch would make a revert a pain.