### PR TITLE
scripts/dev-server: fix misnamed OAuth parameter

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -64,7 +64,7 @@ server.listen(port, hostname, async () => {
 			"apiUrl": "https://en.wikipedia.org/w/api.php",
 			"username": process.env.MW_USERNAME,
 			"password": process.env.MW_PASSWORD,
-			"oauth2Token": process.env.MW_OAUTH2_TOKEN,
+			"OAuth2AccessToken": process.env.MW_OAUTH2_TOKEN,
 			"silent": true
 		});
 		initTime = Date.now();


### PR DESCRIPTION
Per https://mwn.toolforge.org/docs/api/interfaces/mwnoptions.html, the name of the config option is "OAuth2AccessToken", not "oauth2Token". This prevented me from using the gadget-disabling functionality using OAuth (I would have needed a bot password).

(Ignore the name of my repo: GitHub only lets me have one fork.)