### PR TITLE
tests: ignore twinkle.js in code coverage report

### DIFF
--- a/twinkle.js
+++ b/twinkle.js
@@ -17,6 +17,9 @@
 
 /* global Morebits */
 
+// Ignore this file in Jest's test coverage report
+/* istanbul ignore file */
+
 (function() {
 
 // Check if account is experienced enough to use Twinkle


### PR DESCRIPTION
Was showing like 35% covered. But this was just from scaffolding code or something. Actual # of unit tests is 0.