### PR TITLE
config: don't ignore old fluff preferences

### DIFF
--- a/modules/twinklerollback.js
+++ b/modules/twinklerollback.js
@@ -679,7 +679,7 @@ Twinkle.rollback.callbacks = {
 				(
 					Twinkle.getPref('confirmOnMobileRollback') &&
 					// Mobile user agent taken from [[en:MediaWiki:Gadget-confirmationRollback-mobile.js]]
-					/Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent);
+					/Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent)
 				)
 			) &&
 			!userHasAlreadyConfirmedAction;

--- a/modules/twinklerollback.js
+++ b/modules/twinklerollback.js
@@ -673,14 +673,13 @@ Twinkle.rollback.callbacks = {
 				break;
 		}
 
-		// Mobile user agent taken from [[en:MediaWiki:Gadget-confirmationRollback-mobile.js]]
-		const isMobileUser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent);
 		const needToDisplayConfirmation =
 			(
 				Twinkle.getPref('confirmOnRollback') ||
 				(
 					Twinkle.getPref('confirmOnMobileRollback') &&
-					isMobileUser
+					// Mobile user agent taken from [[en:MediaWiki:Gadget-confirmationRollback-mobile.js]]
+					/Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent);
 				)
 			) &&
 			!userHasAlreadyConfirmedAction;

--- a/modules/twinklerollback.js
+++ b/modules/twinklerollback.js
@@ -673,13 +673,19 @@ Twinkle.rollback.callbacks = {
 				break;
 		}
 
-		// Preferences confirmOnRollback and confirmOnMobileRollback were formerly named
-		// confirmOnFluff and confirmOnMobileFluff, respectively. Check both variations for now.
-		if ((Twinkle.getPref('confirmOnRollback') || Twinkle.getPref('confirmOnFluff') ||
-			((Twinkle.getPref('confirmOnMobileRollback') || Twinkle.getPref('confirmOnMobileFluff')) &&
-				// Mobile user agent taken from [[en:MediaWiki:Gadget-confirmationRollback-mobile.js]]
-				/Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent))) &&
-			!userHasAlreadyConfirmedAction && !confirm('Reverting page: are you sure?')) {
+		// Mobile user agent taken from [[en:MediaWiki:Gadget-confirmationRollback-mobile.js]]
+		const isMobileUser = /Android|webOS|iPhone|iPad|iPod|BlackBerry|Mobile|Opera Mini/i.test(navigator.userAgent);
+		const needToDisplayConfirmation =
+			(
+				Twinkle.getPref('confirmOnRollback') ||
+				(
+					Twinkle.getPref('confirmOnMobileRollback') &&
+					isMobileUser
+				)
+			) &&
+			!userHasAlreadyConfirmedAction;
+
+		if (needToDisplayConfirmation && !confirm('Reverting page: are you sure?')) {
 			statelem.error('Aborted by user.');
 			return;
 		}

--- a/twinkle.js
+++ b/twinkle.js
@@ -179,6 +179,7 @@ Twinkle.getPref = function twinkleGetPref(name) {
 	if (typeof Twinkle.prefs === 'object' && Twinkle.prefs[name] !== undefined) {
 		return Twinkle.prefs[name];
 	}
+
 	// Old preferences format, used before twinkleoptions.js was a thing
 	if (typeof window.TwinkleConfig === 'object' && window.TwinkleConfig[name] !== undefined) {
 		return window.TwinkleConfig[name];
@@ -186,6 +187,14 @@ Twinkle.getPref = function twinkleGetPref(name) {
 	if (typeof window.FriendlyConfig === 'object' && window.FriendlyConfig[name] !== undefined) {
 		return window.FriendlyConfig[name];
 	}
+
+	// Backwards compatibility code because we renamed confirmOnFluff to confirmOnRollback, and confirmOnMobileFluff to confirmOnMobileRollback
+	if (name === 'confirmOnRollback' && Twinkle.prefs.confirmOnFluff !== undefined) {
+		return Twinkle.prefs.confirmOnFluff;
+	} else if (name === 'confirmOnMobileRollback' && Twinkle.prefs.confirmOnFluff !== undefined) {
+		return Twinkle.prefs.confirmOnMobileFluff;
+	}
+
 	return Twinkle.defaultConfig[name];
 };
 


### PR DESCRIPTION
- fixes an issue where if a user still had the old confirmOnFluff or confirmOnRollback preferences, and visited the preferences page and saved, their preferences were ignored and silently deleted
- refactor complicated conditional in twinklerollback.js module
- reverts #2059 because we accomplish the same thing by putting the code in twinkle.js -> twinkleGetPref()