### PR TITLE
fix some no-jquery/no-extend autofixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,6 +48,7 @@
 		"new-cap": "warn",
 		"no-jquery/no-constructor-attributes": "warn",
 		"no-jquery/no-each-util": "warn",
+		"no-jquery/no-extend": "warn",
 		"no-jquery/no-grep": "warn",
 		"no-jquery/no-in-array": "warn",
 		"no-jquery/no-map-util": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,6 @@
 		"new-cap": "warn",
 		"no-jquery/no-constructor-attributes": "warn",
 		"no-jquery/no-each-util": "warn",
-		"no-jquery/no-extend": "warn",
 		"no-jquery/no-grep": "warn",
 		"no-jquery/no-in-array": "warn",
 		"no-jquery/no-map-util": "warn",

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1899,7 +1899,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	// "talk page" of an IP range (which does not exist)
 	const userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
-	const params = Object.assign(formData, {
+	const params = $.extend(formData, {
 		messageData: Twinkle.block.blockPresetsInfo[formData.template],
 		reason: Twinkle.block.field_template_options.block_reason,
 		disabletalk: Twinkle.block.field_template_options.notalk,

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -1899,7 +1899,7 @@ Twinkle.block.callback.issue_template = function twinkleblockCallbackIssueTempla
 	// "talk page" of an IP range (which does not exist)
 	const userTalkPage = 'User_talk:' + mw.config.get('wgRelevantUserName');
 
-	const params = $.extend(formData, {
+	const params = Object.assign(formData || {}, {
 		messageData: Twinkle.block.blockPresetsInfo[formData.template],
 		reason: Twinkle.block.field_template_options.block_reason,
 		disabletalk: Twinkle.block.field_template_options.notalk,

--- a/morebits.js
+++ b/morebits.js
@@ -758,7 +758,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 
 			data.inputs.forEach((subdata) => {
-				const cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
+				const cell = new Morebits.quickForm.element(Object.assign(subdata || {}, { type: '_dyninput_cell' }));
 				node.appendChild(cell.render());
 			});
 			if (data.remove) {

--- a/morebits.js
+++ b/morebits.js
@@ -758,7 +758,7 @@ Morebits.quickForm.element.prototype.compute = function QuickFormElementCompute(
 			node = document.createElement('div');
 
 			data.inputs.forEach((subdata) => {
-				const cell = new Morebits.quickForm.element(Object.assign(subdata, { type: '_dyninput_cell' }));
+				const cell = new Morebits.quickForm.element($.extend(subdata, { type: '_dyninput_cell' }));
 				node.appendChild(cell.render());
 			});
 			if (data.remove) {

--- a/twinkle.js
+++ b/twinkle.js
@@ -337,7 +337,7 @@ $.ajax({
 			const options = JSON.parse(optionsText);
 			if (options) {
 				if (options.twinkle || options.friendly) { // Old preferences format
-					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
+					Twinkle.prefs = Object.assign(options.twinkle || {}, options.friendly);
 				} else {
 					Twinkle.prefs = options;
 				}

--- a/twinkle.js
+++ b/twinkle.js
@@ -337,7 +337,7 @@ $.ajax({
 			const options = JSON.parse(optionsText);
 			if (options) {
 				if (options.twinkle || options.friendly) { // Old preferences format
-					Twinkle.prefs = Object.assign(options.twinkle, options.friendly);
+					Twinkle.prefs = $.extend(options.twinkle, options.friendly);
 				} else {
 					Twinkle.prefs = options;
 				}


### PR DESCRIPTION
Upstream, they caught a bug in the autofix algorithm. Basically, you should only change $.extend() to Object.assign() if you're sure the first argument isn't null or undefined. Else it will throw.

This patch changes a couple from `Object.assign(variable` to `Object.assign(variable || {}`.

https://github.com/wikimedia/eslint-plugin-no-jquery/commit/35d44891f1f09422211e8e1b02db10db6e27a2a8

Related #2079