### PR TITLE
protect: added 2-hour noticeboard LTA preset

### DIFF
--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -791,7 +791,6 @@ Twinkle.protect.protectionPresetsInfo = {
 	},
 	'pp-sock-noticeboard': {
 		edit: 'autoconfirmed',
-		move: 'autoconfirmed',
 		expiry: '2 hours',
 		reason: 'Persistent [[WP:Sock puppetry|sock puppetry]]',
 		template: 'pp-sock'
@@ -872,14 +871,12 @@ Twinkle.protect.protectionPresetsInfo = {
 	},
 	'pp-semi-usertalk': {
 		edit: 'autoconfirmed',
-		move: 'autoconfirmed',
 		expiry: 'infinity',
 		reason: '[[WP:PP#Talk-page protection|Inappropriate use of user talk page while blocked]]',
 		template: 'pp-usertalk'
 	},
 	'pp-semi-template': { // removed for now
 		edit: 'autoconfirmed',
-		move: 'autoconfirmed',
 		expiry: 'infinity',
 		reason: '[[WP:High-risk templates|Highly visible template]]',
 		template: 'pp-template'

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -724,7 +724,8 @@ Twinkle.protect.protectionTypes = [
 			{ label: 'Adding unsourced content (semi)', value: 'pp-semi-unsourced' },
 			{ label: 'BLP policy violations (semi)', value: 'pp-semi-blp' },
 			{ label: 'Sockpuppetry (semi)', value: 'pp-semi-sock' },
-			{ label: 'User talk of blocked user (semi)', value: 'pp-semi-usertalk' }
+			{ label: 'User talk of blocked user (semi)', value: 'pp-semi-usertalk' },
+			{ label: 'Noticeboard LTA (semi)', value: 'pp-sock-noticeboard' }
 		]
 	},
 	{
@@ -787,6 +788,13 @@ Twinkle.protect.protectionPresetsInfo = {
 		edit: 'sysop',
 		move: 'sysop',
 		reason: '[[WP:PP#Content disputes|Edit warring / content dispute]]'
+	},
+	'pp-sock-noticeboard': {
+		edit: 'autoconfirmed',
+		move: 'autoconfirmed',
+		expiry: '2 hours',
+		reason: 'Persistent [[WP:Sock puppetry|sock puppetry]]',
+		template: 'pp-sock'
 	},
 	'pp-vandalism': {
 		edit: 'sysop',
@@ -1244,6 +1252,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				case 'pp-30-500':
 					typename = 'extended confirmed protection';
 					break;
+				case 'pp-sock-noticeboard':
 				case 'pp-semi-vandalism':
 				case 'pp-semi-disruptive':
 				case 'pp-semi-unsourced':
@@ -1315,6 +1324,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 				case 'pp-semi-usertalk':
 					typereason = 'Inappropriate use of user talk page while blocked';
 					break;
+				case 'pp-noticeboard-sock':
 				case 'pp-semi-sock':
 				case 'pp-30-500-sock':
 					typereason = 'Persistent [[WP:SOCK|sockpuppetry]]';


### PR DESCRIPTION
Resolves #2095

While I was at it, I also noticed a few protection presets with semi-move protection, which doesn't do anything and isn't selectable in the Twinkle protect dialogue anyways, so I removed it.

<img width="583" alt="image" src="https://github.com/user-attachments/assets/592098a2-6fc8-4e39-9dc8-f94f287b915a">
