### PR TITLE
eslint: fix es-x/no-array-prototype-includes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -41,7 +41,6 @@
 			}
 		],
 
-		"es-x/no-array-prototype-includes": "warn",
 		"es-x/no-object-values": "warn",
 		"mediawiki/class-doc": "warn",
 		"new-cap": "warn",

--- a/modules/twinklearv.js
+++ b/modules/twinklearv.js
@@ -537,7 +537,7 @@ Twinkle.arv.callback.evaluate = function(e) {
 
 		// Report inappropriate username
 		case 'username':
-			var censorUsername = input.arvtype.includes('offensive'); // check if the username is marked offensive
+			var censorUsername = input.arvtype.indexOf('offensive') !== -1; // check if the username is marked offensive
 
 			reason = Twinkle.arv.callback.getUsernameReportWikitext(input);
 

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -508,7 +508,7 @@ Twinkle.protect.callback.changeAction = function twinkleprotectCallbackChangeAct
 
 			var isTemplateNamespace = mw.config.get('wgNamespaceNumber') === 10;
 			var isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
-			var isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
+			var isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			field1.append({
 				type: 'checkbox',
 				list: [
@@ -1073,7 +1073,7 @@ Twinkle.protect.callback.changePreset = function twinkleprotectCallbackChangePre
 			const isTemplateEditorProtection = form.category.value === 'pp-template';
 			const isAFD = Morebits.pageNameNorm.startsWith('Wikipedia:Articles for deletion/');
 			const isNotTemplateNamespace = mw.config.get('wgNamespaceNumber') !== 10;
-			const isCode = ['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'));
+			const isCode = ['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1;
 			if ((isTemplateEditorProtection || isAFD) && !isCode) {
 				form.noinclude.checked = true;
 			} else if (isCode || isNotTemplateNamespace) {

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -45,7 +45,7 @@ Twinkle.tag.callback = function twinkletagCallback() {
 	const form = new Morebits.QuickForm(Twinkle.tag.callback.evaluate);
 
 	// if page is unreviewed, add a checkbox to the form so that user can pick whether or not to review it
-	const isPatroller = mw.config.get('wgUserGroups').some((r) => ['patroller', 'sysop'].includes(r));
+	const isPatroller = mw.config.get('wgUserGroups').some((r) => ['patroller', 'sysop'].indexOf(r) !== -1);
 	if (isPatroller) {
 		new mw.Api().get({
 			action: 'pagetriagelist',
@@ -2085,38 +2085,38 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 				// Check that selected templates make sense given the file's extension.
 
 				// {{Bad GIF|JPEG|SVG}}, {{Fake SVG}}
-				if (extensionUpper !== 'GIF' && params.tags.includes('Bad GIF')) {
+				if (extensionUpper !== 'GIF' && params.tags.indexOf('Bad GIF') !== -1) {
 					alert('This appears to be a ' + extension + ' file, so {{Bad GIF}} is inappropriate.');
 					return;
-				} else if (extensionUpper !== 'JPEG' && params.tags.includes('Bad JPEG')) {
+				} else if (extensionUpper !== 'JPEG' && params.tags.indexOf('Bad JPEG') !== -1) {
 					alert('This appears to be a ' + extension + ' file, so {{Bad JPEG}} is inappropriate.');
 					return;
-				} else if (extensionUpper !== 'SVG' && params.tags.includes('Bad SVG')) {
+				} else if (extensionUpper !== 'SVG' && params.tags.indexOf('Bad SVG') !== -1) {
 					alert('This appears to be a ' + extension + ' file, so {{Bad SVG}} is inappropriate.');
 					return;
-				} else if (extensionUpper !== 'SVG' && params.tags.includes('Fake SVG')) {
+				} else if (extensionUpper !== 'SVG' && params.tags.indexOf('Fake SVG') !== -1) {
 					alert('This appears to be a ' + extension + ' file, so {{Fake SVG}} is inappropriate.');
 					return;
 				}
 
 				// {{Should be PNG|SVG}}
-				if (params.tags.includes('Should be ' + extensionUpper)) {
+				if (params.tags.indexOf('Should be ' + extensionUpper) !== -1) {
 					alert('This is already a ' + extension + ' file, so {{Should be ' + extensionUpper + '}} is inappropriate.');
 					return;
 				}
 
 				// {{Overcompressed JPEG}}
-				if (params.tags.includes('Overcompressed JPEG') && extensionUpper !== 'JPEG') {
+				if (params.tags.indexOf('Overcompressed JPEG') !== -1 && extensionUpper !== 'JPEG') {
 					alert('This appears to be a ' + extension + ' file, so {{Overcompressed JPEG}} probably doesn\'t apply.');
 					return;
 				}
 
 				// {{Bad trace}} and {{Bad font}}
 				if (extensionUpper !== 'SVG') {
-					if (params.tags.includes('Bad trace')) {
+					if (params.tags.indexOf('Bad trace') !== -1) {
 						alert('This appears to be a ' + extension + ' file, so {{Bad trace}} probably doesn\'t apply.');
 						return;
-					} else if (params.tags.includes('Bad font')) {
+					} else if (params.tags.indexOf('Bad font') !== -1) {
 						alert('This appears to be a ' + extension + ' file, so {{Bad font}} probably doesn\'t apply.');
 						return;
 					}
@@ -2125,7 +2125,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 
 			// {{Do not move to Commons}}
 			if (
-				params.tags.includes('Do not move to Commons') &&
+				params.tags.indexOf('Do not move to Commons') !== -1 &&
 				params.DoNotMoveToCommons_expiry &&
 				(
 					!/^2\d{3}$/.test(params.DoNotMoveToCommons_expiry) ||


### PR DESCRIPTION
manual fixes

apparently Array.includes() is >ES6, so to keep compatibility with old browsers it should be removed for now