### PR TITLE
fix linter error no-sequences

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,6 @@
 		"no-new": "warn",
 		"no-return-assign": "warn",
 		"no-script-url": "warn",
-		"no-sequences": "warn",
 		"no-throw-literal": "warn",
 		"no-unneeded-ternary": "warn",
 		"no-unused-expressions": "warn",

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -186,9 +186,11 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 	// Toggle unblock link if not the user in question; always first
 	const unblockLink = document.querySelector('.morebits-dialog-footerlinks a');
 	if (blockedUserName !== relevantUserName) {
-		unblockLink.hidden = true, unblockLink.nextSibling.hidden = true; // link+trailing bullet
+		unblockLink.hidden = true;
+		unblockLink.nextSibling.hidden = true; // link+trailing bullet
 	} else {
-		unblockLink.hidden = false, unblockLink.nextSibling.hidden = false; // link+trailing bullet
+		unblockLink.hidden = false;
+		unblockLink.nextSibling.hidden = false; // link+trailing bullet
 	}
 
 	// Semi-busted on ranges, see [[phab:T270737]] and [[phab:T146628]].

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -1273,7 +1273,7 @@ Twinkle.xfd.callbacks = {
 			const params = pageobj.getCallbackParameters();
 
 			const date = new Morebits.date(pageobj.getLoadTime());
-			params.logpage = 'Wikipedia:Templates for discussion/Log/' + date.format('YYYY MMMM D', 'utc'),
+			params.logpage = 'Wikipedia:Templates for discussion/Log/' + date.format('YYYY MMMM D', 'utc');
 			params.discussionpage = params.logpage + '#' + Morebits.pageNameNorm;
 			// Add log/discussion page params to the already-loaded page object
 			pageobj.setCallbackParameters(params);

--- a/morebits.js
+++ b/morebits.js
@@ -1966,7 +1966,8 @@ Morebits.date.prototype = {
 			// No built-in week functions, so rather than build out ISO's getWeek/setWeek, just multiply
 			// Probably can't be used for Julian->Gregorian changeovers, etc.
 			if (unitNorm === 'Week') {
-				unitNorm = 'Date', num *= 7;
+				unitNorm = 'Date';
+				num *= 7;
 			}
 			this['set' + unitNorm](this['get' + unitNorm]() + num);
 			return this;


### PR DESCRIPTION
manual fixes. I tested one fix in the console, worked as expected. All 4 fixes follow the pattern of `var1 = 'x', var2 = 'y'` -> `var1 = 'x'; 'var2 = 'y'`