### PR TITLE
Add context to mw.hook calls for script compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 alltwinkle.js
 .twinklerc
 scripts/credentials.json
+.idea/
 /.settings
 /.project
 jsl.conf

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml


### PR DESCRIPTION
Call all functions that fire within mw.hook with a context to increase compatibility with other scripts, like [Instant Diffs](https://www.mediawiki.org/wiki/Instant_Diffs) that dynamically loads diffs in dialog windows.

See the [issue](https://www.mediawiki.org/wiki/Talk:Instant_Diffs#Feedback) reported on my talk page. Thanks!