### PR TITLE
rollback: fix "cannot read properties of undefined"

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -189,9 +189,9 @@ Twinkle.getPref = function twinkleGetPref(name) {
 	}
 
 	// Backwards compatibility code because we renamed confirmOnFluff to confirmOnRollback, and confirmOnMobileFluff to confirmOnMobileRollback
-	if (name === 'confirmOnRollback' && Twinkle.prefs.confirmOnFluff !== undefined) {
+	if (name === 'confirmOnRollback' && typeof Twinkle.prefs === 'object' && Twinkle.prefs.confirmOnFluff !== undefined) {
 		return Twinkle.prefs.confirmOnFluff;
-	} else if (name === 'confirmOnMobileRollback' && Twinkle.prefs.confirmOnMobileFluff !== undefined) {
+	} else if (name === 'confirmOnMobileRollback' && typeof Twinkle.prefs === 'object' && Twinkle.prefs.confirmOnMobileFluff !== undefined) {
 		return Twinkle.prefs.confirmOnMobileFluff;
 	}
 


### PR DESCRIPTION
hotfix

https://en.wikipedia.org/wiki/Wikipedia_talk:Twinkle#Problems_with_WP%3ATwinkle