### PR TITLE
eslint: fix no-undef in tests

### DIFF
--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -5,6 +5,15 @@
 	"env": {
 		"jest": true
 	},
+	"globals": {
+		"assert": "readonly",
+		"document": "readonly",
+		"jQuery": "readonly",
+		"Morebits": "readonly",
+		"mw": "readonly",
+		"Twinkle": "readonly",
+		"window": "readonly"
+	},
 	"root": true,
 	"rules": {
 		"array-bracket-spacing": "off",
@@ -20,7 +29,6 @@
 		"prefer-arrow-callback": "warn",
 		"prefer-const": "warn",
 		"no-trailing-spaces": "warn",
-		"no-undef": "warn",
 		"no-useless-escape": "warn",
 		"no-var": "warn",
 		"semi": "warn",


### PR DESCRIPTION
manual fixes

basically just hard-code all the existing globals into the "globals" section of .eslintrc.json