### PR TITLE
eslint: fix camelcase in tests

### DIFF
--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -13,7 +13,6 @@
 		"object-curly-spacing": "off",
 		"space-in-parens": "off",
 
-		"camelcase": "warn",
 		"comma-dangle": "warn",
 		"eol-last": "warn",
 		"new-cap": "warn",

--- a/tests/morebits.date.js
+++ b/tests/morebits.date.js
@@ -1,6 +1,6 @@
 describe('Morebits.date', () => {
 	var now = Date.now();
-	var ts_mw = '16:26, 7 November 2020 (UTC)', ts_iso = '2020-11-07T16:26:00.000Z', naive = 20201107162600;
+	var timestampMediaWiki = '16:26, 7 November 2020 (UTC)', timestampIso = '2020-11-07T16:26:00.000Z', naive = 20201107162600;
 	test('Construction', () => {
 		// getTime and toISOString imply testing of inherited methods
 		// Allow off-by-one values in milliseconds for not-quite-simultaneous date contructions
@@ -8,13 +8,13 @@ describe('Morebits.date', () => {
 
 		assert.strictEqual(new Morebits.date(now).getTime(), new Date(now).getTime(), 'Constructor from timestring');
 		assert.strictEqual(new Morebits.date(2020, 11, 7, 16, 26).getTime(), new Date(2020, 11, 7, 16, 26).getTime(), 'Constructor from parts');
-		assert.strictEqual(new Morebits.date(ts_mw).toISOString(), ts_iso, 'enWiki timestamp format');
-		assert.strictEqual(new Morebits.date(naive).toISOString(), ts_iso, 'MediaWiki 14-digit number');
-		assert.strictEqual(new Morebits.date(naive.toString()).toISOString(), ts_iso, 'MediaWiki 14-digit string');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).toISOString(), timestampIso, 'enWiki timestamp format');
+		assert.strictEqual(new Morebits.date(naive).toISOString(), timestampIso, 'MediaWiki 14-digit number');
+		assert.strictEqual(new Morebits.date(naive.toString()).toISOString(), timestampIso, 'MediaWiki 14-digit string');
 		assert.strictEqual(new Morebits.date(parseInt(naive / 10, 10)).toISOString(), new Date(parseInt(naive / 10, 10)).toISOString(), 'native 13 digit');
 		assert.strictEqual(new Morebits.date(naive * 10).toISOString(), new Date(naive * 10).toISOString(), 'native 15 digit');
 	});
-	var date = new Morebits.date(ts_mw);
+	var date = new Morebits.date(timestampMediaWiki);
 	test('Methods', () => {
 		assert.true(date.isValid(), 'Valid');
 		// Logs a message; not a failure, but annoying
@@ -41,22 +41,22 @@ describe('Morebits.date', () => {
 		assert.false(date.monthHeaderRegex().test('==December 2020=='), 'Wrong month');
 	});
 	test('add/subtract', () => {
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'day').toISOString(), '2020-11-08T16:26:00.000Z', 'Add 1 day');
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'DaY').toISOString(), '2020-11-08T16:26:00.000Z', 'Loudly add 1 day');
-		assert.strictEqual(new Morebits.date(ts_mw).add('1', 'day').toISOString(), '2020-11-08T16:26:00.000Z', "Add 1 day but it's a string");
-		assert.strictEqual(new Morebits.date(ts_mw).subtract(1, 'day').toISOString(), '2020-11-06T16:26:00.000Z', 'Subtract 1 day');
-		assert.strictEqual(new Morebits.date(ts_mw).add(2, 'weeks').toISOString(), '2020-11-21T16:26:00.000Z', 'Add 2 weeks');
-		assert.strictEqual(new Morebits.date(ts_mw).add(2, 'weeks').subtract(2, 'weeks').toISOString(), ts_iso, '2 weeks roundtrip'); // Note, this intentionally twice-crosses a US DST
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'day').toISOString(), '2020-11-08T16:26:00.000Z', 'Add 1 day');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'DaY').toISOString(), '2020-11-08T16:26:00.000Z', 'Loudly add 1 day');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add('1', 'day').toISOString(), '2020-11-08T16:26:00.000Z', "Add 1 day but it's a string");
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).subtract(1, 'day').toISOString(), '2020-11-06T16:26:00.000Z', 'Subtract 1 day');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(2, 'weeks').toISOString(), '2020-11-21T16:26:00.000Z', 'Add 2 weeks');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(2, 'weeks').subtract(2, 'weeks').toISOString(), timestampIso, '2 weeks roundtrip'); // Note, this intentionally twice-crosses a US DST
 
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'second').toISOString(), '2020-11-07T16:26:01.000Z', 'Add 1 second');
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'minute').toISOString(), '2020-11-07T16:27:00.000Z', 'Add 1 minute');
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'hour').toISOString(), '2020-11-07T17:26:00.000Z', 'Add 1 hour');
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'month').toISOString(), '2020-12-07T16:26:00.000Z', 'Add 1 month');
-		assert.strictEqual(new Morebits.date(ts_mw).add(1, 'year').toISOString(), '2021-11-07T16:26:00.000Z', 'Add 1 year');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'second').toISOString(), '2020-11-07T16:26:01.000Z', 'Add 1 second');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'minute').toISOString(), '2020-11-07T16:27:00.000Z', 'Add 1 minute');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'hour').toISOString(), '2020-11-07T17:26:00.000Z', 'Add 1 hour');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'month').toISOString(), '2020-12-07T16:26:00.000Z', 'Add 1 month');
+		assert.strictEqual(new Morebits.date(timestampMediaWiki).add(1, 'year').toISOString(), '2021-11-07T16:26:00.000Z', 'Add 1 year');
 
-		assert.throws(() => new Morebits.date(ts_mw).add('forty-two'), 'throws: non-number provided');
-		assert.throws(() => new Morebits.date(ts_mw).add(1), 'throws: no unit');
-		assert.throws(() => new Morebits.date(ts_mw).subtract(1, 'dayo'), 'throws: bad unit');
+		assert.throws(() => new Morebits.date(timestampMediaWiki).add('forty-two'), 'throws: non-number provided');
+		assert.throws(() => new Morebits.date(timestampMediaWiki).add(1), 'throws: no unit');
+		assert.throws(() => new Morebits.date(timestampMediaWiki).subtract(1, 'dayo'), 'throws: bad unit');
 	});
 	test('Formats', () => {
 		assert.strictEqual(new Morebits.date(now).format('YYYY-MM-DDTHH:mm:ss.SSSZ', 'utc'), new Date(now).toISOString(), 'ISO format');


### PR DESCRIPTION
manual fixes using F2 rename variable in VS Code