### PR TITLE
block: soft redirect to Special:Block for multi-blocked targets

### DIFF
--- a/modules/twinkleblock.js
+++ b/modules/twinkleblock.js
@@ -3,7 +3,7 @@
 (function() {
 
 const api = new mw.Api();
-let relevantUserName, blockedUserName;
+let relevantUserName, blockedUserName, blockWindow;
 const menuFormattedNamespaces = $.extend({}, mw.config.get('wgFormattedNamespaces'));
 menuFormattedNamespaces[0] = '(Article)';
 
@@ -34,18 +34,18 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	Twinkle.block.field_block_options = {};
 	Twinkle.block.field_template_options = {};
 
-	const Window = new Morebits.SimpleWindow(650, 530);
+	blockWindow = new Morebits.SimpleWindow(650, 530);
 	// need to be verbose about who we're blocking
-	Window.setTitle('Block or issue block template to ' + relevantUserName);
-	Window.setScriptName('Twinkle');
-	Window.addFooterLink('Block templates', 'Template:Uw-block/doc/Block_templates');
-	Window.addFooterLink('Block policy', 'WP:BLOCK');
-	Window.addFooterLink('Block prefs', 'WP:TW/PREF#block');
-	Window.addFooterLink('Twinkle help', 'WP:TW/DOC#block');
-	Window.addFooterLink('Give feedback', 'WT:TW');
+	blockWindow.setTitle('Block or issue block template to ' + relevantUserName);
+	blockWindow.setScriptName('Twinkle');
+	blockWindow.addFooterLink('Block templates', 'Template:Uw-block/doc/Block_templates');
+	blockWindow.addFooterLink('Block policy', 'WP:BLOCK');
+	blockWindow.addFooterLink('Block prefs', 'WP:TW/PREF#block');
+	blockWindow.addFooterLink('Twinkle help', 'WP:TW/DOC#block');
+	blockWindow.addFooterLink('Give feedback', 'WT:TW');
 
 	// Always added, hidden later if actual user not blocked
-	Window.addFooterLink('Unblock this user', 'Special:Unblock/' + relevantUserName, true);
+	blockWindow.addFooterLink('Unblock this user', 'Special:Unblock/' + relevantUserName, true);
 
 	const form = new Morebits.QuickForm(Twinkle.block.callback.evaluate);
 	const actionfield = form.append({
@@ -125,8 +125,8 @@ Twinkle.block.callback = function twinkleblockCallback() {
 	form.append({ type: 'submit' });
 
 	const result = form.render();
-	Window.setContent(result);
-	Window.display();
+	blockWindow.setContent(result);
+	blockWindow.display();
 	result.root = result;
 
 	Twinkle.block.fetchUserInfo(() => {
@@ -154,10 +154,21 @@ Twinkle.block.callback = function twinkleblockCallback() {
 
 // Store fetched user data, only relevant if switching IPv6 to a /64
 Twinkle.block.fetchedData = {};
-// Processes the data from a a query response, separated from
+// Processes the data from a query response, separated from
 // Twinkle.block.fetchUserInfo to allow reprocessing of already-fetched data
 Twinkle.block.processUserInfo = function twinkleblockProcessUserInfo(data, fn) {
 	let blockinfo = data.query.blocks[0];
+	// Soft redirect to Special:Block if the user is multi-blocked (#2178)
+	if (blockinfo && data.query.blocks.length > 1) {
+		// Remove submission buttons.
+		$(blockWindow.content).dialog('widget').find('.morebits-dialog-buttons').empty();
+		Morebits.Status.init(blockWindow.content.querySelector('form'));
+		Morebits.Status.warn(
+			`This target has ${data.query.blocks.length} active blocks`,
+			`Multiblocks is not supported by Twinkle. Use [[Special:Block/${relevantUserName}]] instead.`
+		);
+		return;
+	}
 	const userinfo = data.query.users[0];
 	// If an IP is blocked *and* rangeblocked, the above finds
 	// whichever block is more recent, not necessarily correct.


### PR DESCRIPTION
Rename the Window variable to blockWindow, since Window is a global function.

Closes #2178