### PR TITLE
Port the deployment script from perl to node.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .mediawiki-bot-*
 alltwinkle.js
 .twinklerc
+scripts/credentials.json
 /.settings
 /.project
 jsl.conf

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,16 @@
 		"": {
 			"name": "twinkle",
 			"devDependencies": {
+				"chalk": "^4.1.2",
+				"commander": "^14.0.0",
+				"diff": "^8.0.2",
 				"eslint-config-wikimedia": "^0.28.2",
+				"fs-extra": "^11.3.0",
 				"jest": "^29.7.0",
 				"jest-environment-jsdom": "^29.7.0",
 				"mock-mediawiki": "^1.4.0",
-				"mwn": "^1.11.5"
+				"mwn": "^3.0.1",
+				"simple-git": "^3.28.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1078,6 +1083,23 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@mdn/browser-compat-data": {
 			"version": "5.6.22",
 			"resolved": "https://registry.npmjs.org/@mdn/browser-compat-data/-/browser-compat-data-5.6.22.tgz",
@@ -1209,12 +1231,6 @@
 			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
 			"dev": true
 		},
-		"node_modules/@types/eventsource": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
-			"integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
-			"dev": true
-		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.9",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1248,15 +1264,6 @@
 				"@types/istanbul-lib-report": "*"
 			}
 		},
