### PR TITLE
welcome: change {{welcomeunsourced}} to {{welcome-unsourced}} as result of page move

### DIFF
--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -323,10 +323,10 @@ Twinkle.welcome.templates = {
 				linkedArticle: true,
 				syntax: '{{subst:welcomenpov|$ARTICLE$|$USERNAME$}} ~~~~'
 			},
-			welcomeunsourced: {
+			'welcome-unsourced': {
 				description: 'for someone whose initial efforts are unsourced',
 				linkedArticle: true,
-				syntax: '{{subst:welcomeunsourced|$ARTICLE$|$USERNAME$}} ~~~~'
+				syntax: '{{subst:welcome-unsourced|$ARTICLE$|$USERNAME$}} ~~~~'
 			},
 			welcomevandal: {
 				description: 'for someone whose initial efforts appear to be vandalism',

--- a/modules/twinklewelcome.js
+++ b/modules/twinklewelcome.js
@@ -314,6 +314,11 @@ Twinkle.welcome.templates = {
 				linkedArticle: true,
 				syntax: '{{subst:welcome-image|$USERNAME$|art=$ARTICLE$}}'
 			},
+			'welcome-unsourced': {
+				description: 'for someone whose initial efforts are unsourced',
+				linkedArticle: true,
+				syntax: '{{subst:welcome-unsourced|$ARTICLE$|$USERNAME$}} ~~~~'
+			},
 			welcomelaws: {
 				description: 'welcome with information about copyrights, NPOV, the sandbox, and vandalism',
 				syntax: '{{subst:welcomelaws|$USERNAME$}} ~~~~'
@@ -322,11 +327,6 @@ Twinkle.welcome.templates = {
 				description: 'for someone whose initial efforts do not adhere to the neutral point of view policy',
 				linkedArticle: true,
 				syntax: '{{subst:welcomenpov|$ARTICLE$|$USERNAME$}} ~~~~'
-			},
-			'welcome-unsourced': {
-				description: 'for someone whose initial efforts are unsourced',
-				linkedArticle: true,
-				syntax: '{{subst:welcome-unsourced|$ARTICLE$|$USERNAME$}} ~~~~'
 			},
 			welcomevandal: {
 				description: 'for someone whose initial efforts appear to be vandalism',


### PR DESCRIPTION
https://en.wikipedia.org/w/index.php?title=Wikipedia_talk:Twinkle&oldid=1260049504#Moving_Template:Welcomeunsourced_to_Template:Welcome-unsourced
