### PR TITLE
eslint: replace es-x/no-array-prototype-includes with unicorn/prefer-includes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
 	"rules": {
 		"array-bracket-spacing": "off",
 		"computed-property-spacing": "off",
+		"es-x/no-array-prototype-includes": "off",
 		"indent": "off",
 		"jsdoc/require-param": "off",
 		"jsdoc/require-returns": "off",
@@ -40,7 +41,6 @@
 		],
 
 		"camelcase": ["warn", {"properties": "never"}],
-		"es-x/no-array-prototype-includes": "warn",
 		"es-x/no-object-values": "warn",
 		"mediawiki/class-doc": "warn",
 		"new-cap": "warn",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
 				"selector": "MemberExpression > Identifier[name=\"fail\"]"
 			}
 		],
+		"unicorn/prefer-includes": "error",
 
 		"camelcase": ["warn", {"properties": "never"}],
 		"es-x/no-object-values": "warn",

--- a/modules/twinklebatchdelete.js
+++ b/modules/twinklebatchdelete.js
@@ -305,7 +305,7 @@ Twinkle.batchdelete.callback.toggleSubpages = function twDbatchToggleSubpages(e)
 			const pageTitle = mw.Title.newFromText(pageName);
 
 			// No need to look for subpages in main/file/mediawiki space