-		"node_modules/@types/jquery": {
-			"version": "3.5.32",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
-			"integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/sizzle": "*"
-			}
-		},
 		"node_modules/@types/jsdom": {
 			"version": "20.0.1",
 			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
@@ -1287,28 +1294,6 @@
 			"version": "2.4.4",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
 			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-			"dev": true
-		},
-		"node_modules/@types/oojs": {
-			"version": "7.0.7",
-			"resolved": "https://registry.npmjs.org/@types/oojs/-/oojs-7.0.7.tgz",
-			"integrity": "sha512-l99Ab1s+EhCWR/38z5VI3aimTT9QZNjpd3JlJnECHXq6uJ/osLchkkhVfY7ANeOMVT978LawYO4JyOYPQO7VLQ==",
-			"dev": true
-		},
-		"node_modules/@types/oojs-ui": {
-			"version": "0.46.4",
-			"resolved": "https://registry.npmjs.org/@types/oojs-ui/-/oojs-ui-0.46.4.tgz",
-			"integrity": "sha512-tpQyPjxr6FhMRNaactbjNXkr4uCsKNQMOVNJiAO5AvzxoPddChNZp4gG37Pm80jAeDP11k9ww4durnEjzqqKsQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/jquery": "*",
-				"@types/oojs": "*"
-			}
-		},
-		"node_modules/@types/sizzle": {
-			"version": "2.3.9",
-			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
-			"integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
 			"dev": true
 		},
 		"node_modules/@types/stack-utils": {
@@ -1480,118 +1465,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.1.tgz",
 			"integrity": "sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==",
-			"dev": true
-		},
-		"node_modules/@vue/compiler-core": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.9.tgz",
-			"integrity": "sha512-+/Lf68Vr/nFBA6ol4xOtJrW+BQWv3QWKfRwGSm70jtXwfhZNF4R/eRgyVJYoxFRhdCTk/F6g99BP0ffPgZihfQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/parser": "^7.23.3",
-				"@vue/shared": "3.3.9",
-				"estree-walker": "^2.0.2",
-				"source-map-js": "^1.0.2"
-			}
-		},
-		"node_modules/@vue/compiler-dom": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.9.tgz",
-			"integrity": "sha512-nfWubTtLXuT4iBeDSZ5J3m218MjOy42Vp2pmKVuBKo2/BLcrFUX8nCSr/bKRFiJ32R8qbdnnnBgRn9AdU5v0Sg==",
-			"dev": true,
-			"dependencies": {
-				"@vue/compiler-core": "3.3.9",
-				"@vue/shared": "3.3.9"
-			}
-		},
-		"node_modules/@vue/compiler-sfc": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.9.tgz",
-			"integrity": "sha512-wy0CNc8z4ihoDzjASCOCsQuzW0A/HP27+0MDSSICMjVIFzk/rFViezkR3dzH+miS2NDEz8ywMdbjO5ylhOLI2A==",
-			"dev": true,
-			"dependencies": {
-				"@babel/parser": "^7.23.3",
-				"@vue/compiler-core": "3.3.9",
-				"@vue/compiler-dom": "3.3.9",
-				"@vue/compiler-ssr": "3.3.9",
-				"@vue/reactivity-transform": "3.3.9",
-				"@vue/shared": "3.3.9",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.5",
-				"postcss": "^8.4.31",
-				"source-map-js": "^1.0.2"
-			}
-		},
-		"node_modules/@vue/compiler-ssr": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.9.tgz",
-			"integrity": "sha512-NO5oobAw78R0G4SODY5A502MGnDNiDjf6qvhn7zD7TJGc8XDeIEw4fg6JU705jZ/YhuokBKz0A5a/FL/XZU73g==",
-			"dev": true,
-			"dependencies": {
-				"@vue/compiler-dom": "3.3.9",
-				"@vue/shared": "3.3.9"
-			}
-		},
-		"node_modules/@vue/reactivity": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.9.tgz",
-			"integrity": "sha512-VmpIqlNp+aYDg2X0xQhJqHx9YguOmz2UxuUJDckBdQCNkipJvfk9yA75woLWElCa0Jtyec3lAAt49GO0izsphw==",
-			"dev": true,
-			"dependencies": {
-				"@vue/shared": "3.3.9"
-			}
-		},
-		"node_modules/@vue/reactivity-transform": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.9.tgz",
-			"integrity": "sha512-HnUFm7Ry6dFa4Lp63DAxTixUp8opMtQr6RxQCpDI1vlh12rkGIeYqMvJtK+IKyEfEOa2I9oCkD1mmsPdaGpdVg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/parser": "^7.23.3",
-				"@vue/compiler-core": "3.3.9",
-				"@vue/shared": "3.3.9",
-				"estree-walker": "^2.0.2",
-				"magic-string": "^0.30.5"
-			}
-		},
-		"node_modules/@vue/runtime-core": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.9.tgz",
-			"integrity": "sha512-xxaG9KvPm3GTRuM4ZyU8Tc+pMVzcu6eeoSRQJ9IE7NmCcClW6z4B3Ij6L4EDl80sxe/arTtQ6YmgiO4UZqRc+w==",
-			"dev": true,
-			"dependencies": {
-				"@vue/reactivity": "3.3.9",
-				"@vue/shared": "3.3.9"
-			}
-		},
-		"node_modules/@vue/runtime-dom": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.9.tgz",
-			"integrity": "sha512-e7LIfcxYSWbV6BK1wQv9qJyxprC75EvSqF/kQKe6bdZEDNValzeRXEVgiX7AHI6hZ59HA4h7WT5CGvm69vzJTQ==",
-			"dev": true,
-			"dependencies": {
-				"@vue/runtime-core": "3.3.9",
-				"@vue/shared": "3.3.9",
-				"csstype": "^3.1.2"
-			}
-		},
-		"node_modules/@vue/server-renderer": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.9.tgz",
-			"integrity": "sha512-w0zT/s5l3Oa3ZjtLW88eO4uV6AQFqU8X5GOgzq7SkQQu6vVr+8tfm+OI2kDBplS/W/XgCBuFXiPw6T5EdwXP0A==",
-			"dev": true,
-			"dependencies": {
-				"@vue/compiler-ssr": "3.3.9",
-				"@vue/shared": "3.3.9"
-			},
-			"peerDependencies": {
-				"vue": "3.3.9"
-			}
-		},
-		"node_modules/@vue/shared": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.9.tgz",
-			"integrity": "sha512-ZE0VTIR0LmYgeyhurPTpy4KzKsuDyQbMSdM49eKkMnT5X4VfFBLysMzjIZhLEFQYjjOVVfbvUDHckwjDFiO2eA==",
 			"dev": true
 		},
 		"node_modules/abab": {
@@ -1767,30 +1640,15 @@
 			"dev": true
 		},
 		"node_modules/axios": {
-			"version": "0.25.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-			"integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.14.7"
-			}
-		},
-		"node_modules/axios-cookiejar-support": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz",
-			"integrity": "sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==",
-			"dev": true,
-			"dependencies": {
-				"is-redirect": "^1.0.0",
-				"pify": "^5.0.0"
-			},
-			"engines": {
-				"node": ">= 10.0.0"
-			},
-			"peerDependencies": {
-				"@types/tough-cookie": ">=2.3.3",
-				"axios": ">=0.16.2",
-				"tough-cookie": ">=2.3.3"
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.0",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/babel-jest": {
@@ -2011,6 +1869,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2054,6 +1926,7 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -2164,15 +2037,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/colors": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-			"integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.1.90"
-			}
-		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -2183,6 +2047,16 @@
 			},
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/commander": {
+			"version": "14.0.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/comment-parser": {
@@ -2290,12 +2164,6 @@
 			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
 			"dev": true
 		},
-		"node_modules/csstype": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-			"dev": true
-		},
 		"node_modules/data-urls": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
