### PR TITLE
tests: turn on eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,2 @@
 scripts/
-tests/
 lib/

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -10,6 +10,7 @@
 		"array-bracket-spacing": "off",
 		"computed-property-spacing": "off",
 		"no-shadow": "off",
+		"object-curly-spacing": "off",
 		"space-in-parens": "off",
 
 		"camelcase": "warn",

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+	"extends": [
+		"wikimedia/server"
+	],
+	"env": {
+		"jest": true
+	},
+	"root": true,
+	"rules": {
+		"array-bracket-spacing": "off",
+		"computed-property-spacing": "off",
+		"no-shadow": "off",
+		"space-in-parens": "off",
+
+		"camelcase": "warn",
+		"comma-dangle": "warn",
+		"eol-last": "warn",
+		"new-cap": "warn",
+		"prefer-arrow-callback": "warn",
+		"prefer-const": "warn",
+		"no-trailing-spaces": "warn",
+		"no-undef": "warn",
+		"no-useless-escape": "warn",
+		"no-var": "warn",
+		"semi": "warn",
+		"strict": "warn",
+		"quotes": "warn",
+		"unicorn/prefer-date-now": "warn"
+	}
+}


### PR DESCRIPTION
I had it off. I guess because it needs a different config (wikimedia/server). This patch sets that up.

Will run autofixes in the next patch. Should be able to get rid of a bunch of rule exceptions by running the autofixes.