-			if ([0, 6, 8].indexOf(pageTitle.namespace) > -1) {
+			if ([0, 6, 8].includes(pageTitle.namespace)) {
 				subpageLister.workerSuccess();
 				return;
 			}

--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -170,7 +170,7 @@ Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 
 	Twinkle.block.isRegistered = !!userinfo.userid;
 	if (Twinkle.block.isRegistered) {
-		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map((e) => e.group).indexOf('bot') !== -1;
+		Twinkle.block.userIsBot = !!userinfo.groupmemberships && userinfo.groupmemberships.map((e) => e.group).includes('bot');
 	} else {
 		Twinkle.block.userIsBot = false;
 	}
@@ -1548,7 +1548,7 @@ Twinkle.block.callback.toggle_see_alsos = function twinkleblockCallbackToggleSee
 
 	if (!Twinkle.block.seeAlsos.length) {
 		this.form.reason.value = reason;
-	} else if (reason.indexOf('{{') !== -1) {
+	} else if (reason.includes('{{')) {
 		this.form.reason.value = reason + ' <!-- see also ' + seeAlsoMessage + ' -->';
 	} else {
 		this.form.reason.value = reason + '; see also ' + seeAlsoMessage;
@@ -1760,7 +1760,7 @@ Twinkle.block.callback.evaluate = function twinkleblockCallbackEvaluate(e) {
 
 	if (toBlock) {
 		if (blockoptions.partial) {
-			if (blockoptions.disabletalk && blockoptions.namespacerestrictions.indexOf('3') === -1) {
+			if (blockoptions.disabletalk && !blockoptions.namespacerestrictions.includes('3')) {
 				return alert('Partial blocks cannot prevent talk page access unless also restricting them from editing User talk space!');
 			}
 			if (!blockoptions.namespacerestrictions && !blockoptions.pagerestrictions) {

--- a/modules/twinkleconfig.js
+++ b/modules/twinkleconfig.js
@@ -1171,12 +1171,12 @@ Twinkle.config.init = function twinkleconfigInit() {
 							check.setAttribute('type', 'checkbox');
 							check.setAttribute('id', pref.name + '_' + itemkey);
 							check.setAttribute('name', pref.name + '_' + itemkey);
-							if (gotPref && gotPref.indexOf(itemkey) !== -1) {
+							if (gotPref && gotPref.includes(itemkey)) {
 								check.setAttribute('checked', 'checked');
 							}
 							// cater for legacy integer array values for unlinkNamespaces (this can be removed a few years down the track...)
 							if (pref.name === 'unlinkNamespaces') {
-								if (gotPref && gotPref.indexOf(parseInt(itemkey, 10)) !== -1) {
+								if (gotPref && gotPref.includes(parseInt(itemkey, 10))) {
 									check.setAttribute('checked', 'checked');
 								}
 							}
@@ -1314,7 +1314,7 @@ Twinkle.config.init = function twinkleconfigInit() {
 			box.appendChild(document.createTextNode(', or by editing this page.'));
 			$(box).insertAfter($('#contentSub'));
 
-		} else if (['monobook', 'vector', 'vector-2022', 'cologneblue', 'modern', 'timeless', 'minerva', 'common'].indexOf(scriptPageName) !== -1) {
+		} else if (['monobook', 'vector', 'vector-2022', 'cologneblue', 'modern', 'timeless', 'minerva', 'common'].includes(scriptPageName)) {
 			// place "Looking for Twinkle options?" notice
 			box.setAttribute('class', 'config-userskin-box');
 
@@ -1537,7 +1537,7 @@ Twinkle.config.resetPref = function twinkleconfigResetPref(pref) {
 		case 'set':
 			$.each(pref.setValues, (itemkey) => {
 				if (document.getElementById(pref.name + '_' + itemkey)) {
-					document.getElementById(pref.name + '_' + itemkey).checked = Twinkle.defaultConfig[pref.name].indexOf(itemkey) !== -1;
+					document.getElementById(pref.name + '_' + itemkey).checked = Twinkle.defaultConfig[pref.name].includes(itemkey);
 				}
 			});
 			break;

--- a/modules/twinkleimage.js
+++ b/modules/twinkleimage.js
@@ -209,7 +209,7 @@ Twinkle.image.callback.evaluate = function twinkleimageCallbackEvaluate(event) {
 			throw new Error('Twinkle.image.callback.evaluate: unknown criterion');
 	}
 
-	const lognomination = Twinkle.getPref('logSpeedyNominations') && Twinkle.getPref('noLogOnSpeedyNomination').indexOf(csdcrit.toLowerCase()) === -1;
+	const lognomination = Twinkle.getPref('logSpeedyNominations') && !Twinkle.getPref('noLogOnSpeedyNomination').includes(csdcrit.toLowerCase());
 	const templatename = input.derivative ? 'dw ' + input.type : input.type;
 
 	const params = $.extend({

--- a/modules/twinkleprod.js
+++ b/modules/twinkleprod.js
@@ -11,7 +11,7 @@
  */
 
 Twinkle.prod = function twinkleprod() {
-	if (([0, 6].indexOf(mw.config.get('wgNamespaceNumber')) === -1) ||
+	if ((![0, 6].includes(mw.config.get('wgNamespaceNumber'))) ||
 		!mw.config.get('wgCurRevisionId') ||
 		Morebits.isPageRedirect()) {
 		return;

--- a/modules/twinkleprotect.js
+++ b/modules/twinkleprotect.js
@@ -1274,7 +1274,7 @@ Twinkle.protect.callback.evaluate = function twinkleprotectCallbackEvaluate(e) {
 					break;
 				case 'unprotect':
 					var admins = $.map(Twinkle.protect.currentProtectionLevels, (pl) => {
-						if (!pl.admin || Twinkle.protect.trustedBots.indexOf(pl.admin) !== -1) {
+						if (!pl.admin || Twinkle.protect.trustedBots.includes(pl.admin)) {
 							return null;
 						}
 						return 'User:' + pl.admin;
@@ -1401,7 +1401,7 @@ Twinkle.protect.callback.annotateProtectReason = function twinkleprotectCallback
 			$(form.protectReason_notes_rfppRevid).parent().hide();
 		}
 	} else if (this.name === 'protectReason_notes_rfppRevid') {
-		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter((el) => el.indexOf('[[Special:Permalink') === -1);
+		Twinkle.protect.protectReasonAnnotations = Twinkle.protect.protectReasonAnnotations.filter((el) => !el.includes('[[Special:Permalink'));
 		if (e.target.value.length) {
 			const permalink = '[[Special:Permalink/' + e.target.value + '#' + Morebits.pageNameNorm + ']]';
 			Twinkle.protect.protectReasonAnnotations.push(permalink);
@@ -1459,7 +1459,7 @@ Twinkle.protect.callbacks = {
 					return;
 				}
 			} else {
-				const needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].indexOf(protectedPage.getContentModel()) !== -1;
+				const needsTagToBeCommentedOut = ['javascript', 'css', 'sanitized-css'].includes(protectedPage.getContentModel());
 				if (needsTagToBeCommentedOut) {
 					if (params.noinclude) {
 						tag = '/* <noinclude>{{' + tag + '}}</noinclude> */';

--- a/modules/twinklerollback.js
+++ b/modules/twinklerollback.js
@@ -192,9 +192,9 @@ Twinkle.rollback.addLinks = {
 		if (mw.config.exists('wgRelevantUserName') || isRange) {
 			// Get the username these contributions are for
 			let username = mw.config.get('wgRelevantUserName');
-			if (Twinkle.getPref('showRollbackLinks').indexOf('contribs') !== -1 ||
-				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').indexOf('others') !== -1) ||
-				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').indexOf('mine') !== -1)) {
+			if (Twinkle.getPref('showRollbackLinks').includes('contribs') ||
+				(mw.config.get('wgUserName') !== username && Twinkle.getPref('showRollbackLinks').includes('others')) ||
+				(mw.config.get('wgUserName') === username && Twinkle.getPref('showRollbackLinks').includes('mine'))) {
 				const $list = $('#mw-content-text').find('ul li:has(span.mw-uctop):has(.mw-changeslist-diff)');
 
 				$list.each((key, current) => {
@@ -218,7 +218,7 @@ Twinkle.rollback.addLinks = {
 	},
 
 	recentchanges: function() {
-		if (Twinkle.getPref('showRollbackLinks').indexOf('recent') !== -1) {
+		if (Twinkle.getPref('showRollbackLinks').includes('recent')) {
 			// Latest and revertable (not page creations, logs, categorizations, etc.)
 			let $list = $('.mw-changeslist .mw-changeslist-last.mw-changeslist-src-mw-edit');
 			// Exclude top-level header if "group changes" preference is used
@@ -238,7 +238,7 @@ Twinkle.rollback.addLinks = {
 	},
 
 	history: function() {
-		if (Twinkle.getPref('showRollbackLinks').indexOf('history') !== -1) {
+		if (Twinkle.getPref('showRollbackLinks').includes('history')) {
 			// All revs
 			const histList = $('#pagehistory li').toArray();
 
@@ -286,7 +286,7 @@ Twinkle.rollback.addLinks = {
 				extraParams += xtitle === 'otitle' ? mw.config.get('wgDiffOldId') : mw.config.get('wgDiffNewId');
 
 				const href = $talkLink.attr('href');
-				if (href.indexOf('?') === -1) {
+				if (!href.includes('?')) {
 					$talkLink.attr('href', href + '?' + extraParams);
 				} else {
 					$talkLink.attr('href', href + '&' + extraParams);
@@ -311,7 +311,7 @@ Twinkle.rollback.addLinks = {
 			// Not latest revision, add [restore this revision] link to newer revision
 			const newTitle = document.getElementById('mw-diff-ntitle1').parentNode;
 			newTitle.insertBefore(Twinkle.rollback.linkBuilder.restoreThisRevisionLink('wgDiffNewId'), newTitle.firstChild);
-		} else if (Twinkle.getPref('showRollbackLinks').indexOf('diff') !== -1 && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
+		} else if (Twinkle.getPref('showRollbackLinks').includes('diff') && mw.config.get('wgDiffOldId') && (mw.config.get('wgDiffOldId') !== mw.config.get('wgDiffNewId') || document.getElementById('differences-prevlink'))) {
 			// Normally .mw-userlink is a link, but if the
 			// username is hidden, it will be a span with
 			// .history-deleted as well. When a sysop views the
@@ -459,11 +459,11 @@ Twinkle.rollback.callbacks = {
 			undoafter: revertToRevID,
 			basetimestamp: touched,
 			starttimestamp: loadtimestamp,
-			minor: Twinkle.getPref('markRevertedPagesAsMinor').indexOf('torev') !== -1 ? true : undefined,
+			minor: Twinkle.getPref('markRevertedPagesAsMinor').includes('torev') ? true : undefined,
 			format: 'json'
 		};
 		// Handle watching, possible expiry
-		if (Twinkle.getPref('watchRevertedPages').indexOf('torev') !== -1) {
+		if (Twinkle.getPref('watchRevertedPages').includes('torev')) {
 			const watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {
@@ -541,7 +541,7 @@ Twinkle.rollback.callbacks = {
 			} else if (params.type === 'vand' &&
 					// Okay to test on user since it will either fail or sysop will correctly access it
 					// Besides, none of the trusted bots are going to be revdel'd
-					Twinkle.rollback.trustedBots.indexOf(top.user) !== -1 && revs.length > 1 &&
+					Twinkle.rollback.trustedBots.includes(top.user) && revs.length > 1 &&
 					revs[1].revid === params.revid) {
 				Morebits.Status.info('Info', [ 'Latest revision was made by ', Morebits.htmlNode('strong', lastuser), ', a trusted bot, and the revision before was made by our vandal, so we will proceed with the revert.' ]);
 				index = 2;
@@ -557,7 +557,7 @@ Twinkle.rollback.callbacks = {
 			userNorm = params.user || Twinkle.rollback.hiddenName;
 		}
 
-		if (Twinkle.rollback.trustedBots.indexOf(params.user) !== -1) {
+		if (Twinkle.rollback.trustedBots.includes(params.user)) {
 			switch (params.type) {
 				case 'vand':
 					Morebits.Status.info('Info', [ 'Vandalism revert was chosen on ', Morebits.htmlNode('strong', userNorm), '. As this is a trusted bot, we assume you wanted to revert vandalism made by the previous user instead.' ]);
@@ -685,7 +685,7 @@ Twinkle.rollback.callbacks = {
 		}
 
 		// Decide whether to notify the user on success
-		if (!Twinkle.rollback.skipTalk && Twinkle.getPref('openTalkPage').indexOf(params.type) !== -1 &&
+		if (!Twinkle.rollback.skipTalk && Twinkle.getPref('openTalkPage').includes(params.type) &&
 				!params.userHidden && mw.config.get('wgUserName') !== params.user) {
 			params.notifyUser = true;
 			// Pass along to the warn module
@@ -712,11 +712,11 @@ Twinkle.rollback.callbacks = {
 			undoafter: params.goodid,
 			basetimestamp: touched,
 			starttimestamp: loadtimestamp,
-			minor: Twinkle.getPref('markRevertedPagesAsMinor').indexOf(params.type) !== -1 ? true : undefined,
+			minor: Twinkle.getPref('markRevertedPagesAsMinor').includes(params.type) ? true : undefined,
 			format: 'json'
 		};
 		// Handle watching, possible expiry
-		if (Twinkle.getPref('watchRevertedPages').indexOf(params.type) !== -1) {
+		if (Twinkle.getPref('watchRevertedPages').includes(params.type)) {
 			const watchOrExpiry = Twinkle.getPref('watchRevertedExpiry');
 
 			if (!watchOrExpiry || watchOrExpiry === 'no') {

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -437,10 +437,10 @@ Twinkle.speedy.generateCsdList = function twinklespeedyGenerateCsdList(list, mod
 			return null;
 		}
 
-		if (criterion.showInNamespaces && criterion.showInNamespaces.indexOf(pageNamespace) < 0) {
+		if (criterion.showInNamespaces && !criterion.showInNamespaces.includes(pageNamespace)) {
 			return null;
 		}
-		if (criterion.hideInNamespaces && criterion.hideInNamespaces.indexOf(pageNamespace) > -1) {
+		if (criterion.hideInNamespaces && criterion.hideInNamespaces.includes(pageNamespace)) {
 			return null;
 		}
 
@@ -713,7 +713,7 @@ Twinkle.speedy.userList = [
 		label: 'U1: User request',
 		value: 'userreq',
 		tooltip: 'Personal subpages, upon request by their user. In some rare cases there may be administrative need to retain the page. Also, sometimes, main user pages may be deleted as well. See Wikipedia:User page for full instructions and guidelines',
-		subgroup: mw.config.get('wgNamespaceNumber') === 3 && mw.config.get('wgTitle').indexOf('/') === -1 ? {
+		subgroup: mw.config.get('wgNamespaceNumber') === 3 && !mw.config.get('wgTitle').includes('/') ? {
 			name: 'userreq_rationale',
 			type: 'input',
 			label: 'A mandatory rationale to explain why this user talk page should be deleted:',
@@ -1169,7 +1169,7 @@ Twinkle.speedy.callbacks = {
 			notifytext += (params.welcomeuser ? '' : '|nowelcome=yes') + '}} ~~~~';
 
 			editsummary = 'Notification: speedy deletion' + (params.warnUser ? '' : ' nomination');
-			if (params.normalizeds.indexOf('g10') === -1) { // no article name in summary for G10 taggings
+			if (!params.normalizeds.includes('g10')) { // no article name in summary for G10 taggings
 				editsummary += ' of [[:' + Morebits.pageNameNorm + ']].';
 			} else {
 				editsummary += ' of an attack page.';
@@ -1371,12 +1371,12 @@ Twinkle.speedy.callbacks = {
 			params.utparams = buildData[1];
 
 			// Set the correct value for |ts= parameter in {{db-g13}}
-			if (params.normalizeds.indexOf('g13') !== -1) {
+			if (params.normalizeds.includes('g13')) {
 				code = code.replace('$TIMESTAMP', pageobj.getLastEditTime());
 			}
 
 			// Tag if possible, post on talk if not
-			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1 && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */) {
+			if (pageobj.canEdit() && ['wikitext', 'Scribunto', 'javascript', 'css', 'sanitized-css'].includes(pageobj.getContentModel()) && mw.config.get('wgNamespaceNumber') !== 710 /* TimedText */) {
 				let text = pageobj.getPageText();
 
 				statelem.status('Checking for tags on the page...');
@@ -1412,7 +1412,7 @@ Twinkle.speedy.callbacks = {
 				}
 
 				if (params.requestsalt) {
-					if (params.normalizeds.indexOf('g10') === -1) {
+					if (!params.normalizeds.includes('g10')) {
 						code += '\n{{salt}}';
 					} else {
 						code = '{{salt}}\n' + code;
@@ -1422,11 +1422,11 @@ Twinkle.speedy.callbacks = {
 				if (mw.config.get('wgPageContentModel') === 'Scribunto') {
 					// Scribunto isn't parsed like wikitext, so CSD templates on modules need special handling to work
 					let equals = '';
-					while (code.indexOf(']' + equals + ']') !== -1) {
+					while (code.includes(']' + equals + ']')) {
 						equals += '=';
 					}
 					code = "require('Module:Module wikitext')._addText([" + equals + '[' + code + ']' + equals + ']);';
-				} else if (['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1) {
+				} else if (['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'))) {
 					// Likewise for JS/CSS pages
 					code = '/* ' + code + ' */';
 				}
@@ -1447,7 +1447,7 @@ Twinkle.speedy.callbacks = {
 				}
 
 				// Blank attack pages
-				if (params.normalizeds.indexOf('g10') !== -1) {
+				if (params.normalizeds.includes('g10')) {
 					text = code;
 				} else {
 					// Insert tag after short description or any hatnotes
@@ -1532,7 +1532,7 @@ Twinkle.speedy.callbacks = {
 			let editsummary = 'Logging speedy deletion nomination';
 			let appendText = '# [[:' + Morebits.pageNameNorm;
 
-			if (params.normalizeds.indexOf('g10') === -1) { // no article name in log for G10 taggings
+			if (!params.normalizeds.includes('g10')) { // no article name in log for G10 taggings
 				appendText += ']]' + fileLogLink + ': ';
 				editsummary += ' of [[:' + Morebits.pageNameNorm + ']].';
 			} else {
@@ -1900,18 +1900,18 @@ Twinkle.speedy.callback.evaluateSysop = function twinklespeedyCallbackEvaluateSy
 	// analyse each criterion to determine whether to watch the page, prompt for summary, or notify the creator
 	let watchPage, promptForSummary;
 	normalizeds.forEach((norm) => {
-		if (Twinkle.getPref('watchSpeedyPages').indexOf(norm) !== -1) {
+		if (Twinkle.getPref('watchSpeedyPages').includes(norm)) {
 			watchPage = Twinkle.getPref('watchSpeedyExpiry');
 		}
-		if (Twinkle.getPref('promptForSpeedyDeletionSummary').indexOf(norm) !== -1) {
+		if (Twinkle.getPref('promptForSpeedyDeletionSummary').includes(norm)) {
 			promptForSummary = true;
 		}
 	});
 
-	const warnusertalk = form.warnusertalk.checked && normalizeds.some((norm, index) => Twinkle.getPref('warnUserOnSpeedyDelete').indexOf(norm) !== -1 &&
+	const warnusertalk = form.warnusertalk.checked && normalizeds.some((norm, index) => Twinkle.getPref('warnUserOnSpeedyDelete').includes(norm) &&
 			!(norm === 'g6' && values[index] !== 'copypaste'));
 
-	const welcomeuser = warnusertalk && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1);
+	const welcomeuser = warnusertalk && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').includes(norm));
 
 	const params = {
 		values: values,
@@ -1953,12 +1953,12 @@ Twinkle.speedy.callback.evaluateUser = function twinklespeedyCallbackEvaluateUse
 	const normalizeds = values.map((value) => Twinkle.speedy.normalizeHash[value]);
 
 	// analyse each criterion to determine whether to watch the page/notify the creator
-	const watchPage = normalizeds.some((csdCriteria) => Twinkle.getPref('watchSpeedyPages').indexOf(csdCriteria) !== -1) && Twinkle.getPref('watchSpeedyExpiry');
+	const watchPage = normalizeds.some((csdCriteria) => Twinkle.getPref('watchSpeedyPages').includes(csdCriteria)) && Twinkle.getPref('watchSpeedyExpiry');
 
-	const notifyuser = form.notify.checked && normalizeds.some((norm, index) => Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').indexOf(norm) !== -1 &&
+	const notifyuser = form.notify.checked && normalizeds.some((norm, index) => Twinkle.getPref('notifyUserOnSpeedyDeletionNomination').includes(norm) &&
 			!(norm === 'g6' && values[index] !== 'copypaste'));
-	const welcomeuser = notifyuser && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').indexOf(norm) !== -1);
-	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some((norm) => Twinkle.getPref('noLogOnSpeedyNomination').indexOf(norm) === -1);
+	const welcomeuser = notifyuser && normalizeds.some((norm) => Twinkle.getPref('welcomeUserOnSpeedyDeletionNotification').includes(norm));
+	const csdlog = Twinkle.getPref('logSpeedyNominations') && normalizeds.some((norm) => !Twinkle.getPref('noLogOnSpeedyNomination').includes(norm));
 
 	const params = {
 		values: values,

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -21,7 +21,7 @@ Twinkle.tag = function twinkletag() {
 		Twinkle.tag.mode = 'file';
 		Twinkle.addPortletLink(Twinkle.tag.callback, 'Tag', 'twinkle-tag', 'Add maintenance tags to file');
 	// article/draft article tagging
-	} else if ([0, 118].indexOf(mw.config.get('wgNamespaceNumber')) !== -1 && mw.config.get('wgCurRevisionId')) {
+	} else if ([0, 118].includes(mw.config.get('wgNamespaceNumber')) && mw.config.get('wgCurRevisionId')) {
 		Twinkle.tag.mode = 'article';
 		// Can't remove tags when not viewing current version
 		Twinkle.tag.canRemove = (mw.config.get('wgCurRevisionId') === mw.config.get('wgRevisionId')) &&
@@ -372,7 +372,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 	const makeCheckbox = function (item) {
 		const tag = item.tag, description = item.description;
 		const checkbox = { value: tag, label: '{{' + tag + '}}: ' + description };
-		if (Twinkle.tag.checkedTags.indexOf(tag) !== -1) {
+		if (Twinkle.tag.checkedTags.includes(tag)) {
 			checkbox.checked = true;
 		}
 		checkbox.subgroup = item.subgroup;
@@ -389,7 +389,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 				{
 					value: tag,
 					label: '{{' + tag + '}}' + (Twinkle.tag.article.flatObject[tag] ? ': ' + Twinkle.tag.article.flatObject[tag].description : ''),
-					checked: unCheckedTags.indexOf(tag) === -1,
+					checked: !unCheckedTags.includes(tag),
 					style: 'font-style: italic'
 				};
 
@@ -407,7 +407,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		const doCategoryCheckboxes = function(subdiv, subgroup) {
 			const checkboxes = [];
 			$.each(subgroup, (k, item) => {
-				if (Twinkle.tag.alreadyPresentTags.indexOf(item.tag) === -1) {
+				if (!Twinkle.tag.alreadyPresentTags.includes(item.tag)) {
 					checkboxes.push(makeCheckbox(item));
 				}
 			});
@@ -445,7 +445,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		Twinkle.tag.article.alphabeticalList = Twinkle.tag.article.alphabeticalList || Object.keys(Twinkle.tag.article.flatObject).sort();
 		const checkboxes = [];
 		Twinkle.tag.article.alphabeticalList.forEach((tag) => {
-			if (Twinkle.tag.alreadyPresentTags.indexOf(tag) === -1) {
+			if (!Twinkle.tag.alreadyPresentTags.includes(tag)) {
 				checkboxes.push(makeCheckbox(Twinkle.tag.article.flatObject[tag]));
 			}
 		});
@@ -461,7 +461,7 @@ Twinkle.tag.updateSortOrder = function(e) {
 		container.append({ type: 'header', label: 'Custom tags' });
 		container.append({ type: 'checkbox', name: 'tags',
 			list: Twinkle.getPref('customTagList').map((el) => {
-				el.checked = Twinkle.tag.checkedTags.indexOf(el.value) !== -1;
+				el.checked = Twinkle.tag.checkedTags.includes(el.value);
 				return el;
 			})
 		});
@@ -512,8 +512,8 @@ var generateLinks = function(checkbox) {
 	link.setAttribute('class', 'tag-template-link');
 	const tagname = checkbox.values;
 	link.setAttribute('href', mw.util.getUrl(
-		(tagname.indexOf(':') === -1 ? 'Template:' : '') +
-		(tagname.indexOf('|') === -1 ? tagname : tagname.slice(0, tagname.indexOf('|')))
+		(!tagname.includes(':') ? 'Template:' : '') +
+		(!tagname.includes('|') ? tagname : tagname.slice(0, tagname.indexOf('|')))
 	));
 	link.setAttribute('target', '_blank');
 	$(checkbox).parent().append(['\u00A0', link]);
@@ -1353,10 +1353,10 @@ Twinkle.tag.callbacks = {
 			const makeTemplateLink = function(tag) {
 				let text = '{{[[';
 				// if it is a custom tag with a parameter
-				if (tag.indexOf('|') !== -1) {
+				if (tag.includes('|')) {
 					tag = tag.slice(0, tag.indexOf('|'));
 				}
-				text += tag.indexOf(':') !== -1 ? tag : 'Template:' + tag + '|' + tag;
+				text += tag.includes(':') ? tag : 'Template:' + tag + '|' + tag;
 				return text + ']]}}';
 			};
 
@@ -1381,7 +1381,7 @@ Twinkle.tag.callbacks = {
 
 			pageobj.setPageText(pageText);
 			pageobj.setEditSummary(summaryText);
-			if ((mw.config.get('wgNamespaceNumber') === 0 && Twinkle.getPref('watchTaggedVenues').indexOf('articles') !== -1) || (mw.config.get('wgNamespaceNumber') === 118 && Twinkle.getPref('watchTaggedVenues').indexOf('drafts') !== -1)) {
+			if ((mw.config.get('wgNamespaceNumber') === 0 && Twinkle.getPref('watchTaggedVenues').includes('articles')) || (mw.config.get('wgNamespaceNumber') === 118 && Twinkle.getPref('watchTaggedVenues').includes('drafts'))) {
 				pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 			}
 			pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
@@ -1447,13 +1447,13 @@ Twinkle.tag.callbacks = {
 						let templateText;
 
 						let text, summary;
-						if (params.tags.indexOf('Rough translation') !== -1) {
+						if (params.tags.includes('Rough translation')) {
 							templateText = '{{subst:Dual fluency request|pg=' + Morebits.pageNameNorm + '|Language=' +
 							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
 							// Place in section == Translated pages that could still use some cleanup ==
 							text = old_text + '\n\n' + templateText;
 							summary = 'Translation cleanup requested on ';
-						} else if (params.tags.indexOf('Not English') !== -1) {
+						} else if (params.tags.includes('Not English')) {
 							templateText = '{{subst:Translation request|pg=' + Morebits.pageNameNorm + '|Language=' +
 							(lang || 'uncertain') + '|Comments=' + reason.trim() + '}} ~~~~';
 							// Place in section == Pages for consideration ==
@@ -1694,7 +1694,7 @@ Twinkle.tag.callbacks = {
 					Morebits.Status.warn('Info', 'Found {{' + tag +
 						'}} on the article already...excluding');
 					// don't do anything else with merge tags
-					if (['Merge', 'Merge to'].indexOf(tag) !== -1) {
+					if (['Merge', 'Merge to'].includes(tag)) {
 						params.mergeTarget = params.mergeReason = params.mergeTagOther = null;
 					}
 				}
@@ -1835,7 +1835,7 @@ Twinkle.tag.callbacks = {
 				}
 			}
 
-			summaryText += ' {{[[:' + (tagName.indexOf(':') !== -1 ? tagName : 'Template:' + tagName + '|' + tagName) + ']]}}';
+			summaryText += ' {{[[:' + (tagName.includes(':') ? tagName : 'Template:' + tagName + '|' + tagName) + ']]}}';
 		};
 
 		if (!tags.length) {
@@ -1874,7 +1874,7 @@ Twinkle.tag.callbacks = {
 
 		pageobj.setPageText(pageText);
 		pageobj.setEditSummary(summaryText);
-		if (Twinkle.getPref('watchTaggedVenues').indexOf('redirects') !== -1) {
+		if (Twinkle.getPref('watchTaggedVenues').includes('redirects')) {
 			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
@@ -1898,7 +1898,7 @@ Twinkle.tag.callbacks = {
 			let tagtext = '', currentTag;
 			$.each(params.tags, (k, tag) => {
 				// when other commons-related tags are placed, remove "move to Commons" tag
-				if (['Keep local', 'Do not move to Commons'].indexOf(tag) !== -1) {
+				if (['Keep local', 'Do not move to Commons'].includes(tag)) {
 					text = text.replace(/\{\{(mtc|(copy |move )?to ?commons|move to wikimedia commons|copy to wikimedia commons)[^}]*\}\}/gi, '');
 				}
 
@@ -1987,7 +1987,7 @@ Twinkle.tag.callbacks = {
 		pageobj.setPageText(text);
 		pageobj.setEditSummary(summary.substring(0, summary.length - 2));
 		pageobj.setChangeTags(Twinkle.changeTags);
-		if (Twinkle.getPref('watchTaggedVenues').indexOf('files') !== -1) {
+		if (Twinkle.getPref('watchTaggedVenues').includes('files')) {
 			pageobj.setWatchlist(Twinkle.getPref('watchTaggedPages'));
 		}
 		pageobj.setMinorEdit(Twinkle.getPref('markTaggedPagesAsMinor'));
@@ -2008,7 +2008,7 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 
 	// Given an array of incompatible tags, check if we have two or more selected
 	const checkIncompatible = function(conflicts, extra) {
-		const count = conflicts.reduce((sum, tag) => sum += params.tags.indexOf(tag) !== -1, 0);
+		const count = conflicts.reduce((sum, tag) => sum += params.tags.includes(tag), 0);
 		if (count > 1) {
 			let message = 'Please select only one of: {{' + conflicts.join('}}, {{') + '}}.';
 			message += extra ? ' ' + extra : '';
@@ -2025,12 +2025,12 @@ Twinkle.tag.callback.evaluate = function twinkletagCallbackEvaluate(e) {
 			params.tagsToRemove = form.getUnchecked('existingTags'); // not in `input`
 			params.tagsToRemain = params.existingTags || []; // container not created if none present
 
-			if ((params.tags.indexOf('Merge') !== -1) || (params.tags.indexOf('Merge from') !== -1) ||
-				(params.tags.indexOf('Merge to') !== -1)) {
+			if ((params.tags.includes('Merge')) || (params.tags.includes('Merge from')) ||
+				(params.tags.includes('Merge to'))) {
 				if (checkIncompatible(['Merge', 'Merge from', 'Merge to'], 'If several merges are required, use {{Merge}} and separate the article names with pipes (although in this case Twinkle cannot tag the other articles automatically).')) {
 					return;
 				}
-				if ((params.mergeTagOther || params.mergeReason) && params.mergeTarget.indexOf('|') !== -1) {
+				if ((params.mergeTagOther || params.mergeReason) && params.mergeTarget.includes('|')) {
 					alert('Tagging multiple articles in a merge, and starting a discussion for multiple articles, is not supported at the moment. Please turn off "tag other article", and/or clear out the "reason" box, and try again.');
 					return;
 				}

--- a/modules/twinkletag.js
+++ b/modules/twinkletag.js
@@ -2009,7 +2009,7 @@ Twinkle.tag.callbacks = {
  * @return {true|undefined}
  */
 Twinkle.tag.checkIncompatible = function(incompatibleTags, tagsToCheck, extraMessage = null) {
-	const count = incompatibleTags.reduce((sum, tag) => sum += tagsToCheck.indexOf(tag) !== -1, 0);
+	const count = incompatibleTags.reduce((sum, tag) => sum += tagsToCheck.includes(tag), 0);
 	if (count > 1) {
 		const incompatibleTagsString = '{{' + incompatibleTags.join('}}, {{') + '}}';
 		let message = 'Please select only one of: ' + incompatibleTagsString + '.';

--- a/modules/twinkleunlink.js
+++ b/modules/twinkleunlink.js
@@ -122,8 +122,8 @@ Twinkle.unlink.callback.evaluate = function twinkleunlinkCallbackEvaluate(event)
 		const wikipedia_page = new Morebits.wiki.Page(pageName, 'Unlinking in page "' + pageName + '"');
 		wikipedia_page.setBotEdit(true); // unlink considered a floody operation
 		wikipedia_page.setCallbackParameters($.extend({
-			doBacklinks: input.backlinks.indexOf(pageName) !== -1,
-			doImageusage: input.imageusage.indexOf(pageName) !== -1
+			doBacklinks: input.backlinks.includes(pageName),
+			doImageusage: input.imageusage.includes(pageName)
 		}, params));
 		wikipedia_page.load(Twinkle.unlink.callbacks.unlinkBacklinks);
 	});

--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -36,7 +36,7 @@ Twinkle.warn = function twinklewarn() {
 			// Can't provide vanarticlerevid as only wgCurRevisionId is provided
 			const extraParam = 'vanarticle=' + mw.util.rawurlencode(Morebits.pageNameNorm);
 			const href = $vandalTalkLink.attr('href');
-			if (href.indexOf('?') === -1) {
+			if (!href.includes('?')) {
 				$vandalTalkLink.attr('href', href + '?' + extraParam);
 			} else {
 				$vandalTalkLink.attr('href', href + '&' + extraParam);
@@ -1634,7 +1634,7 @@ Twinkle.warn.callback.change_subcategory = function twinklewarnCallbackChangeSub
 		'uw-aiv': 'Optional username that was reported (without User:) '
 	};
 
-	const hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].indexOf(selected_main_group) !== -1;
+	const hasLevel = ['singlenotice', 'singlewarn', 'singlecombined', 'kitchensink'].includes(selected_main_group);
 	if (hasLevel) {
 		if (notLinkedArticle[selected_template]) {
 			if (Twinkle.warn.prev_article === null) {

--- a/modules/twinklexfd.js
+++ b/modules/twinklexfd.js
@@ -143,7 +143,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	categories.append({
 		type: 'option',
 		label: 'TfD (Templates for discussion)',
-		selected: [ 10, 828 ].indexOf(namespace) !== -1, // Template and module namespaces
+		selected: [ 10, 828 ].includes(namespace), // Template and module namespaces
 		value: 'tfd'
 	});
 	categories.append({
@@ -166,7 +166,7 @@ Twinkle.xfd.callback = function twinklexfdCallback() {
 	categories.append({
 		type: 'option',
 		label: 'MfD (Miscellany for deletion)',
-		selected: [ 0, 6, 10, 14, 828 ].indexOf(namespace) === -1 || Morebits.pageNameNorm.indexOf('Template:User ', 0) === 0,
+		selected: ![ 0, 6, 10, 14, 828 ].includes(namespace) || Morebits.pageNameNorm.indexOf('Template:User ', 0) === 0,
 		// Other namespaces, and userboxes in template namespace
 		value: 'mfd'
 	});
@@ -249,7 +249,7 @@ Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(ve
 			}
 			break;
 		case 'cfd':
-			if ([ 10, 14 ].indexOf(namespace) === -1) {
+			if (![ 10, 14 ].includes(namespace)) {
 				text = 'CfD is only for categories and stub templates.';
 			}
 			break;
@@ -266,7 +266,7 @@ Twinkle.xfd.callback.wrongVenueWarning = function twinklexfdWrongVenueWarning(ve
 		case 'rm':
 			if (namespace === 14) { // category
 				text = 'Please use CfD or CfDS for category renames.';
-			} else if ([118, 119, 2, 3].indexOf(namespace) > -1) { // draft, draft talk, user, user talk
+			} else if ([118, 119, 2, 3].includes(namespace)) { // draft, draft talk, user, user talk
 				text = 'RMs are not permitted in draft and userspace, unless they are uncontroversial technical requests.';
 			}
 			break;
@@ -981,7 +981,7 @@ Twinkle.xfd.callbacks = {
 		}
 	},
 	addToLog: function(params, initialContrib) {
-		if (!Twinkle.getPref('logXfdNominations') || Twinkle.getPref('noLogOnXfdNomination').indexOf(params.venue) !== -1) {
+		if (!Twinkle.getPref('logXfdNominations') || Twinkle.getPref('noLogOnXfdNomination').includes(params.venue)) {
 			return;
 		}
 
@@ -1360,7 +1360,7 @@ Twinkle.xfd.callbacks = {
 					page.setCallbackParameters(params);
 					page.lookupCreation((innerpage) => {
 						const username = innerpage.getCreator();
-						if (seenusers.indexOf(username) === -1) {
+						if (!seenusers.includes(username)) {
 							seenusers.push(username);
 							// Only log once on merge nominations, for the initial template
 							Twinkle.xfd.callbacks.notifyUser(innerpage.getCallbackParameters(), username,
@@ -1382,7 +1382,7 @@ Twinkle.xfd.callbacks = {
 					'Templates used by Ultraviolet': 'Wikipedia talk:Ultraviolet'
 				};
 				$.each(categoryNotificationPageMap, (category, page) => {
-					if (inCategories.indexOf(category) !== -1) {
+					if (inCategories.includes(category)) {
 						Twinkle.xfd.callbacks.notifyUser(params, page, true, 'Notifying ' + page + ' of template nomination');
 					}
 				});
@@ -1404,7 +1404,7 @@ Twinkle.xfd.callbacks = {
 				params.tagText += params.templatetype === 'standard' || params.templatetype === 'sidebar' || params.templatetype === 'disabled' ? '\n' : ''; // No newline for inline
 			}
 
-			if (pageobj.canEdit() && ['wikitext', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1) {
+			if (pageobj.canEdit() && ['wikitext', 'sanitized-css'].includes(pageobj.getContentModel())) {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
@@ -1433,7 +1433,7 @@ Twinkle.xfd.callbacks = {
 				params.tagText += params.templatetype === 'standard' || params.templatetype === 'sidebar' || params.templatetype === 'disabled' ? '\n' : ''; // No newline for inline
 			}
 
-			if (pageobj.canEdit() && ['wikitext', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1) {
+			if (pageobj.canEdit() && ['wikitext', 'sanitized-css'].includes(pageobj.getContentModel())) {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Listed for merging with [[:' + params.otherTemplateName + ']]; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);
@@ -1558,7 +1558,7 @@ Twinkle.xfd.callbacks = {
 
 			params.tagText = '{{' + (params.number === '' ? 'mfd' : 'mfdx|' + params.number) + '|help=off}}';
 
-			if (['javascript', 'css', 'sanitized-css'].indexOf(mw.config.get('wgPageContentModel')) !== -1) {
+			if (['javascript', 'css', 'sanitized-css'].includes(mw.config.get('wgPageContentModel'))) {
 				params.tagText = '/* ' + params.tagText + ' */\n';
 			} else {
 				params.tagText += '\n';
@@ -1567,7 +1567,7 @@ Twinkle.xfd.callbacks = {
 				}
 			}
 
-			if (pageobj.canEdit() && ['wikitext', 'javascript', 'css', 'sanitized-css'].indexOf(pageobj.getContentModel()) !== -1) {
+			if (pageobj.canEdit() && ['wikitext', 'javascript', 'css', 'sanitized-css'].includes(pageobj.getContentModel())) {
 				pageobj.setPageText(params.tagText + text);
 				pageobj.setEditSummary('Nominated for deletion; see [[:' + params.discussionpage + ']].');
 				pageobj.setChangeTags(Twinkle.changeTags);

--- a/morebits.js
+++ b/morebits.js
@@ -131,7 +131,7 @@ Morebits.l10n = {
  * @return {boolean}
  */
 Morebits.userIsInGroup = function (group) {
-	return mw.config.get('wgUserGroups').indexOf(group) !== -1;
+	return mw.config.get('wgUserGroups').includes(group);
 };
 /**
  * Hardcodes whether the user is a sysop, used a lot.
@@ -269,7 +269,7 @@ Morebits.namespaceRegex = function(namespaces) {
 	const aliases = [];
 	let regex;
 	$.each(mw.config.get('wgNamespaceIds'), (name, number) => {
-		if (namespaces.indexOf(number) !== -1) {
+		if (namespaces.includes(number)) {
 			// Namespaces are completely agnostic as to case,
 			// and a regex string is more useful/compatible than a RegExp object,
 			// so we accept any casing for any letter.
@@ -1557,7 +1557,7 @@ Morebits.string = {
 	 * @return {boolean}
 	 */
 	isInfinity: function morebitsStringIsInfinity(expiry) {
-		return ['indefinite', 'infinity', 'infinite', 'never'].indexOf(expiry) !== -1;
+		return ['indefinite', 'infinity', 'infinite', 'never'].includes(expiry);
 	},
 
 	/**
@@ -1653,7 +1653,7 @@ Morebits.select2 = {
 			const result = originalMatcher(params, data);
 
 			if (result && params.term &&
-				data.text.toUpperCase().indexOf(params.term.toUpperCase()) !== -1) {
+				data.text.toUpperCase().includes(params.term.toUpperCase())) {
 				result.children = data.children;
 			}
 			return result;
@@ -2284,7 +2284,7 @@ Morebits.wiki.api = function(currentAction, query, onSuccess, statusElement, onE
 	this.query = query;
 	this.query.assert = 'user';
 	// Enforce newer error formats, preferring html
-	if (!query.errorformat || ['wikitext', 'plaintext'].indexOf(query.errorformat) === -1) {
+	if (!query.errorformat || !['wikitext', 'plaintext'].includes(query.errorformat)) {
 		this.query.errorformat = 'html';
 	}
 	// Explicitly use the wiki's content language to minimize confusion,
@@ -2305,12 +2305,12 @@ Morebits.wiki.api = function(currentAction, query, onSuccess, statusElement, onE
 		this.query.format = 'xml';
 	} else if (query.format === 'json' && !query.formatversion) {
 		this.query.formatversion = '2';
-	} else if (['xml', 'json'].indexOf(query.format) === -1) {
+	} else if (!['xml', 'json'].includes(query.format)) {
 		this.statelem.error('Invalid API format: only xml and json are supported.');
 	}
 
 	// Ignore tags for queries and most common unsupported actions, produces warnings
-	if (query.action && ['query', 'review', 'stabilize', 'pagetriageaction', 'watch'].indexOf(query.action) !== -1) {
+	if (query.action && ['query', 'review', 'stabilize', 'pagetriageaction', 'watch'].includes(query.action)) {
 		delete query.tags;
 	} else if (!query.tags && morebitsWikiChangeTag) {
 		query.tags = morebitsWikiChangeTag;
@@ -2900,7 +2900,7 @@ Morebits.wiki.page = function(pageName, status) {
 				break;
 		}
 
-		if (['recreate', 'createonly', 'nocreate'].indexOf(ctx.createOption) !== -1) {
+		if (['recreate', 'createonly', 'nocreate'].includes(ctx.createOption)) {
 			query[ctx.createOption] = '';
 		}
 
@@ -3432,7 +3432,7 @@ Morebits.wiki.page = function(pageName, status) {
 
 	/** @return {boolean} whether or not you can edit the page */
 	this.canEdit = function() {
-		return !!ctx.testActions && ctx.testActions.indexOf('edit') !== -1;
+		return !!ctx.testActions && ctx.testActions.includes('edit');
 	};
 
 	/**
@@ -3594,7 +3594,7 @@ Morebits.wiki.page = function(pageName, status) {
 	 */
 	this.triage = function() {
 		// Fall back to patrol if not a valid triage namespace
-		if (mw.config.get('pageTriageNamespaces').indexOf(new mw.Title(ctx.pageName).getNamespaceId()) === -1) {
+		if (!mw.config.get('pageTriageNamespaces').includes(new mw.Title(ctx.pageName).getNamespaceId())) {
 			this.patrol();
 		} else {
 			if (!Morebits.userIsSysop && !Morebits.userIsInGroup('patroller')) {
@@ -3778,7 +3778,7 @@ Morebits.wiki.page = function(pageName, status) {
 			// wgRestrictionEdit is null on non-existent pages,
 			// so this neatly handles nonexistent pages
 			const editRestriction = mw.config.get('wgRestrictionEdit');
-			if (!editRestriction || editRestriction.indexOf('sysop') !== -1) {
+			if (!editRestriction || editRestriction.includes('sysop')) {
 				return false;
 			}
 		}
@@ -4231,7 +4231,7 @@ Morebits.wiki.page = function(pageName, status) {
 		const missing = response.pages[0].missing;
 
 		// No undelete as an existing page could have deleted revisions
-		const actionMissing = missing && ['delete', 'stabilize', 'move'].indexOf(action) !== -1;
+		const actionMissing = missing && ['delete', 'stabilize', 'move'].includes(action);
 		const protectMissing = action === 'protect' && missing && (ctx.protectEdit || ctx.protectMove);
 		const saltMissing = action === 'protect' && !missing && ctx.protectCreate;
 
@@ -4944,7 +4944,7 @@ Morebits.wikitext.page.prototype = {
 
 		// For most namespaces, unlink both [[User:Test]] and [[:User:Test]]
 		// For files and categories, only unlink [[:Category:Test]]. Do not unlink [[Category:Test]]
-		const isFileOrCategory = [6, 14].indexOf(namespaceID) !== -1;
+		const isFileOrCategory = [6, 14].includes(namespaceID);
 		const colon = isFileOrCategory ? ':' : ':?';
 
 		const simple_link_regex = new RegExp('\\[\\[' + colon + '(' + link_regex_string + ')\\]\\]', 'g');

--- a/twinkle.js
+++ b/twinkle.js
@@ -363,7 +363,7 @@ Twinkle.load = function () {
 		activeSpecialPageList = activeSpecialPageList.concat([ 'DeletedContributions', 'Prefixindex' ]);
 	}
 	if (mw.config.get('wgNamespaceNumber') === -1 &&
-		activeSpecialPageList.indexOf(mw.config.get('wgCanonicalSpecialPageName')) === -1) {
+		!activeSpecialPageList.includes(mw.config.get('wgCanonicalSpecialPageName'))) {
 		return;
 	}
 
@@ -380,7 +380,7 @@ Twinkle.load = function () {
 	// Redefine addInitCallback so that any modules being loaded now on are directly
 	// initialised rather than added to initCallbacks array
 	Twinkle.addInitCallback = function(func, name) {
-		if (!name || Twinkle.disabledModules.indexOf(name) === -1) {
+		if (!name || !Twinkle.disabledModules.includes(name)) {
 			func();
 		}
 	};


### PR DESCRIPTION
after discussion in #2101, removes the prohibition on using .includes()

also, adds a prohibition on using .indexOf !== -1, and applies the autofixes