@@ -2380,6 +2248,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/diff": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
+			"integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/diff-sequences": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -2412,6 +2290,21 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -2470,6 +2363,55 @@
 			"dev": true,
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-set-tostringtag": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.6",
+				"has-tostringtag": "^1.0.2",
+				"hasown": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/escalade": {
@@ -3118,12 +3060,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/estree-walker": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-			"dev": true
-		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3131,15 +3067,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eventsource": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.2.tgz",
-			"integrity": "sha512-xAH3zWhgO2/3KIniEKYPr8plNSzlGINOUqYj0m0u7AB81iRw8b/3E73W6AuU+6klLbaSFmZnaETQ2lXPfAydrA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
 			}
 		},
 		"node_modules/execa": {
@@ -3325,6 +3252,7 @@
 					"url": "https://github.com/sponsors/RubenVerborgh"
 				}
 			],
+			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
 			},
@@ -3335,17 +3263,45 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.3.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fs-extra/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -3395,6 +3351,31 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3402,6 +3383,20 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -3476,6 +3471,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3488,27 +3496,6 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"node_modules/has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/has-ansi/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3516,6 +3503,35 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/hasown": {
@@ -3779,15 +3795,6 @@
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true
-		},
-		"node_modules/is-redirect": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-			"integrity": "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -4611,6 +4618,29 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonfile": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonfile/node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4699,15 +4729,6 @@
 				"yallist": "^3.0.2"
 			}
 		},
-		"node_modules/magic-string": {
-			"version": "0.30.14",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.14.tgz",
-			"integrity": "sha512-5c99P1WKTed11ZC0HMJOj6CDIue6F8ySu+bJL+85q1zBEIY8IklrJ1eiKC2NDRh3Ct3FcvmJPyQHb9erXMTJNw==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0"
-			}
-		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -4730,6 +4751,16 @@
 			"dev": true,
 			"dependencies": {
 				"tmpl": "1.0.5"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -4811,15 +4842,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/mock-mediawiki": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/mock-mediawiki/-/mock-mediawiki-1.4.0.tgz",
@@ -4836,26 +4858,23 @@
 			"dev": true
 		},
 		"node_modules/mwn": {
-			"version": "1.11.5",
-			"resolved": "https://registry.npmjs.org/mwn/-/mwn-1.11.5.tgz",
-			"integrity": "sha512-gt+so4kY1aTst5/+B5ziJAxwh3R4W4iEBcypjFjo626jvAHz03ogWTBdNU3cK+xKehAu3iS17dP3WVqW5P1G0g==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mwn/-/mwn-3.0.1.tgz",
+			"integrity": "sha512-FuANXsGtDbkRYd4c2we7veVasX6eicCIzX/bKS7mrR/3c1FlPDZKSsSSIuDhWOx008OCoTFyL8j4ayekx0rvyQ==",
 			"dev": true,
+			"license": "LGPL-3.0-or-later",
 			"dependencies": {
-				"@types/eventsource": "^1.1.4",
-				"@types/node": "^14.14.25",
-				"@types/tough-cookie": "^4.0.0",
-				"axios": "^0.25.0",
-				"axios-cookiejar-support": "^1.0.1",
-				"chalk": "^1.1.3",
-				"eventsource": "^1.0.7",
-				"form-data": "^3.0.0",
+				"@types/node": "^14.18.63",
+				"@types/tough-cookie": "^4.0.5",
+				"axios": "^1.8.3",
+				"chalk": "^4.1.2",
+				"form-data": "^4.0.2",
 				"oauth-1.0a": "^2.2.6",
-				"prettyjson": "^1.1.3",
-				"tough-cookie": "^4.0.0",
-				"types-mediawiki": "^1.0.0"
+				"tough-cookie": "^4.1.4",
+				"types-mediawiki-api": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=14"
 			}
 		},
 		"node_modules/mwn/node_modules/@types/node": {
@@ -4863,102 +4882,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
 			"integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
 			"dev": true
-		},
-		"node_modules/mwn/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mwn/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mwn/node_modules/chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mwn/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/mwn/node_modules/form-data": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.2.tgz",
-			"integrity": "sha512-sJe+TQb2vIaIyO783qN6BlMYWMw3WBOHA1Ay2qxsnjuafEOQFJ2JakedOQirT6D5XPRxDvS7AHYyem9fTpb4LQ==",
-			"dev": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/mwn/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mwn/node_modules/supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/nanoid": {
-			"version": "3.3.8",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"bin": {
-				"nanoid": "bin/nanoid.cjs"
-			},
-			"engines": {
-				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-			}
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
@@ -5217,18 +5140,6 @@
 				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
-		"node_modules/pify": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz",
-			"integrity": "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/pirates": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
@@ -5311,34 +5222,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/postcss": {
-			"version": "8.4.49",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-			"integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/postcss"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"dependencies": {
-				"nanoid": "^3.3.7",
-				"picocolors": "^1.1.1",
-				"source-map-js": "^1.2.1"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			}
-		},
 		"node_modules/postcss-selector-parser": {
 			"version": "6.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -5387,19 +5270,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/prettyjson": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
-			"integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
-			"dev": true,
-			"dependencies": {
-				"colors": "1.4.0",
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"prettyjson": "bin/prettyjson"
-			}
-		},
 		"node_modules/prompts": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5412,6 +5282,13 @@
 			"engines": {
 				"node": ">= 6"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/psl": {
 			"version": "1.15.0",
@@ -5824,6 +5701,22 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
+		"node_modules/simple-git": {
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+			"integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
+		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5843,15 +5736,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/source-map-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -6166,16 +6050,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/types-mediawiki": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/types-mediawiki/-/types-mediawiki-1.9.0.tgz",
-			"integrity": "sha512-ramdgqi1r/+BDuTTHd7wfDcDqky06rOx2naGp9C2nPIQHcmSm0htoiIMmlP2VoOuR89H0K/ejtSBCXT8guujpA==",
+		"node_modules/types-mediawiki-api": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/types-mediawiki-api/-/types-mediawiki-api-2.0.0.tgz",
+			"integrity": "sha512-JeAm+5vD0Fe131UBt8ihJyRtXQlO4Zj180mOE3fcsdBLchqn1+ZfWBvJhBknd+hMalJ2H4DmsTzmbtDRB/sSYQ==",
 			"dev": true,
-			"dependencies": {
-				"@types/jquery": "^3.5.5",
-				"@types/oojs-ui": "^0.46.0",
-				"vue": "3.3.9"
-			}
+			"license": "GPL-3.0-or-later"
 		},
 		"node_modules/typescript": {
 			"version": "5.7.2",
@@ -6303,27 +6183,6 @@
 			"dependencies": {
 				"spdx-exceptions": "^2.1.0",
 				"spdx-license-ids": "^3.0.0"
-			}
-		},
-		"node_modules/vue": {
-			"version": "3.3.9",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-3.3.9.tgz",
-			"integrity": "sha512-sy5sLCTR8m6tvUk1/ijri3Yqzgpdsmxgj6n6yl7GXXCXqVbmW2RCXe9atE4cEI6Iv7L89v5f35fZRRr5dChP9w==",
-			"dev": true,
-			"dependencies": {
-				"@vue/compiler-dom": "3.3.9",
-				"@vue/compiler-sfc": "3.3.9",
-				"@vue/runtime-dom": "3.3.9",
-				"@vue/server-renderer": "3.3.9",
-				"@vue/shared": "3.3.9"
-			},
-			"peerDependencies": {
-				"typescript": "*"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -4,18 +4,22 @@
 	"private": true,
 	"repository": "wikimedia-gadgets/twinkle",
 	"scripts": {
-		"deploy": "perl scripts/deploy.pl",
-		"deployall": "perl scripts/deploy.pl --mode=deploy --all",
+		"deploy": "node scripts/deploy.js",
 		"lint:fix": "eslint . --fix",
 		"lint": "eslint .",
 		"start": "node scripts/dev-server.js",
 		"test": "jest"
 	},
 	"devDependencies": {
+		"chalk": "^4.1.2",
+		"commander": "^14.0.0",
+		"diff": "^8.0.2",
 		"eslint-config-wikimedia": "^0.28.2",
+		"fs-extra": "^11.3.0",
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"mock-mediawiki": "^1.4.0",
-		"mwn": "^1.11.5"
+		"mwn": "^3.0.1",
+		"simple-git": "^3.28.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"repository": "wikimedia-gadgets/twinkle",
 	"scripts": {
 		"deploy": "node scripts/deploy.js",
+		"deploy:cd": "node scripts/deploy.js -y",
 		"lint:fix": "eslint . --fix",
 		"lint": "eslint .",
 		"start": "node scripts/dev-server.js",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -128,7 +128,7 @@ async function buildEditSummary(page, file, oldSummary, timestamp, user, conf) {
 
     // 'Repo at' will add 17 characters and MW truncates at 497 to allow for '...'
     const maxLength = 480;
-    while (editSummary.length > maxLength) {
+    while (editSummary.length > maxLength && !conf.yes) {
         const over = editSummary.length - maxLength;
         console.log(`The current edit summary is too long by ${over} character${over === 1 ? '' : 's'} and would thus be truncated.`);
         console.log(`\t${editSummary}`);
@@ -193,12 +193,12 @@ async function main() {
 
     // Confirm
     if (!conf.dry) {
-        console.log('Attempting to ' + chalk.magentaBright('DEPLOY'));
+        console.log('Attempting to deploy');
         if (program.args.length) {
-            files.forEach(f => console.log(chalk.blue('\t' + f)));
+            files.forEach(f => console.log('\t' + chalk.yellow(f)));
         }
-        console.log('to pages prefixed by ' + chalk.whiteBright(conf.base));
-        console.log('at site ' + chalk.magentaBright(apiUrl));
+        console.log('to pages prefixed by ' + chalk.bold(conf.base));
+        console.log('at site ' + chalk.bold.magenta(new URL(apiUrl).hostname));
         if (conf.accessToken) {
             console.log('using the given OAuth2 access token');
         } else {
@@ -238,11 +238,13 @@ async function main() {
     let countDiff = 0;
     for (const file of files) {
         let page = file;
+
         // Twinkle.js, Twinkle.css, and Twinkle-pagestyles.css have leading uppercase on-wiki
         // TODO: Remove once onwiki pages are renamed
         if (GADGET_FILES.indexOf(file) < 3) {
             page = page.charAt(0).toUpperCase() + page.slice(1);
         }
+
         if (!page.startsWith(conf.base)) {
             page = conf.base + page.replace(/^.*\//, '');
         }
@@ -298,7 +300,7 @@ async function main() {
                 basetimestamp: wikiPage?.revisions?.[0]?.timestamp,
                 nocreate: !conf.create
             });
-            console.log(chalk.green(`${file} successfully deployed to ${page}`));
+            console.log(chalk.green(`\t${file} successfully deployed to ${page}`));
         } catch (e) {
             console.log(chalk.red(`Error deploying ${file}: ${e.message}`));
         }

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+const path = require('path');
+const { program } = require('commander');
+const { Mwn } = require('mwn');
+const chalk = require('chalk');
+const { createTwoFilesPatch } = require('diff');
+const fs = require('fs-extra');
+const simpleGit = require('simple-git');
+
+program
+    .description('Deploy Twinkle gadget files to MediaWiki')
+    .option('-s, --site <site>', 'Wiki site: enwiki, testwiki, or a full MediaWiki API URL')
+    .option('-u, --username <username>', 'Username (for bot password login)')
+    .option('-p, --password <password>', 'Password (for bot password login)')
+    .option('--accessToken <accessToken>', 'OAuth2 access token')
+    .option('-b, --base <base>', 'Base page prefix', 'MediaWiki:Gadget-')
+    .option('-d, --dry', 'Dry run: show diffs of changes instead of deploying')
+    .option('-c, --create', 'Create pages onwiki if they are missing')
+    .option('-y, --yes', 'Skip all prompts and proceed (for CI)')
+    .option('-h, --help', 'Show help', usage)
+    .allowUnknownOption(false)
+    .argument('[files...]', 'Files to deploy (if omitted, deploy all)')
+    .parse(process.argv);
+
+const GADGET_FILES = [
+    'twinkle.js',
+    'twinkle.css',
+    'twinkle-pagestyles.css',
+    'morebits.js',
+    'morebits.css',
+    'lib/select2.min.js',
+    'lib/select2.min.css',
+    'modules/twinklearv.js',
+    'modules/twinklebatchdelete.js',
+    'modules/twinklebatchprotect.js',
+    'modules/twinklebatchundelete.js',
+    'modules/twinkleblock.js',
+    'modules/twinkleconfig.js',
+    'modules/twinkledeprod.js',
+    'modules/twinklediff.js',
+    'modules/twinkleimage.js',
+    'modules/twinkleprod.js',
+    'modules/twinkleprotect.js',
+    'modules/twinklerollback.js',
+    'modules/twinkleshared.js',
+    'modules/twinklespeedy.js',
+    'modules/twinkletag.js',
+    'modules/twinkletalkback.js',
+    'modules/twinkleunlink.js',
+    'modules/twinklewarn.js',
+    'modules/twinklewelcome.js',
+    'modules/twinklexfd.js'
+];
+
+const DEFAULT_CONF = {
+    username: '',
+    password: '',
+    accessToken: '',
+    apiUrl: '',
+    base: 'MediaWiki:Gadget-'
+};
+
+const repoRoot = path.resolve(__dirname, '..');
+
+function loadCredentials() {
+    const credsPath = path.join(__dirname, 'credentials.json');
+    if (fs.existsSync(credsPath)) {
+        try {
+            return JSON.parse(fs.readFileSync(credsPath, 'utf8'));
+        } catch (e) {
+            console.error(chalk.red('Error reading credentials.json: ' + e.message));
+        }
+    }
+    return {};
+}
+
+function usage() {
+    program.outputHelp();
+    process.exit(1);
+}
+
+function resolveApiUrl(site) {
+    if (!site) return null;
+    if (site === 'testwiki') return 'https://test.wikipedia.org/w/api.php';
+    if (site === 'enwiki') return 'https://en.wikipedia.org/w/api.php';
+    if (/^https?:\/\//.test(site) && site.endsWith('api.php')) return site;
+    return null;
+}
+
+const simpleGitInstance = simpleGit();
+
+async function buildEditSummary(page, file, oldSummary, timestamp, user, conf) {
+    let editSummary = '';
+
+    // Try to extract commit hash from on-wiki edit summary
+    let commitMatch = oldSummary && oldSummary.match(/Repo at (\w*?):/);
+    if (commitMatch && commitMatch[1]) {
+        // Check if commit is ancestor of HEAD
+        try {
+            await simpleGitInstance.raw(['merge-base', '--is-ancestor', commitMatch[1], 'HEAD']);
+            // Get log between commit and HEAD for this file
+            const newLog = await simpleGitInstance.raw(['rev-list', '--format=%s', '--oneline', '--no-merges', `${commitMatch[1]}..HEAD`, path.join(repoRoot, file)]);
+            const lines = newLog.split('\n').filter(Boolean).reverse();
+            console.log(`\t${lines.length} new commit(s) affecting this file since last deployment.`);
+            for (const line of lines) {
+                const message = line.split(' ').slice(1).join(' ');
+                // Trim module name prefix and trailing period
+                let portion = message.replace(/^\S+(?::| -) /, '').replace(/\.$/, '');
+                editSummary += portion + '; ';
+            }
+        } catch (e) {
+            // Not a valid ancestor, fallback
+        }
+    }
+
+    // Prompt for manual entry if still empty
+    if (!editSummary && !conf.yes) {
+        console.log(chalk.yellow(`Unable to autogenerate edit summary for ${page}`));
+        console.log('The most recent ON-WIKI edit summary is:');
+        console.log(chalk.cyan(`\t${oldSummary} (${user}, ${timestamp})`));
+        console.log('The most recent GIT LOG entries for this file are:');
+        const log = await simpleGitInstance.raw(['log', '-5', '--pretty=format:%s (%h, %ad)', '--no-merges', '--no-color', '--date=short', path.join(repoRoot, file)]);
+        log.split('\n').forEach(l => console.log(chalk.cyan(`\t${l}`)));
+        editSummary = await promptInput('Please provide an edit summary (commit ref will be prefixed automatically):');
+    }
+    editSummary = editSummary.replace(/[\.; ]+$/, ''); // Tidy
+
+    // 'Repo at' will add 17 characters and MW truncates at 497 to allow for '...'
+    const maxLength = 480;
+    while (editSummary.length > maxLength) {
+        const over = editSummary.length - maxLength;
+        console.log(`The current edit summary is too long by ${over} character${over === 1 ? '' : 's'} and would thus be truncated.`);
+        console.log(`\t${editSummary}`);
+        editSummary = await promptInput(`Please provide a shorter summary (under ${maxLength} characters, the latest commit ref will be added automatically):`);
+    }
+
+    // Add commit ref
+    const commitRef = (await simpleGitInstance.raw(['rev-parse', '--short', 'HEAD'])).trim();
+    return `Repo at ${commitRef}: ${editSummary}`;
+}
+
+async function promptInput(promptText) {
+    process.stdin.resume();
+    process.stdout.write(promptText + '\n');
+    const input = await new Promise(resolve => {
+        process.stdin.once('data', d => resolve(d.toString().trim()));
+    });
+    process.stdin.pause();
+    return input;
+}
+
+async function main() {
+    let conf = { ...DEFAULT_CONF, ...loadCredentials(), ...program.opts() };
+
+    // Set apiUrl from --site
+    let apiUrl = resolveApiUrl(conf.site);
+    if (!apiUrl) {
+        console.log(chalk.red('Missing or invalid --site! Pass enwiki, testwiki, or a full MediaWiki API URL, eg. https://en.wikipedia.org/w/api.php'));
+        usage();
+    }
+
+    if (!conf.accessToken && (!conf.username || !conf.password)) {
+        console.log(chalk.red('Missing authentication! Provide either --accessToken or both --username and --password (or set them in credentials.json).'));
+        usage();
+    }
+
+    // Check git status
+    const git = simpleGit();
+    const status = await git.status();
+    // Ignore untracked files
+    if (status.files.length - status.not_added.length > 0 && !process.env.ALLOW_DIRTY_REPO) {
+        console.log(chalk.red('Repository is not clean, aborting'));
+        process.exit(1);
+    }
+
+    // Determine files
+    let files = [];
+    if (program.args.length) {
+        files = program.args
+            .map(f => f.trim())
+            .filter(Boolean)
+            // Normalize file paths to be relative to the repo root
+            .map(f => path.relative(repoRoot, path.resolve(process.cwd(), f)))
+            .filter(f => GADGET_FILES.includes(f));
+    } else {
+        files = [...GADGET_FILES];
+    }
+    if (!files.length) {
+        console.log(chalk.red('No valid input files provided!'));
+        usage();
+    }
+
+    // Confirm
+    if (!conf.dry) {
+        console.log('Attempting to ' + chalk.magentaBright('DEPLOY'));
+        if (program.args.length) {
+            files.forEach(f => console.log(chalk.blue('\t' + f)));
+        }
+        console.log('to pages prefixed by ' + chalk.whiteBright(conf.base));
+        console.log('at site ' + chalk.magentaBright(apiUrl));
+        if (conf.accessToken) {
+            console.log('using the given OAuth2 access token');
+        } else {
+            console.log('as user ' + chalk.yellow(conf.username));
+        }
+        if (!conf.yes) {
+            const answer = await promptInput('Enter (y)es to proceed or (n)o to cancel:');
+            if (!['y', 'yes'].includes(answer.toLowerCase())) {
+                console.log('Aborting');
+                process.exit(0);
+            }
+        }
+    } else {
+        console.log(chalk.magentaBright('Dry run mode enabled, no changes will be made'));
+    }
+
+    // Login
+    let bot;
+    try {
+        bot = await Mwn.init({
+            apiUrl: apiUrl,
+            userAgent: 'deploy.js (https://github.com/wikimedia-gadgets/twinkle) (mwn)',
+            username: conf.username,
+            password: conf.password,
+            OAuth2AccessToken: conf.accessToken,
+            defaultParams: {
+                assert: 'user',
+                maxlag: 1000000, // not a botty script, thus smash it!
+            }
+        });
+    } catch (e) {
+        console.log(chalk.red('Error logging in: ' + e.message));
+        process.exit(1);
+    }
+
+    // Main loop
+    let countDiff = 0;
+    for (const file of files) {
+        let page = file;
+        // Twinkle.js, Twinkle.css, and Twinkle-pagestyles.css have leading uppercase on-wiki
+        // TODO: Remove once onwiki pages are renamed
+        if (GADGET_FILES.indexOf(file) < 3) {
+            page = page.charAt(0).toUpperCase() + page.slice(1);
+        }
+        if (!page.startsWith(conf.base)) {
+            page = conf.base + page.replace(/^.*\//, '');
+        }
+
+        let wikiPage;
+        try {
+            wikiPage = await bot.read(page, {
+                rvprop: ['content', 'comment'],
+                redirects: false,
+            });
+        } catch (e) {
+            console.log(chalk.red(`Error fetching ${page}: ${e.message}`));
+            continue;
+        }
+
+        const fileText = await fs.readFile(path.join(repoRoot, file), 'utf8');
+        const wpText = (wikiPage.revisions?.[0]?.content ?? '') + '\n';
+        const oldSummary = wikiPage.revisions?.[0]?.comment || '';
+        const oldTimestamp = wikiPage.revisions?.[0]?.timestamp || '';
+        const oldUser = wikiPage.revisions?.[0]?.user || '';
+
+        process.stdout.write(
+            chalk.cyanBright('Deploying ') +
+            `${file} to ${page}...`
+        );
+
+        if (!wikiPage.missing && wpText === fileText) {
+            console.log(chalk.blue(' No changes found, skipping'));
+            continue;
+        }
+
+        if (wikiPage.missing && !conf.create) {
+            console.log(chalk.yellow(` Page does not exist, skipping (use --create to create)`));
+            continue;
+        }
+
+        if (conf.dry) {
+            countDiff++;
+            if (!wikiPage.missing) {
+                console.log(chalk.magenta(' Showing diff:'));
+                const differences = createTwoFilesPatch(wikiPage.title, file, wpText, fileText);
+                console.log(differences);
+            } else {
+                console.log(chalk.magenta('Page does not exist. Will be CREATED!'));
+            }
+            continue;
+        }
+
+        process.stdout.write('\n\t');
+        let summary = await buildEditSummary(page, file, oldSummary, oldTimestamp, oldUser, conf);
+        try {
+            await bot.save(page, fileText, summary, {
+                basetimestamp: wikiPage?.revisions?.[0]?.timestamp,
+                nocreate: !conf.create
+            });
+            console.log(chalk.green(`${file} successfully deployed to ${page}`));
+        } catch (e) {
+            console.log(chalk.red(`Error deploying ${file}: ${e.message}`));
+        }
+        console.log();
+    }
+
+    // Show summary of any changes
+    if (conf.dry) {
+        console.log();
+        if (countDiff) {
+            console.log(`${countDiff} file${countDiff > 1 ? 's' : ''} need updating`);
+        } else {
+            console.log(chalk.green('No actions needed'));
+        }
+    }
+
+    // If deploying to MediaWiki:Gadgets-definition, check gadget definition file
+    if (conf.base === 'MediaWiki:Gadget-') {
+        let wikiGadgetDef = '';
+        try {
+            const allGadgetDefs = await bot.read('MediaWiki:Gadgets-definition');
+            const lines = (allGadgetDefs.revisions[0]?.content || '').split('\n');
+            let twLine = lines.findIndex(l => /\* ?Twinkle ?\[/.test(l));
+            if (twLine !== -1) {
+                wikiGadgetDef = lines.slice(twLine, twLine + 5).join('\n') + '\n';
+            }
+        } catch (e) {
+            console.log(chalk.red('Error fetching Gadgets-definition: ' + e.message));
+        }
+        const gadgetFile = path.join(repoRoot, 'gadget.txt');
+        let localGadgetDef = await fs.readFile(gadgetFile, 'utf8');
+        if (wikiGadgetDef === localGadgetDef) {
+            console.log('Gadget definition up-to-date');
+        } else {
+            console.log(chalk.red('MediaWiki:Gadgets-definition needs updating!') + chalk.magenta(' Showing diff:'));
+            console.log(createTwoFilesPatch('MediaWiki:Gadgets-definition', 'gadget.txt', wikiGadgetDef, localGadgetDef));
+        }
+    }
+}
+
+main().catch(e => {
+    console.error(chalk.red('Fatal error: ' + e.message));
+    process.exit(1);
+});

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -53,14 +53,14 @@ server.listen(port, hostname, async () => {
 	if (!process.env.MW_OAUTH2_TOKEN && (!process.env.MW_USERNAME || !process.env.MW_PASSWORD)) {
 		return console.log("Ensure the Twinkle gadget version is disabled. If you provide your credentials as environment variables (either the BotPassword credentials as MW_USERNAME and MW_PASSWORD, or an owner-only OAuth2 consumer token as MW_OAUTH2_TOKEN), we'll try to automatically disable the gadget for you and re-enable it when you're done testing.");
 	}
-	let mwn, user, initTime;
+	let Mwn, user, initTime;
 	try {
-		mwn = require('mwn').mwn;
+		Mwn = require('mwn').Mwn;
 	} catch (_) {
 		return console.error("Failed to load mwn. Please run `npm install` and retry.");
 	}
 	try {
-		user = await mwn.init({
+		user = await Mwn.init({
 			"apiUrl": "https://en.wikipedia.org/w/api.php",
 			"username": process.env.MW_USERNAME,
 			"password": process.env.MW_PASSWORD,
@@ -69,7 +69,7 @@ server.listen(port, hostname, async () => {
 		});
 		initTime = Date.now();
 	} catch (e) {
-		if (e instanceof mwn.Error) {
+		if (e instanceof Mwn.Error) {
 			console.log(`[mwn]: can't disable twinkle as gadget: login failure: ${e}`);
 			console.log(e.stack);
 		}


### PR DESCRIPTION
* Easier to setup and run as Twinkle developers already have node.js and npm installed. (Closes [#1771](https://github.com/wikimedia-gadgets/twinkle/pull/2183))
* Uses npm libraries that are fully compatible with Windows. (Closes [#1909](https://github.com/wikimedia-gadgets/twinkle/pull/1909), [#2065](https://github.com/wikimedia-gadgets/twinkle/pull/2065), [#2066](https://github.com/wikimedia-gadgets/twinkle/pull/2066))
* Fixes existing bugs in the perl script. (Closes [#2067](https://github.com/wikimedia-gadgets/twinkle/pull/2067), [#2068](https://github.com/wikimedia-gadgets/twinkle/pull/2068))
* Removes unused features like the "pull" mode and the edit summary override options.
* Simplifies the cli interface: 
  * Defaults to deploying all files (no more passing `--all`) 
  * Combines `lang`, `family` and `url` params into a single `site` param. 
  * Merges `dry` and `diff` params.

To run, create the file `scripts/credentials.json` with content:
```json
{
  "site": "https://test.wikipedia.org/w/api.php",
  "username": "",
  "password": ""
}
```

And just run `node deploy.js`.