### PR TITLE
speedy: refactor data to be in JSON

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -131,6 +131,7 @@ Here is a checklist for writing a patch to add a speedy deletion criteria:
     * make sure this template also exists on testwiki when you're testing, to avoid the error "The "reason" for deleting was not provided, or Twinkle was unable to compute it. Aborting."
 * modules/twinklespeedy.js -> add it to Twinkle.speedy.data
     * If you create a new list (examples of lists are fileList, redirectList, etc), make sure to create a new variable, add the new list to the `Twinkle.speedy.callback.modeChanged()` function, as a case in the `switch (namespace)` statement
+    * If the new CSD has some data it needs to collect (for example it will be adding a "subgroup" that contains a text box), and you need to do form validation on that data, modify the code in `Twinkle.speedy.getParameters()`
 * To allow the preference "add tagged/deleted page to watchlist" (should usually do this), add to:
     * modules/twinkleconfig.js -> `csdCriteria`
     * modules/twinkleconfig.js -> `csdCriteriaDisplayOrder`

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -129,9 +129,8 @@ Here is a checklist for writing a patch to add a speedy deletion criteria:
 
 * make sure Template:Db-XX exists onwiki. This template will be placed on the page when tagging
     * make sure this template also exists on testwiki when you're testing, to avoid the error "The "reason" for deleting was not provided, or Twinkle was unable to compute it. Aborting."
-* modules/twinklespeedy.js -> add it to one of the "lists", such as "articleList", "talkList", or "templateList"
-    * If you create a new list, make sure to add the new list to the `Twinkle.speedy.callback.modeChanged()` function, as a case in the `switch (namespace)` statement
-* add to modules/twinklespeedy.js -> `normalizeHash`
+* modules/twinklespeedy.js -> add it to Twinkle.speedy.data
+    * If you create a new list (examples of lists are fileList, redirectList, etc), make sure to create a new variable, add the new list to the `Twinkle.speedy.callback.modeChanged()` function, as a case in the `switch (namespace)` statement
 * To allow the preference "add tagged/deleted page to watchlist" (should usually do this), add to:
     * modules/twinkleconfig.js -> `csdCriteria`
     * modules/twinkleconfig.js -> `csdCriteriaDisplayOrder`

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -27,8 +27,9 @@ Twinkle.speedy = function twinklespeedy() {
 	Twinkle.addPortletLink(Twinkle.speedy.callback, 'CSD', 'tw-csd', Morebits.userIsSysop ? 'Delete page according to WP:CSD' : 'Request speedy deletion according to WP:CSD');
 };
 
-Twinkle.speedy.customRationale = [
+Twinkle.speedy.data = [
 	{
+		list: 'customRationale',
 		label: 'Custom rationale' + (Morebits.userIsSysop ? ' (custom deletion reason)' : ' using {{db}} template'),
 		value: 'reason',
 		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
@@ -39,19 +40,15 @@ Twinkle.speedy.customRationale = [
 			size: 60
 		},
 		hideWhenMultiple: true
-	}
-];
-
-Twinkle.speedy.talkList = [
+	},
 	{
+		list: 'talkList',
 		label: 'G8: Talk pages with no corresponding subject page',
 		value: 'talk',
 		tooltip: 'This excludes any page that is useful to the project - in particular, user talk pages, talk page archives, and talk pages for files that exist on Wikimedia Commons.'
-	}
-];
-
-Twinkle.speedy.fileList = [
+	},
 	{
+		list: 'fileList',
 		label: 'F1: Redundant file',
 		value: 'redundantimage',
 		tooltip: 'Any file that is a redundant copy, in the same file format and same or lower resolution, of something else on Wikipedia. Likewise, other media that is a redundant copy, in the same format and of the same or lower quality. This does not apply to files duplicated on Wikimedia Commons, because of licence issues; these should be tagged with {{subst:ncd|Image:newname.ext}} or {{subst:ncd}} instead',
@@ -63,40 +60,47 @@ Twinkle.speedy.fileList = [
 		}
 	},
 	{
+		list: 'fileList',
 		label: 'F2: Corrupt, missing, or empty file',
 		value: 'noimage',
 		tooltip: 'Before deleting this type of file, verify that the MediaWiki engine cannot read it by previewing a resized thumbnail of it. This also includes empty (i.e., no content) file description pages for Commons files'
 	},
 	{
+		list: 'fileList',
 		label: 'F2: Unneeded file description page for a file on Commons',
 		value: 'fpcfail',
 		tooltip: 'An image, hosted on Commons, but with tags or information on its English Wikipedia description page that are no longer needed. (For example, a failed featured picture candidate.)',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'fileList',
 		label: 'F3: Improper license',
 		value: 'noncom',
 		tooltip: 'Files licensed as "for non-commercial use only", "non-derivative use" or "used with permission" that were uploaded on or after 2005-05-19, except where they have been shown to comply with the limited standards for the use of non-free content. This includes files licensed under a "Non-commercial Creative Commons License". Such files uploaded before 2005-05-19 may also be speedily deleted if they are not used in any articles'
 	},
 	{
+		list: 'fileList',
 		label: 'F4: Lack of licensing information',
 		value: 'unksource',
 		tooltip: 'Files in category "Files with unknown source", "Files with unknown copyright status", or "Files with no copyright tag" that have been tagged with a template that places them in the category for more than seven days, regardless of when uploaded. Note, users sometimes specify their source in the upload summary, so be sure to check the circumstances of the file.',
 		hideWhenUser: true
 	},
 	{
+		list: 'fileList',
 		label: 'F5: Unused non-free copyrighted file',
 		value: 'f5',
 		tooltip: 'Files that are not under a free license or in the public domain that are not used in any article, whose only use is in a deleted article, and that are very unlikely to be used on any other article. Reasonable exceptions may be made for files uploaded for an upcoming article. For other unused non-free files, use the "Orphaned non-free use" option in Twinkle\'s DI tab.',
 		hideWhenUser: true
 	},
 	{
+		list: 'fileList',
 		label: 'F6: Missing fair-use rationale',
 		value: 'norat',
 		tooltip: 'Any file without a fair use rationale may be deleted seven days after it is uploaded.  Boilerplate fair use templates do not constitute a fair use rationale.  Files uploaded before 2006-05-04 should not be deleted immediately; instead, the uploader should be notified that a fair-use rationale is needed.  Files uploaded after 2006-05-04 can be tagged using the "No non-free use rationale" option in Twinkle\'s DI module. Such files can be found in the dated subcategories of Category:Files with no non-free use rationale.',
 		hideWhenUser: true
 	},
 	{
+		list: 'fileList',
 		label: 'F7: Fair-use media from a commercial image agency which is not the subject of sourced commentary',
 		value: 'badfairuse',
 		tooltip: 'Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC. For cases that require a waiting period (invalid or otherwise disputed rationales or replaceable images), use the options on Twinkle\'s DI tab.',
@@ -109,6 +113,7 @@ Twinkle.speedy.fileList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'fileList',
 		label: 'F8: File available as an identical or higher-resolution copy on Wikimedia Commons',
 		value: 'commons',
 		tooltip: 'Provided the following conditions are met: 1: The file format of both images is the same. 2: The file\'s license and source status is beyond reasonable doubt, and the license is undoubtedly accepted at Commons. 3: All information on the file description page is present on the Commons file description page. That includes the complete upload history with links to the uploader\'s local user pages. 4: The file is not protected, and the file description page does not contain a request not to move it to Commons. 5: If the file is available on Commons under a different name than locally, all local references to the file must be updated to point to the title used at Commons. 6: For {{c-uploaded}} files: They may be speedily deleted as soon as they are off the Main Page',
@@ -122,6 +127,7 @@ Twinkle.speedy.fileList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'fileList',
 		label: 'F9: Unambiguous copyright infringement',
 		value: 'imgcopyvio',
 		tooltip: 'The file was copied from a website or other source that does not have a license compatible with Wikipedia, and the uploader neither claims fair use nor makes a credible assertion of permission of free use. Sources that do not have a license compatible with Wikipedia include stock photo libraries such as Getty Images or Corbis. Non-blatant copyright infringements should be discussed at Wikipedia:Files for deletion',
@@ -141,25 +147,26 @@ Twinkle.speedy.fileList = [
 		]
 	},
 	{
+		list: 'fileList',
 		label: 'F11: No evidence of permission',
 		value: 'nopermission',
 		tooltip: 'If an uploader has specified a license and has named a third party as the source/copyright holder without providing evidence that this third party has in fact agreed, the item may be deleted seven days after notification of the uploader',
 		hideWhenUser: true
 	},
 	{
+		list: 'fileList',
 		label: 'G8: File description page with no corresponding file',
 		value: 'imagepage',
 		tooltip: 'This is only for use when the file doesn\'t exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use R4.'
-	}
-];
-
-Twinkle.speedy.articleList = [
+	},
 	{
+		list: 'articleList',
 		label: 'A1: No context. Articles lacking sufficient context to identify the subject of the article.',
 		value: 'nocontext',
 		tooltip: 'Example: "He is a funny man with a red car. He makes people laugh." This applies only to very short articles. Context is different from content, treated in A3, below.'
 	},
 	{
+		list: 'articleList',
 		label: 'A2: Foreign language articles that exist on another Wikimedia project',
 		value: 'foreign',
 		tooltip: 'If the article in question does not exist on another project, the template {{notenglish}} should be used instead. All articles in a non-English language that do not meet this criteria (and do not meet any other criteria for speedy deletion) should be listed at Pages Needing Translation (PNT) for review and possible translation',
@@ -171,64 +178,75 @@ Twinkle.speedy.articleList = [
 		}
 	},
 	{
+		list: 'articleList',
 		label: 'A3: No content whatsoever',
 		value: 'nocontent',
 		tooltip: 'Any article consisting only of links elsewhere (including hyperlinks, category tags and "see also" sections), a rephrasing of the title, and/or attempts to correspond with the person or group named by its title. This does not include disambiguation pages'
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (people, groups, companies, web content, individual animals, or organized events)',
 		value: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (person)',
 		value: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (musician(s) or band)',
 		value: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (club, society or group)',
 		value: 'club',
 		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (company or organization)',
 		value: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (website or web content)',
 		value: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (individual animal)',
 		value: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A7: No indication of importance (organized event)',
 		value: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'articleList',
 		label: 'A9: Unremarkable musical recording where artist\'s article doesn\'t exist',
 		value: 'a9',
 		tooltip: 'An article about a musical recording which does not indicate why its subject is important or significant, and where the artist\'s article has never existed or has been deleted'
 	},
 	{
+		list: 'articleList',
 		label: 'A10: Recently created article that duplicates an existing topic',
 		value: 'a10',
 		tooltip: 'A recently created article with no relevant page history that does not aim to expand upon, detail or improve information within any existing article(s) on the subject, and where the title is not a plausible redirect. This does not include content forks, split pages or any article that aims at expanding or detailing an existing one.',
@@ -239,19 +257,19 @@ Twinkle.speedy.articleList = [
 		}
 	},
 	{
+		list: 'articleList',
 		label: 'A11: Obviously made up by creator, and no claim of significance',
 		value: 'madeup',
 		tooltip: 'An article which plainly indicates that the subject was invented/coined/discovered by the article\'s creator or someone they know personally, and does not credibly indicate why its subject is important or significant'
-	}
-];
-
-Twinkle.speedy.categoryList = [
+	},
 	{
+		list: 'categoryList',
 		label: 'C1: Empty categories',
 		value: 'catempty',
 		tooltip: 'Categories that have been unpopulated for at least seven days. This does not apply to categories being discussed at WP:CFD, disambiguation categories, and certain other exceptions. If the category isn\'t relatively new, it possibly contained articles earlier, and deeper investigation is needed'
 	},
 	{
+		list: 'categoryList',
 		label: 'C4: Permanently unused maintenance categories',
 		value: 'c4',
 		tooltip: 'Unused maintenance categories, such as empty dated maintenance categories for dates in the past, tracking categories no longer used by a template after a rewrite, or empty subcategories of Category:Wikipedia sockpuppets or Category:Suspected Wikipedia sockpuppets. Empty maintenance categories are not necessarily unused—this criterion is for categories which will always be empty, not just currently empty.',
@@ -261,19 +279,15 @@ Twinkle.speedy.categoryList = [
 			label: 'Optional explanation:',
 			size: 60
 		}
-	}
-];
-
-Twinkle.speedy.templateList = [
+	},
 	{
+		list: 'templateList',
 		label: 'T5: Unused template subpages',
 		value: 't5',
 		tooltip: 'Unused subpages of templates and Lua modules. This does not apply to /testcases and /sandbox subpages, or subpages of Module:Sandbox.'
-	}
-];
-
-Twinkle.speedy.userList = [
+	},
 	{
+		list: 'userList',
 		label: 'U1: User request',
 		value: 'userreq',
 		tooltip: 'Personal subpages, upon request by their user. In some rare cases there may be administrative need to retain the page. Also, sometimes, main user pages may be deleted as well. See Wikipedia:User page for full instructions and guidelines',
@@ -287,17 +301,20 @@ Twinkle.speedy.userList = [
 		hideSubgroupWhenMultiple: true
 	},
 	{
+		list: 'userList',
 		label: 'U2: Nonexistent user',
 		value: 'nouser',
 		tooltip: 'User pages of users that do not exist (Check Special:Listusers)'
 	},
 	{
+		list: 'userList',
 		label: 'U5: A non-contributor misusing Wikipedia as a web host',
 		value: 'notwebhost',
 		tooltip: 'Pages in userspace consisting of writings, information, discussions, or activities not closely related to Wikipedia\'s goals, where the owner has made few or no edits outside of user pages, except for plausible drafts and pages adhering to WP:UPYES. It applies regardless of the age of the page in question.',
 		hideWhenRedirect: true
 	},
 	{
+		list: 'userList',
 		label: 'G11: Promotional user page under a promotional user name',
 		value: 'spamuser',
 		tooltip: 'A promotional user page, with a username that promotes or implies affiliation with the thing being promoted. Note that simply having a page on a company or product in one\'s userspace does not qualify it for deletion. If a user page is spammy but the username is not, then consider tagging with regular G11 instead.',
@@ -305,39 +322,42 @@ Twinkle.speedy.userList = [
 		hideWhenRedirect: true
 	},
 	{
+		list: 'userList',
 		label: 'G13: AfC draft submission or a blank draft, stale by over 6 months',
 		value: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC draft submission or a blank draft, that has not been edited in over 6 months (excluding bot edits).',
 		hideWhenMultiple: true,
 		hideWhenRedirect: true
-	}
-];
-
-Twinkle.speedy.generalList = [
+	},
 	{
+		list: 'generalList',
 		label: 'G1: Patent nonsense. Pages consisting purely of incoherent text or gibberish with no meaningful content or history.',
 		value: 'nonsense',
 		tooltip: 'This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
 	},
 	{
+		list: 'generalList',
 		label: 'G2: Test page',
 		value: 'test',
 		tooltip: 'A page created to test editing or other Wikipedia functions. Pages in the User namespace are not included, nor are valid but unused or duplicate templates.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
 	},
 	{
+		list: 'generalList',
 		label: 'G3: Pure vandalism',
 		value: 'vandalism',
 		tooltip: 'Plain pure vandalism (including redirects left behind from pagemove vandalism)'
 	},
 	{
+		list: 'generalList',
 		label: 'G3: Blatant hoax',
 		value: 'hoax',
 		tooltip: 'Blatant and obvious hoax, to the point of vandalism',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G4: Recreation of material deleted via a deletion discussion',
 		value: 'repost',
 		tooltip: 'A copy, by any title, of a page that was deleted via an XfD process or Deletion review, provided that the copy is substantially identical to the deleted version. This clause does not apply to content that has been "userfied", to content undeleted as a result of Deletion review, or if the prior deletions were proposed or speedy deletions, although in this last case, other speedy deletion criteria may still apply',
@@ -350,6 +370,7 @@ Twinkle.speedy.generalList = [
 		}
 	},
 	{
+		list: 'generalList',
 		label: 'G5: Created by a banned or blocked user',
 		value: 'banned',
 		tooltip: 'Pages created by banned or blocked users in violation of their ban or block, and which have no substantial edits by others',
@@ -361,12 +382,14 @@ Twinkle.speedy.generalList = [
 		}
 	},
 	{
+		list: 'generalList',
 		label: 'G6: Error',
 		value: 'error',
 		tooltip: 'A page that was obviously created in error, or a redirect left over from moving a page that was obviously created at the wrong title.',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G6: Move',
 		value: 'move',
 		tooltip: 'Making way for an uncontroversial move like reversing a redirect',
@@ -386,6 +409,7 @@ Twinkle.speedy.generalList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G6: XfD',
 		value: 'xfd',
 		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn\'t actually deleted.',
@@ -399,6 +423,7 @@ Twinkle.speedy.generalList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G6: AfC move',
 		value: 'afc-move',
 		tooltip: 'Making way for acceptance of a draft submitted to AfC',
@@ -410,6 +435,7 @@ Twinkle.speedy.generalList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G6: Copy-and-paste page move',
 		value: 'copypaste',
 		tooltip: 'This only applies for a copy-and-paste page move of another page that needs to be temporarily deleted to make room for a clean page move.',
@@ -421,6 +447,7 @@ Twinkle.speedy.generalList = [
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G6: Housekeeping and non-controversial cleanup',
 		value: 'g6',
 		tooltip: 'Other routine maintenance tasks',
@@ -432,6 +459,7 @@ Twinkle.speedy.generalList = [
 		}
 	},
 	{
+		list: 'generalList',
 		label: 'G7: Author requests deletion, or author blanked',
 		value: 'author',
 		tooltip: 'Any page for which deletion is requested by the original author in good faith, provided the page\'s only substantial content was added by its author. If the author blanks the page, this can also be taken as a deletion request.',
@@ -445,6 +473,7 @@ Twinkle.speedy.generalList = [
 		hideSubgroupWhenSysop: true
 	},
 	{
+		list: 'generalList',
 		label: 'G8: Pages dependent on a non-existent or deleted page',
 		value: 'g8',
 		tooltip: 'such as talk pages with no corresponding subject page; subpages with no parent page; file pages without a corresponding file; redirects to non-existent targets; or categories populated by deleted or retargeted templates. This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
@@ -457,6 +486,7 @@ Twinkle.speedy.generalList = [
 		hideSubgroupWhenSysop: true
 	},
 	{
+		list: 'generalList',
 		label: 'G8: Subpages with no parent page',
 		value: 'subpage',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
@@ -464,22 +494,26 @@ Twinkle.speedy.generalList = [
 		hideInNamespaces: [ 0, 6, 8 ] // hide in main, file, and mediawiki-spaces
 	},
 	{
+		list: 'generalList',
 		label: 'G10: Attack page',
 		value: 'attack',
 		tooltip: 'Pages that serve no purpose but to disparage or threaten their subject or some other entity (e.g., "John Q. Doe is an imbecile"). This includes a biography of a living person that is negative in tone and unsourced, where there is no NPOV version in the history to revert to. Administrators deleting such pages should not quote the content of the page in the deletion summary!'
 	},
 	{
+		list: 'generalList',
 		label: 'G10: Wholly negative, unsourced BLP',
 		value: 'negublp',
 		tooltip: 'A biography of a living person that is entirely negative in tone and unsourced, where there is no neutral version in the history to revert to.',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'generalList',
 		label: 'G11: Unambiguous advertising or promotion',
 		value: 'spam',
 		tooltip: 'Pages which exclusively promote a company, product, group, service, or person and which would need to be fundamentally rewritten in order to become encyclopedic. Note that an article about a company or a product which describes its subject from a neutral point of view does not qualify for this criterion; an article that is blatant advertising should have inappropriate content as well'
 	},
 	{
+		list: 'generalList',
 		label: 'G12: Unambiguous copyright infringement',
 		value: 'copyvio',
 		tooltip: 'Either: (1) Material was copied from another website that does not have a license compatible with Wikipedia, or is photography from a stock photo seller (such as Getty Images or Corbis) or other commercial content provider; (2) There is no non-infringing content in the page history worth saving; or (3) The infringement was introduced at once by a single person rather than created organically on wiki and then copied by another website such as one of the many Wikipedia mirrors',
@@ -508,6 +542,7 @@ Twinkle.speedy.generalList = [
 		]
 	},
 	{
+		list: 'generalList',
 		label: 'G13: Page in draft namespace or userspace AfC submission, stale by over 6 months',
 		value: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC submission in userspace or any non-redirect page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.',
@@ -515,48 +550,78 @@ Twinkle.speedy.generalList = [
 		showInNamespaces: [2, 118] // user, draft namespaces only
 	},
 	{
+		list: 'generalList',
 		label: 'G14: Unnecessary disambiguation page',
 		value: 'disambig',
 		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)'
-	}
-];
-
-Twinkle.speedy.redirectList = [
+	},
 	{
+		list: 'redirectList',
 		label: 'R2: Redirect from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
 		value: 'rediruser',
 		tooltip: 'This does not include the pseudo-namespace shortcuts. If this was the result of a page move, consider waiting a day or two before deleting the redirect',
 		showInNamespaces: [ 0 ]
 	},
 	{
+		list: 'redirectList',
 		label: 'R3: Recently created redirect from an implausible typo or misnomer',
 		value: 'redirtypo',
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
 	},
 	{
+		list: 'redirectList',
 		label: 'R4: File namespace redirect with a name that matches a Commons page',
 		value: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).',
 		showInNamespaces: [ 6 ]
 	},
 	{
+		list: 'redirectList',
 		label: 'G6: Redirect to malplaced disambiguation page',
 		value: 'movedab',
 		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'redirectList',
 		label: 'G8: Redirects to non-existent targets',
 		value: 'redirnone',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true
 	},
 	{
+		list: 'redirectList',
 		label: 'X3: Redirects with no space before a parenthetical disambiguation',
 		value: 'x3',
 		tooltip: 'This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).'
 	}
 ];
+
+/**
+ * Given a list name such as talkList, fileList, redirectList, etc, return the CSDs that should be in that list.
+ */
+Twinkle.speedy.getCsdList = ( csdList ) => {
+	const list = [];
+	for (const item of Twinkle.speedy.data) {
+		if (item.list === csdList) {
+			const copy = Object.assign({}, item);
+			// Delete the "list" key and value from the output, since the old spec didn't have this.
+			delete copy.list;
+			list.push(copy);
+		}
+	}
+	return list;
+};
+
+Twinkle.speedy.customRationale = Twinkle.speedy.getCsdList( 'customRationale' );
+Twinkle.speedy.talkList = Twinkle.speedy.getCsdList( 'talkList' );
+Twinkle.speedy.fileList = Twinkle.speedy.getCsdList( 'fileList' );
+Twinkle.speedy.articleList = Twinkle.speedy.getCsdList( 'articleList' );
+Twinkle.speedy.categoryList = Twinkle.speedy.getCsdList( 'categoryList' );
+Twinkle.speedy.templateList = Twinkle.speedy.getCsdList( 'templateList' );
+Twinkle.speedy.userList = Twinkle.speedy.getCsdList( 'userList' );
+Twinkle.speedy.generalList = Twinkle.speedy.getCsdList( 'generalList' );
+Twinkle.speedy.redirectList = Twinkle.speedy.getCsdList( 'redirectList' );
 
 Twinkle.speedy.normalizeHash = {
 	reason: 'db',

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -31,7 +31,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'customRationale',
 		label: 'Custom rationale' + (Morebits.userIsSysop ? ' (custom deletion reason)' : ' using {{db}} template'),
-		value: 'reason',
+		db: 'reason',
 		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
 		subgroup: {
 			name: 'reason_1',
@@ -44,13 +44,13 @@ Twinkle.speedy.data = [
 	{
 		list: 'talkList',
 		label: 'G8: Talk pages with no corresponding subject page',
-		value: 'talk',
+		db: 'talk',
 		tooltip: 'This excludes any page that is useful to the project - in particular, user talk pages, talk page archives, and talk pages for files that exist on Wikimedia Commons.'
 	},
 	{
 		list: 'fileList',
 		label: 'F1: Redundant file',
-		value: 'redundantimage',
+		db: 'redundantimage',
 		tooltip: 'Any file that is a redundant copy, in the same file format and same or lower resolution, of something else on Wikipedia. Likewise, other media that is a redundant copy, in the same format and of the same or lower quality. This does not apply to files duplicated on Wikimedia Commons, because of licence issues; these should be tagged with {{subst:ncd|Image:newname.ext}} or {{subst:ncd}} instead',
 		subgroup: {
 			name: 'redundantimage_filename',
@@ -62,47 +62,47 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F2: Corrupt, missing, or empty file',
-		value: 'noimage',
+		db: 'noimage',
 		tooltip: 'Before deleting this type of file, verify that the MediaWiki engine cannot read it by previewing a resized thumbnail of it. This also includes empty (i.e., no content) file description pages for Commons files'
 	},
 	{
 		list: 'fileList',
 		label: 'F2: Unneeded file description page for a file on Commons',
-		value: 'fpcfail',
+		db: 'fpcfail',
 		tooltip: 'An image, hosted on Commons, but with tags or information on its English Wikipedia description page that are no longer needed. (For example, a failed featured picture candidate.)',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'fileList',
 		label: 'F3: Improper license',
-		value: 'noncom',
+		db: 'noncom',
 		tooltip: 'Files licensed as "for non-commercial use only", "non-derivative use" or "used with permission" that were uploaded on or after 2005-05-19, except where they have been shown to comply with the limited standards for the use of non-free content. This includes files licensed under a "Non-commercial Creative Commons License". Such files uploaded before 2005-05-19 may also be speedily deleted if they are not used in any articles'
 	},
 	{
 		list: 'fileList',
 		label: 'F4: Lack of licensing information',
-		value: 'unksource',
+		db: 'unksource',
 		tooltip: 'Files in category "Files with unknown source", "Files with unknown copyright status", or "Files with no copyright tag" that have been tagged with a template that places them in the category for more than seven days, regardless of when uploaded. Note, users sometimes specify their source in the upload summary, so be sure to check the circumstances of the file.',
 		hideWhenUser: true
 	},
 	{
 		list: 'fileList',
 		label: 'F5: Unused non-free copyrighted file',
-		value: 'f5',
+		db: 'f5',
 		tooltip: 'Files that are not under a free license or in the public domain that are not used in any article, whose only use is in a deleted article, and that are very unlikely to be used on any other article. Reasonable exceptions may be made for files uploaded for an upcoming article. For other unused non-free files, use the "Orphaned non-free use" option in Twinkle\'s DI tab.',
 		hideWhenUser: true
 	},
 	{
 		list: 'fileList',
 		label: 'F6: Missing fair-use rationale',
-		value: 'norat',
+		db: 'norat',
 		tooltip: 'Any file without a fair use rationale may be deleted seven days after it is uploaded.  Boilerplate fair use templates do not constitute a fair use rationale.  Files uploaded before 2006-05-04 should not be deleted immediately; instead, the uploader should be notified that a fair-use rationale is needed.  Files uploaded after 2006-05-04 can be tagged using the "No non-free use rationale" option in Twinkle\'s DI module. Such files can be found in the dated subcategories of Category:Files with no non-free use rationale.',
 		hideWhenUser: true
 	},
 	{
 		list: 'fileList',
 		label: 'F7: Fair-use media from a commercial image agency which is not the subject of sourced commentary',
-		value: 'badfairuse',
+		db: 'badfairuse',
 		tooltip: 'Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC. For cases that require a waiting period (invalid or otherwise disputed rationales or replaceable images), use the options on Twinkle\'s DI tab.',
 		subgroup: {
 			name: 'badfairuse_rationale',
@@ -115,7 +115,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F8: File available as an identical or higher-resolution copy on Wikimedia Commons',
-		value: 'commons',
+		db: 'commons',
 		tooltip: 'Provided the following conditions are met: 1: The file format of both images is the same. 2: The file\'s license and source status is beyond reasonable doubt, and the license is undoubtedly accepted at Commons. 3: All information on the file description page is present on the Commons file description page. That includes the complete upload history with links to the uploader\'s local user pages. 4: The file is not protected, and the file description page does not contain a request not to move it to Commons. 5: If the file is available on Commons under a different name than locally, all local references to the file must be updated to point to the title used at Commons. 6: For {{c-uploaded}} files: They may be speedily deleted as soon as they are off the Main Page',
 		subgroup: {
 			name: 'commons_filename',
@@ -129,7 +129,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F9: Unambiguous copyright infringement',
-		value: 'imgcopyvio',
+		db: 'imgcopyvio',
 		tooltip: 'The file was copied from a website or other source that does not have a license compatible with Wikipedia, and the uploader neither claims fair use nor makes a credible assertion of permission of free use. Sources that do not have a license compatible with Wikipedia include stock photo libraries such as Getty Images or Corbis. Non-blatant copyright infringements should be discussed at Wikipedia:Files for deletion',
 		subgroup: [
 			{
@@ -149,26 +149,26 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F11: No evidence of permission',
-		value: 'nopermission',
+		db: 'nopermission',
 		tooltip: 'If an uploader has specified a license and has named a third party as the source/copyright holder without providing evidence that this third party has in fact agreed, the item may be deleted seven days after notification of the uploader',
 		hideWhenUser: true
 	},
 	{
 		list: 'fileList',
 		label: 'G8: File description page with no corresponding file',
-		value: 'imagepage',
+		db: 'imagepage',
 		tooltip: 'This is only for use when the file doesn\'t exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use R4.'
 	},
 	{
 		list: 'articleList',
 		label: 'A1: No context. Articles lacking sufficient context to identify the subject of the article.',
-		value: 'nocontext',
+		db: 'nocontext',
 		tooltip: 'Example: "He is a funny man with a red car. He makes people laugh." This applies only to very short articles. Context is different from content, treated in A3, below.'
 	},
 	{
 		list: 'articleList',
 		label: 'A2: Foreign language articles that exist on another Wikimedia project',
-		value: 'foreign',
+		db: 'foreign',
 		tooltip: 'If the article in question does not exist on another project, the template {{notenglish}} should be used instead. All articles in a non-English language that do not meet this criteria (and do not meet any other criteria for speedy deletion) should be listed at Pages Needing Translation (PNT) for review and possible translation',
 		subgroup: {
 			name: 'foreign_source',
@@ -180,75 +180,75 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A3: No content whatsoever',
-		value: 'nocontent',
+		db: 'nocontent',
 		tooltip: 'Any article consisting only of links elsewhere (including hyperlinks, category tags and "see also" sections), a rephrasing of the title, and/or attempts to correspond with the person or group named by its title. This does not include disambiguation pages'
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (people, groups, companies, web content, individual animals, or organized events)',
-		value: 'a7',
+		db: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (person)',
-		value: 'person',
+		db: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (musician(s) or band)',
-		value: 'band',
+		db: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (club, society or group)',
-		value: 'club',
+		db: 'club',
 		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (company or organization)',
-		value: 'corp',
+		db: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (website or web content)',
-		value: 'web',
+		db: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (individual animal)',
-		value: 'animal',
+		db: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (organized event)',
-		value: 'event',
+		db: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'articleList',
 		label: 'A9: Unremarkable musical recording where artist\'s article doesn\'t exist',
-		value: 'a9',
+		db: 'a9',
 		tooltip: 'An article about a musical recording which does not indicate why its subject is important or significant, and where the artist\'s article has never existed or has been deleted'
 	},
 	{
 		list: 'articleList',
 		label: 'A10: Recently created article that duplicates an existing topic',
-		value: 'a10',
+		db: 'a10',
 		tooltip: 'A recently created article with no relevant page history that does not aim to expand upon, detail or improve information within any existing article(s) on the subject, and where the title is not a plausible redirect. This does not include content forks, split pages or any article that aims at expanding or detailing an existing one.',
 		subgroup: {
 			name: 'a10_article',
@@ -259,19 +259,19 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A11: Obviously made up by creator, and no claim of significance',
-		value: 'madeup',
+		db: 'madeup',
 		tooltip: 'An article which plainly indicates that the subject was invented/coined/discovered by the article\'s creator or someone they know personally, and does not credibly indicate why its subject is important or significant'
 	},
 	{
 		list: 'categoryList',
 		label: 'C1: Empty categories',
-		value: 'catempty',
+		db: 'catempty',
 		tooltip: 'Categories that have been unpopulated for at least seven days. This does not apply to categories being discussed at WP:CFD, disambiguation categories, and certain other exceptions. If the category isn\'t relatively new, it possibly contained articles earlier, and deeper investigation is needed'
 	},
 	{
 		list: 'categoryList',
 		label: 'C4: Permanently unused maintenance categories',
-		value: 'c4',
+		db: 'c4',
 		tooltip: 'Unused maintenance categories, such as empty dated maintenance categories for dates in the past, tracking categories no longer used by a template after a rewrite, or empty subcategories of Category:Wikipedia sockpuppets or Category:Suspected Wikipedia sockpuppets. Empty maintenance categories are not necessarily unused—this criterion is for categories which will always be empty, not just currently empty.',
 		subgroup: {
 			name: 'c4_rationale',
@@ -283,13 +283,13 @@ Twinkle.speedy.data = [
 	{
 		list: 'templateList',
 		label: 'T5: Unused template subpages',
-		value: 't5',
+		db: 't5',
 		tooltip: 'Unused subpages of templates and Lua modules. This does not apply to /testcases and /sandbox subpages, or subpages of Module:Sandbox.'
 	},
 	{
 		list: 'userList',
 		label: 'U1: User request',
-		value: 'userreq',
+		db: 'userreq',
 		tooltip: 'Personal subpages, upon request by their user. In some rare cases there may be administrative need to retain the page. Also, sometimes, main user pages may be deleted as well. See Wikipedia:User page for full instructions and guidelines',
 		subgroup: mw.config.get('wgNamespaceNumber') === 3 && !mw.config.get('wgTitle').includes('/') ? {
 			name: 'userreq_rationale',
@@ -303,20 +303,20 @@ Twinkle.speedy.data = [
 	{
 		list: 'userList',
 		label: 'U2: Nonexistent user',
-		value: 'nouser',
+		db: 'nouser',
 		tooltip: 'User pages of users that do not exist (Check Special:Listusers)'
 	},
 	{
 		list: 'userList',
 		label: 'U5: A non-contributor misusing Wikipedia as a web host',
-		value: 'notwebhost',
+		db: 'notwebhost',
 		tooltip: 'Pages in userspace consisting of writings, information, discussions, or activities not closely related to Wikipedia\'s goals, where the owner has made few or no edits outside of user pages, except for plausible drafts and pages adhering to WP:UPYES. It applies regardless of the age of the page in question.',
 		hideWhenRedirect: true
 	},
 	{
 		list: 'userList',
 		label: 'G11: Promotional user page under a promotional user name',
-		value: 'spamuser',
+		db: 'spamuser',
 		tooltip: 'A promotional user page, with a username that promotes or implies affiliation with the thing being promoted. Note that simply having a page on a company or product in one\'s userspace does not qualify it for deletion. If a user page is spammy but the username is not, then consider tagging with regular G11 instead.',
 		hideWhenMultiple: true,
 		hideWhenRedirect: true
@@ -324,7 +324,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'userList',
 		label: 'G13: AfC draft submission or a blank draft, stale by over 6 months',
-		value: 'afc',
+		db: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC draft submission or a blank draft, that has not been edited in over 6 months (excluding bot edits).',
 		hideWhenMultiple: true,
 		hideWhenRedirect: true
@@ -332,34 +332,34 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G1: Patent nonsense. Pages consisting purely of incoherent text or gibberish with no meaningful content or history.',
-		value: 'nonsense',
+		db: 'nonsense',
 		tooltip: 'This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
 	},
 	{
 		list: 'generalList',
 		label: 'G2: Test page',
-		value: 'test',
+		db: 'test',
 		tooltip: 'A page created to test editing or other Wikipedia functions. Pages in the User namespace are not included, nor are valid but unused or duplicate templates.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
 	},
 	{
 		list: 'generalList',
 		label: 'G3: Pure vandalism',
-		value: 'vandalism',
+		db: 'vandalism',
 		tooltip: 'Plain pure vandalism (including redirects left behind from pagemove vandalism)'
 	},
 	{
 		list: 'generalList',
 		label: 'G3: Blatant hoax',
-		value: 'hoax',
+		db: 'hoax',
 		tooltip: 'Blatant and obvious hoax, to the point of vandalism',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'generalList',
 		label: 'G4: Recreation of material deleted via a deletion discussion',
-		value: 'repost',
+		db: 'repost',
 		tooltip: 'A copy, by any title, of a page that was deleted via an XfD process or Deletion review, provided that the copy is substantially identical to the deleted version. This clause does not apply to content that has been "userfied", to content undeleted as a result of Deletion review, or if the prior deletions were proposed or speedy deletions, although in this last case, other speedy deletion criteria may still apply',
 		subgroup: {
 			name: 'repost_xfd',
@@ -372,7 +372,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G5: Created by a banned or blocked user',
-		value: 'banned',
+		db: 'banned',
 		tooltip: 'Pages created by banned or blocked users in violation of their ban or block, and which have no substantial edits by others',
 		subgroup: {
 			name: 'banned_user',
@@ -384,14 +384,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Error',
-		value: 'error',
+		db: 'error',
 		tooltip: 'A page that was obviously created in error, or a redirect left over from moving a page that was obviously created at the wrong title.',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'generalList',
 		label: 'G6: Move',
-		value: 'move',
+		db: 'move',
 		tooltip: 'Making way for an uncontroversial move like reversing a redirect',
 		subgroup: [
 			{
@@ -411,7 +411,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: XfD',
-		value: 'xfd',
+		db: 'xfd',
 		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn\'t actually deleted.',
 		subgroup: {
 			name: 'xfd_fullvotepage',
@@ -425,7 +425,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: AfC move',
-		value: 'afc-move',
+		db: 'afc-move',
 		tooltip: 'Making way for acceptance of a draft submitted to AfC',
 		subgroup: {
 			name: 'draft_page',
@@ -437,7 +437,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Copy-and-paste page move',
-		value: 'copypaste',
+		db: 'copypaste',
 		tooltip: 'This only applies for a copy-and-paste page move of another page that needs to be temporarily deleted to make room for a clean page move.',
 		subgroup: {
 			name: 'copypaste_sourcepage',
@@ -449,7 +449,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Housekeeping and non-controversial cleanup',
-		value: 'g6',
+		db: 'g6',
 		tooltip: 'Other routine maintenance tasks',
 		subgroup: {
 			name: 'g6_rationale',
@@ -461,7 +461,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G7: Author requests deletion, or author blanked',
-		value: 'author',
+		db: 'author',
 		tooltip: 'Any page for which deletion is requested by the original author in good faith, provided the page\'s only substantial content was added by its author. If the author blanks the page, this can also be taken as a deletion request.',
 		subgroup: {
 			name: 'author_rationale',
@@ -475,7 +475,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G8: Pages dependent on a non-existent or deleted page',
-		value: 'g8',
+		db: 'g8',
 		tooltip: 'such as talk pages with no corresponding subject page; subpages with no parent page; file pages without a corresponding file; redirects to non-existent targets; or categories populated by deleted or retargeted templates. This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		subgroup: {
 			name: 'g8_rationale',
@@ -488,7 +488,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G8: Subpages with no parent page',
-		value: 'subpage',
+		db: 'subpage',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true,
 		hideInNamespaces: [ 0, 6, 8 ] // hide in main, file, and mediawiki-spaces
@@ -496,26 +496,26 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G10: Attack page',
-		value: 'attack',
+		db: 'attack',
 		tooltip: 'Pages that serve no purpose but to disparage or threaten their subject or some other entity (e.g., "John Q. Doe is an imbecile"). This includes a biography of a living person that is negative in tone and unsourced, where there is no NPOV version in the history to revert to. Administrators deleting such pages should not quote the content of the page in the deletion summary!'
 	},
 	{
 		list: 'generalList',
 		label: 'G10: Wholly negative, unsourced BLP',
-		value: 'negublp',
+		db: 'negublp',
 		tooltip: 'A biography of a living person that is entirely negative in tone and unsourced, where there is no neutral version in the history to revert to.',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'generalList',
 		label: 'G11: Unambiguous advertising or promotion',
-		value: 'spam',
+		db: 'spam',
 		tooltip: 'Pages which exclusively promote a company, product, group, service, or person and which would need to be fundamentally rewritten in order to become encyclopedic. Note that an article about a company or a product which describes its subject from a neutral point of view does not qualify for this criterion; an article that is blatant advertising should have inappropriate content as well'
 	},
 	{
 		list: 'generalList',
 		label: 'G12: Unambiguous copyright infringement',
-		value: 'copyvio',
+		db: 'copyvio',
 		tooltip: 'Either: (1) Material was copied from another website that does not have a license compatible with Wikipedia, or is photography from a stock photo seller (such as Getty Images or Corbis) or other commercial content provider; (2) There is no non-infringing content in the page history worth saving; or (3) The infringement was introduced at once by a single person rather than created organically on wiki and then copied by another website such as one of the many Wikipedia mirrors',
 		subgroup: [
 			{
@@ -544,7 +544,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G13: Page in draft namespace or userspace AfC submission, stale by over 6 months',
-		value: 'afc',
+		db: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC submission in userspace or any non-redirect page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.',
 		hideWhenRedirect: true,
 		showInNamespaces: [2, 118] // user, draft namespaces only
@@ -552,47 +552,47 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G14: Unnecessary disambiguation page',
-		value: 'disambig',
+		db: 'disambig',
 		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)'
 	},
 	{
 		list: 'redirectList',
 		label: 'R2: Redirect from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
-		value: 'rediruser',
+		db: 'rediruser',
 		tooltip: 'This does not include the pseudo-namespace shortcuts. If this was the result of a page move, consider waiting a day or two before deleting the redirect',
 		showInNamespaces: [ 0 ]
 	},
 	{
 		list: 'redirectList',
 		label: 'R3: Recently created redirect from an implausible typo or misnomer',
-		value: 'redirtypo',
+		db: 'redirtypo',
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
 	},
 	{
 		list: 'redirectList',
 		label: 'R4: File namespace redirect with a name that matches a Commons page',
-		value: 'redircom',
+		db: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).',
 		showInNamespaces: [ 6 ]
 	},
 	{
 		list: 'redirectList',
 		label: 'G6: Redirect to malplaced disambiguation page',
-		value: 'movedab',
+		db: 'movedab',
 		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'redirectList',
 		label: 'G8: Redirects to non-existent targets',
-		value: 'redirnone',
+		db: 'redirnone',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true
 	},
 	{
 		list: 'redirectList',
 		label: 'X3: Redirects with no space before a parenthetical disambiguation',
-		value: 'x3',
+		db: 'x3',
 		tooltip: 'This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).'
 	}
 ];
@@ -605,8 +605,10 @@ Twinkle.speedy.getCsdList = ( csdList ) => {
 	for (const item of Twinkle.speedy.data) {
 		if (item.list === csdList) {
 			const copy = Object.assign({}, item);
-			// Delete the "list" key and value from the output, since the old spec didn't have this.
+			// Change some things to match the old spec, from before I refactored this.
 			delete copy.list;
+			copy.value = copy.db;
+			delete copy.db;
 			list.push(copy);
 		}
 	}

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -96,7 +96,7 @@ Twinkle.speedy.data = [
 		list: 'fileList',
 		label: 'F5: Unused non-free copyrighted file',
 		code: 'f5',
-		db: 'unfree',
+		db: 'f5',
 		tooltip: 'Files that are not under a free license or in the public domain that are not used in any article, whose only use is in a deleted article, and that are very unlikely to be used on any other article. Reasonable exceptions may be made for files uploaded for an upcoming article. For other unused non-free files, use the "Orphaned non-free use" option in Twinkle\'s DI tab.',
 		hideWhenUser: true
 	},

--- a/modules/twinklespeedy.js
+++ b/modules/twinklespeedy.js
@@ -31,6 +31,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'customRationale',
 		label: 'Custom rationale' + (Morebits.userIsSysop ? ' (custom deletion reason)' : ' using {{db}} template'),
+		code: 'db',
 		db: 'reason',
 		tooltip: '{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can\'t find any criteria that fit.',
 		subgroup: {
@@ -44,12 +45,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'talkList',
 		label: 'G8: Talk pages with no corresponding subject page',
+		code: 'g8',
 		db: 'talk',
 		tooltip: 'This excludes any page that is useful to the project - in particular, user talk pages, talk page archives, and talk pages for files that exist on Wikimedia Commons.'
 	},
 	{
 		list: 'fileList',
 		label: 'F1: Redundant file',
+		code: 'f1',
 		db: 'redundantimage',
 		tooltip: 'Any file that is a redundant copy, in the same file format and same or lower resolution, of something else on Wikipedia. Likewise, other media that is a redundant copy, in the same format and of the same or lower quality. This does not apply to files duplicated on Wikimedia Commons, because of licence issues; these should be tagged with {{subst:ncd|Image:newname.ext}} or {{subst:ncd}} instead',
 		subgroup: {
@@ -62,12 +65,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F2: Corrupt, missing, or empty file',
+		code: 'f2',
 		db: 'noimage',
 		tooltip: 'Before deleting this type of file, verify that the MediaWiki engine cannot read it by previewing a resized thumbnail of it. This also includes empty (i.e., no content) file description pages for Commons files'
 	},
 	{
 		list: 'fileList',
 		label: 'F2: Unneeded file description page for a file on Commons',
+		code: 'f2',
 		db: 'fpcfail',
 		tooltip: 'An image, hosted on Commons, but with tags or information on its English Wikipedia description page that are no longer needed. (For example, a failed featured picture candidate.)',
 		hideWhenMultiple: true
@@ -75,12 +80,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F3: Improper license',
+		code: 'f3',
 		db: 'noncom',
 		tooltip: 'Files licensed as "for non-commercial use only", "non-derivative use" or "used with permission" that were uploaded on or after 2005-05-19, except where they have been shown to comply with the limited standards for the use of non-free content. This includes files licensed under a "Non-commercial Creative Commons License". Such files uploaded before 2005-05-19 may also be speedily deleted if they are not used in any articles'
 	},
 	{
 		list: 'fileList',
 		label: 'F4: Lack of licensing information',
+		code: 'f4',
 		db: 'unksource',
 		tooltip: 'Files in category "Files with unknown source", "Files with unknown copyright status", or "Files with no copyright tag" that have been tagged with a template that places them in the category for more than seven days, regardless of when uploaded. Note, users sometimes specify their source in the upload summary, so be sure to check the circumstances of the file.',
 		hideWhenUser: true
@@ -88,13 +95,15 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F5: Unused non-free copyrighted file',
-		db: 'f5',
+		code: 'f5',
+		db: 'unfree',
 		tooltip: 'Files that are not under a free license or in the public domain that are not used in any article, whose only use is in a deleted article, and that are very unlikely to be used on any other article. Reasonable exceptions may be made for files uploaded for an upcoming article. For other unused non-free files, use the "Orphaned non-free use" option in Twinkle\'s DI tab.',
 		hideWhenUser: true
 	},
 	{
 		list: 'fileList',
 		label: 'F6: Missing fair-use rationale',
+		code: 'f6',
 		db: 'norat',
 		tooltip: 'Any file without a fair use rationale may be deleted seven days after it is uploaded.  Boilerplate fair use templates do not constitute a fair use rationale.  Files uploaded before 2006-05-04 should not be deleted immediately; instead, the uploader should be notified that a fair-use rationale is needed.  Files uploaded after 2006-05-04 can be tagged using the "No non-free use rationale" option in Twinkle\'s DI module. Such files can be found in the dated subcategories of Category:Files with no non-free use rationale.',
 		hideWhenUser: true
@@ -102,6 +111,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F7: Fair-use media from a commercial image agency which is not the subject of sourced commentary',
+		code: 'f7',
 		db: 'badfairuse',
 		tooltip: 'Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC. For cases that require a waiting period (invalid or otherwise disputed rationales or replaceable images), use the options on Twinkle\'s DI tab.',
 		subgroup: {
@@ -115,6 +125,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F8: File available as an identical or higher-resolution copy on Wikimedia Commons',
+		code: 'f8',
 		db: 'commons',
 		tooltip: 'Provided the following conditions are met: 1: The file format of both images is the same. 2: The file\'s license and source status is beyond reasonable doubt, and the license is undoubtedly accepted at Commons. 3: All information on the file description page is present on the Commons file description page. That includes the complete upload history with links to the uploader\'s local user pages. 4: The file is not protected, and the file description page does not contain a request not to move it to Commons. 5: If the file is available on Commons under a different name than locally, all local references to the file must be updated to point to the title used at Commons. 6: For {{c-uploaded}} files: They may be speedily deleted as soon as they are off the Main Page',
 		subgroup: {
@@ -129,6 +140,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F9: Unambiguous copyright infringement',
+		code: 'f9',
 		db: 'imgcopyvio',
 		tooltip: 'The file was copied from a website or other source that does not have a license compatible with Wikipedia, and the uploader neither claims fair use nor makes a credible assertion of permission of free use. Sources that do not have a license compatible with Wikipedia include stock photo libraries such as Getty Images or Corbis. Non-blatant copyright infringements should be discussed at Wikipedia:Files for deletion',
 		subgroup: [
@@ -149,6 +161,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'F11: No evidence of permission',
+		code: 'f11',
 		db: 'nopermission',
 		tooltip: 'If an uploader has specified a license and has named a third party as the source/copyright holder without providing evidence that this third party has in fact agreed, the item may be deleted seven days after notification of the uploader',
 		hideWhenUser: true
@@ -156,18 +169,21 @@ Twinkle.speedy.data = [
 	{
 		list: 'fileList',
 		label: 'G8: File description page with no corresponding file',
+		code: 'g8',
 		db: 'imagepage',
 		tooltip: 'This is only for use when the file doesn\'t exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use R4.'
 	},
 	{
 		list: 'articleList',
 		label: 'A1: No context. Articles lacking sufficient context to identify the subject of the article.',
+		code: 'a1',
 		db: 'nocontext',
 		tooltip: 'Example: "He is a funny man with a red car. He makes people laugh." This applies only to very short articles. Context is different from content, treated in A3, below.'
 	},
 	{
 		list: 'articleList',
 		label: 'A2: Foreign language articles that exist on another Wikimedia project',
+		code: 'a2',
 		db: 'foreign',
 		tooltip: 'If the article in question does not exist on another project, the template {{notenglish}} should be used instead. All articles in a non-English language that do not meet this criteria (and do not meet any other criteria for speedy deletion) should be listed at Pages Needing Translation (PNT) for review and possible translation',
 		subgroup: {
@@ -180,12 +196,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A3: No content whatsoever',
+		code: 'a3',
 		db: 'nocontent',
 		tooltip: 'Any article consisting only of links elsewhere (including hyperlinks, category tags and "see also" sections), a rephrasing of the title, and/or attempts to correspond with the person or group named by its title. This does not include disambiguation pages'
 	},
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (people, groups, companies, web content, individual animals, or organized events)',
+		code: 'a7',
 		db: 'a7',
 		tooltip: 'An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenSingle: true
@@ -193,6 +211,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (person)',
+		code: 'a7',
 		db: 'person',
 		tooltip: 'An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead',
 		hideWhenMultiple: true
@@ -200,6 +219,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (musician(s) or band)',
+		code: 'a7',
 		db: 'band',
 		tooltip: 'Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
@@ -207,6 +227,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (club, society or group)',
+		code: 'a7',
 		db: 'club',
 		tooltip: 'Article about a club, society or group that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
@@ -214,6 +235,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (company or organization)',
+		code: 'a7',
 		db: 'corp',
 		tooltip: 'Article about a company or organization that does not assert the importance or significance of the subject',
 		hideWhenMultiple: true
@@ -221,6 +243,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (website or web content)',
+		code: 'a7',
 		db: 'web',
 		tooltip: 'Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
@@ -228,6 +251,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (individual animal)',
+		code: 'a7',
 		db: 'animal',
 		tooltip: 'Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
@@ -235,6 +259,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A7: No indication of importance (organized event)',
+		code: 'a7',
 		db: 'event',
 		tooltip: 'Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject',
 		hideWhenMultiple: true
@@ -242,12 +267,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A9: Unremarkable musical recording where artist\'s article doesn\'t exist',
+		code: 'a9',
 		db: 'a9',
 		tooltip: 'An article about a musical recording which does not indicate why its subject is important or significant, and where the artist\'s article has never existed or has been deleted'
 	},
 	{
 		list: 'articleList',
 		label: 'A10: Recently created article that duplicates an existing topic',
+		code: 'a10',
 		db: 'a10',
 		tooltip: 'A recently created article with no relevant page history that does not aim to expand upon, detail or improve information within any existing article(s) on the subject, and where the title is not a plausible redirect. This does not include content forks, split pages or any article that aims at expanding or detailing an existing one.',
 		subgroup: {
@@ -259,18 +286,21 @@ Twinkle.speedy.data = [
 	{
 		list: 'articleList',
 		label: 'A11: Obviously made up by creator, and no claim of significance',
+		code: 'a11',
 		db: 'madeup',
 		tooltip: 'An article which plainly indicates that the subject was invented/coined/discovered by the article\'s creator or someone they know personally, and does not credibly indicate why its subject is important or significant'
 	},
 	{
 		list: 'categoryList',
 		label: 'C1: Empty categories',
+		code: 'c1',
 		db: 'catempty',
 		tooltip: 'Categories that have been unpopulated for at least seven days. This does not apply to categories being discussed at WP:CFD, disambiguation categories, and certain other exceptions. If the category isn\'t relatively new, it possibly contained articles earlier, and deeper investigation is needed'
 	},
 	{
 		list: 'categoryList',
 		label: 'C4: Permanently unused maintenance categories',
+		code: 'c4',
 		db: 'c4',
 		tooltip: 'Unused maintenance categories, such as empty dated maintenance categories for dates in the past, tracking categories no longer used by a template after a rewrite, or empty subcategories of Category:Wikipedia sockpuppets or Category:Suspected Wikipedia sockpuppets. Empty maintenance categories are not necessarily unused—this criterion is for categories which will always be empty, not just currently empty.',
 		subgroup: {
@@ -283,12 +313,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'templateList',
 		label: 'T5: Unused template subpages',
+		code: 't5',
 		db: 't5',
 		tooltip: 'Unused subpages of templates and Lua modules. This does not apply to /testcases and /sandbox subpages, or subpages of Module:Sandbox.'
 	},
 	{
 		list: 'userList',
 		label: 'U1: User request',
+		code: 'u1',
 		db: 'userreq',
 		tooltip: 'Personal subpages, upon request by their user. In some rare cases there may be administrative need to retain the page. Also, sometimes, main user pages may be deleted as well. See Wikipedia:User page for full instructions and guidelines',
 		subgroup: mw.config.get('wgNamespaceNumber') === 3 && !mw.config.get('wgTitle').includes('/') ? {
@@ -302,6 +334,7 @@ Twinkle.speedy.data = [
 	},
 	{
 		list: 'userList',
+		code: 'u2',
 		label: 'U2: Nonexistent user',
 		db: 'nouser',
 		tooltip: 'User pages of users that do not exist (Check Special:Listusers)'
@@ -309,6 +342,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'userList',
 		label: 'U5: A non-contributor misusing Wikipedia as a web host',
+		code: 'u5',
 		db: 'notwebhost',
 		tooltip: 'Pages in userspace consisting of writings, information, discussions, or activities not closely related to Wikipedia\'s goals, where the owner has made few or no edits outside of user pages, except for plausible drafts and pages adhering to WP:UPYES. It applies regardless of the age of the page in question.',
 		hideWhenRedirect: true
@@ -316,6 +350,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'userList',
 		label: 'G11: Promotional user page under a promotional user name',
+		code: 'g11',
 		db: 'spamuser',
 		tooltip: 'A promotional user page, with a username that promotes or implies affiliation with the thing being promoted. Note that simply having a page on a company or product in one\'s userspace does not qualify it for deletion. If a user page is spammy but the username is not, then consider tagging with regular G11 instead.',
 		hideWhenMultiple: true,
@@ -324,6 +359,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'userList',
 		label: 'G13: AfC draft submission or a blank draft, stale by over 6 months',
+		code: 'g13',
 		db: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC draft submission or a blank draft, that has not been edited in over 6 months (excluding bot edits).',
 		hideWhenMultiple: true,
@@ -332,6 +368,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G1: Patent nonsense. Pages consisting purely of incoherent text or gibberish with no meaningful content or history.',
+		code: 'g1',
 		db: 'nonsense',
 		tooltip: 'This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
@@ -339,6 +376,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G2: Test page',
+		code: 'g2',
 		db: 'test',
 		tooltip: 'A page created to test editing or other Wikipedia functions. Pages in the User namespace are not included, nor are valid but unused or duplicate templates.',
 		hideInNamespaces: [ 2 ] // Not applicable in userspace
@@ -346,12 +384,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G3: Pure vandalism',
+		code: 'g3',
 		db: 'vandalism',
 		tooltip: 'Plain pure vandalism (including redirects left behind from pagemove vandalism)'
 	},
 	{
 		list: 'generalList',
 		label: 'G3: Blatant hoax',
+		code: 'g3',
 		db: 'hoax',
 		tooltip: 'Blatant and obvious hoax, to the point of vandalism',
 		hideWhenMultiple: true
@@ -359,6 +399,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G4: Recreation of material deleted via a deletion discussion',
+		code: 'g4',
 		db: 'repost',
 		tooltip: 'A copy, by any title, of a page that was deleted via an XfD process or Deletion review, provided that the copy is substantially identical to the deleted version. This clause does not apply to content that has been "userfied", to content undeleted as a result of Deletion review, or if the prior deletions were proposed or speedy deletions, although in this last case, other speedy deletion criteria may still apply',
 		subgroup: {
@@ -372,6 +413,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G5: Created by a banned or blocked user',
+		code: 'g5',
 		db: 'banned',
 		tooltip: 'Pages created by banned or blocked users in violation of their ban or block, and which have no substantial edits by others',
 		subgroup: {
@@ -384,6 +426,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Error',
+		code: 'g6',
 		db: 'error',
 		tooltip: 'A page that was obviously created in error, or a redirect left over from moving a page that was obviously created at the wrong title.',
 		hideWhenMultiple: true
@@ -391,6 +434,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Move',
+		code: 'g6',
 		db: 'move',
 		tooltip: 'Making way for an uncontroversial move like reversing a redirect',
 		subgroup: [
@@ -411,6 +455,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: XfD',
+		code: 'g6',
 		db: 'xfd',
 		tooltip: 'A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn\'t actually deleted.',
 		subgroup: {
@@ -425,6 +470,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: AfC move',
+		code: 'g6',
 		db: 'afc-move',
 		tooltip: 'Making way for acceptance of a draft submitted to AfC',
 		subgroup: {
@@ -437,6 +483,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Copy-and-paste page move',
+		code: 'g6',
 		db: 'copypaste',
 		tooltip: 'This only applies for a copy-and-paste page move of another page that needs to be temporarily deleted to make room for a clean page move.',
 		subgroup: {
@@ -449,6 +496,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G6: Housekeeping and non-controversial cleanup',
+		code: 'g6',
 		db: 'g6',
 		tooltip: 'Other routine maintenance tasks',
 		subgroup: {
@@ -461,6 +509,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G7: Author requests deletion, or author blanked',
+		code: 'g7',
 		db: 'author',
 		tooltip: 'Any page for which deletion is requested by the original author in good faith, provided the page\'s only substantial content was added by its author. If the author blanks the page, this can also be taken as a deletion request.',
 		subgroup: {
@@ -475,6 +524,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G8: Pages dependent on a non-existent or deleted page',
+		code: 'g8',
 		db: 'g8',
 		tooltip: 'such as talk pages with no corresponding subject page; subpages with no parent page; file pages without a corresponding file; redirects to non-existent targets; or categories populated by deleted or retargeted templates. This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		subgroup: {
@@ -488,6 +538,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G8: Subpages with no parent page',
+		code: 'g8',
 		db: 'subpage',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true,
@@ -496,12 +547,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G10: Attack page',
+		code: 'g10',
 		db: 'attack',
 		tooltip: 'Pages that serve no purpose but to disparage or threaten their subject or some other entity (e.g., "John Q. Doe is an imbecile"). This includes a biography of a living person that is negative in tone and unsourced, where there is no NPOV version in the history to revert to. Administrators deleting such pages should not quote the content of the page in the deletion summary!'
 	},
 	{
 		list: 'generalList',
 		label: 'G10: Wholly negative, unsourced BLP',
+		code: 'g10',
 		db: 'negublp',
 		tooltip: 'A biography of a living person that is entirely negative in tone and unsourced, where there is no neutral version in the history to revert to.',
 		hideWhenMultiple: true
@@ -509,12 +562,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G11: Unambiguous advertising or promotion',
+		code: 'g11',
 		db: 'spam',
 		tooltip: 'Pages which exclusively promote a company, product, group, service, or person and which would need to be fundamentally rewritten in order to become encyclopedic. Note that an article about a company or a product which describes its subject from a neutral point of view does not qualify for this criterion; an article that is blatant advertising should have inappropriate content as well'
 	},
 	{
 		list: 'generalList',
 		label: 'G12: Unambiguous copyright infringement',
+		code: 'g12',
 		db: 'copyvio',
 		tooltip: 'Either: (1) Material was copied from another website that does not have a license compatible with Wikipedia, or is photography from a stock photo seller (such as Getty Images or Corbis) or other commercial content provider; (2) There is no non-infringing content in the page history worth saving; or (3) The infringement was introduced at once by a single person rather than created organically on wiki and then copied by another website such as one of the many Wikipedia mirrors',
 		subgroup: [
@@ -544,6 +599,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G13: Page in draft namespace or userspace AfC submission, stale by over 6 months',
+		code: 'g13',
 		db: 'afc',
 		tooltip: 'Any rejected or unsubmitted AfC submission in userspace or any non-redirect page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.',
 		hideWhenRedirect: true,
@@ -552,12 +608,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'generalList',
 		label: 'G14: Unnecessary disambiguation page',
+		code: 'g14',
 		db: 'disambig',
 		tooltip: 'This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)'
 	},
 	{
 		list: 'redirectList',
 		label: 'R2: Redirect from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces',
+		code: 'r2',
 		db: 'rediruser',
 		tooltip: 'This does not include the pseudo-namespace shortcuts. If this was the result of a page move, consider waiting a day or two before deleting the redirect',
 		showInNamespaces: [ 0 ]
@@ -565,12 +623,14 @@ Twinkle.speedy.data = [
 	{
 		list: 'redirectList',
 		label: 'R3: Recently created redirect from an implausible typo or misnomer',
+		code: 'r3',
 		db: 'redirtypo',
 		tooltip: 'However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages'
 	},
 	{
 		list: 'redirectList',
 		label: 'R4: File namespace redirect with a name that matches a Commons page',
+		code: 'r4',
 		db: 'redircom',
 		tooltip: 'The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).',
 		showInNamespaces: [ 6 ]
@@ -578,6 +638,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'redirectList',
 		label: 'G6: Redirect to malplaced disambiguation page',
+		code: 'g6',
 		db: 'movedab',
 		tooltip: 'This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.',
 		hideWhenMultiple: true
@@ -585,6 +646,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'redirectList',
 		label: 'G8: Redirects to non-existent targets',
+		code: 'g8',
 		db: 'redirnone',
 		tooltip: 'This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.',
 		hideWhenMultiple: true
@@ -592,6 +654,7 @@ Twinkle.speedy.data = [
 	{
 		list: 'redirectList',
 		label: 'X3: Redirects with no space before a parenthetical disambiguation',
+		code: 'x3',
 		db: 'x3',
 		tooltip: 'This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).'
 	}
@@ -607,6 +670,7 @@ Twinkle.speedy.getCsdList = ( csdList ) => {
 			const copy = Object.assign({}, item);
 			// Change some things to match the old spec, from before I refactored this.
 			delete copy.list;
+			delete copy.code;
 			copy.value = copy.db;
 			delete copy.db;
 			list.push(copy);
@@ -625,71 +689,23 @@ Twinkle.speedy.userList = Twinkle.speedy.getCsdList( 'userList' );
 Twinkle.speedy.generalList = Twinkle.speedy.getCsdList( 'generalList' );
 Twinkle.speedy.redirectList = Twinkle.speedy.getCsdList( 'redirectList' );
 
-Twinkle.speedy.normalizeHash = {
-	reason: 'db',
-	nocontext: 'a1',
-	foreign: 'a2',
-	nocontent: 'a3',
-	a7: 'a7',
-	person: 'a7',
-	corp: 'a7',
-	web: 'a7',
-	band: 'a7',
-	club: 'a7',
-	animal: 'a7',
-	event: 'a7',
-	a9: 'a9',
-	a10: 'a10',
-	madeup: 'a11',
-	catempty: 'c1',
-	c4: 'c4',
-	redundantimage: 'f1',
-	noimage: 'f2',
-	fpcfail: 'f2',
-	noncom: 'f3',
-	unksource: 'f4',
-	unfree: 'f5',
-	f5: 'f5',
-	norat: 'f6',
-	badfairuse: 'f7',
-	commons: 'f8',
-	imgcopyvio: 'f9',
-	nopermission: 'f11',
-	nonsense: 'g1',
-	test: 'g2',
-	vandalism: 'g3',
-	hoax: 'g3',
-	repost: 'g4',
-	banned: 'g5',
-	error: 'g6',
-	move: 'g6',
-	'afc-move': 'g6',
-	xfd: 'g6',
-	movedab: 'g6',
-	copypaste: 'g6',
-	g6: 'g6',
-	author: 'g7',
-	g8: 'g8',
-	talk: 'g8',
-	subpage: 'g8',
-	redirnone: 'g8',
-	imagepage: 'g8',
-	attack: 'g10',
-	negublp: 'g10',
-	spam: 'g11',
-	spamuser: 'g11',
-	copyvio: 'g12',
-	afc: 'g13',
-	disambig: 'g14',
-	rediruser: 'r2',
-	redirtypo: 'r3',
-	redircom: 'r4',
-	t5: 't5',
-	userreq: 'u1',
-	nouser: 'u2',
-	notwebhost: 'u5',
-	x3: 'x3'
+/**
+ * Iterate over Twinkle.speedy.data. Turn `code: 'g8', db: 'redirnone',` into `redirnone: 'g8',`
+ */
+Twinkle.speedy.getNormalizeHash = () => {
+	const hash = {};
+	for (const item of Twinkle.speedy.data) {
+		if (item.code && item.db) {
+			hash[item.db] = item.code;
+		}
+	}
+	return hash;
 };
+
+/**
+ * This is a map of Db-word templates to CSD codes such as a1. For example, `"nocontext": "a1"`
+ */
+Twinkle.speedy.normalizeHash = Twinkle.speedy.getNormalizeHash();
 
 // This function is run when the CSD tab/header link is clicked
 Twinkle.speedy.callback = function twinklespeedyCallback() {

--- a/tests/.eslintrc.json
+++ b/tests/.eslintrc.json
@@ -18,6 +18,7 @@
 	"rules": {
 		"array-bracket-spacing": "off",
 		"computed-property-spacing": "off",
+		"max-len": "off",
 		"no-shadow": "off",
 		"object-curly-spacing": "off",
 		"space-in-parens": "off"

--- a/tests/__snapshots__/twinklespeedy.test.js.snap
+++ b/tests/__snapshots__/twinklespeedy.test.js.snap
@@ -616,7 +616,6 @@ exports[`modules/twinkleblock Twinkle.speedy global variables Should match snaps
   "t5": "t5",
   "talk": "g8",
   "test": "g2",
-  "unfree": "f5",
   "unksource": "f4",
   "userreq": "u1",
   "vandalism": "g3",

--- a/tests/__snapshots__/twinklespeedy.test.js.snap
+++ b/tests/__snapshots__/twinklespeedy.test.js.snap
@@ -1,0 +1,627 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 1`] = `
+[
+  {
+    "hideWhenMultiple": true,
+    "label": "Custom rationale (custom deletion reason)",
+    "subgroup": {
+      "label": "Rationale:",
+      "name": "reason_1",
+      "size": 60,
+      "type": "input",
+    },
+    "tooltip": "{{db}} is short for "delete because". At least one of the other deletion criteria must still apply to the page, and you must make mention of this in your rationale. This is not a "catch-all" for when you can't find any criteria that fit.",
+    "value": "reason",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 2`] = `
+[
+  {
+    "label": "G8: Talk pages with no corresponding subject page",
+    "tooltip": "This excludes any page that is useful to the project - in particular, user talk pages, talk page archives, and talk pages for files that exist on Wikimedia Commons.",
+    "value": "talk",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 3`] = `
+[
+  {
+    "label": "F1: Redundant file",
+    "subgroup": {
+      "label": "File this is redundant to:",
+      "name": "redundantimage_filename",
+      "tooltip": "The "File:" prefix can be left off.",
+      "type": "input",
+    },
+    "tooltip": "Any file that is a redundant copy, in the same file format and same or lower resolution, of something else on Wikipedia. Likewise, other media that is a redundant copy, in the same format and of the same or lower quality. This does not apply to files duplicated on Wikimedia Commons, because of licence issues; these should be tagged with {{subst:ncd|Image:newname.ext}} or {{subst:ncd}} instead",
+    "value": "redundantimage",
+  },
+  {
+    "label": "F2: Corrupt, missing, or empty file",
+    "tooltip": "Before deleting this type of file, verify that the MediaWiki engine cannot read it by previewing a resized thumbnail of it. This also includes empty (i.e., no content) file description pages for Commons files",
+    "value": "noimage",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "F2: Unneeded file description page for a file on Commons",
+    "tooltip": "An image, hosted on Commons, but with tags or information on its English Wikipedia description page that are no longer needed. (For example, a failed featured picture candidate.)",
+    "value": "fpcfail",
+  },
+  {
+    "label": "F3: Improper license",
+    "tooltip": "Files licensed as "for non-commercial use only", "non-derivative use" or "used with permission" that were uploaded on or after 2005-05-19, except where they have been shown to comply with the limited standards for the use of non-free content. This includes files licensed under a "Non-commercial Creative Commons License". Such files uploaded before 2005-05-19 may also be speedily deleted if they are not used in any articles",
+    "value": "noncom",
+  },
+  {
+    "hideWhenUser": true,
+    "label": "F4: Lack of licensing information",
+    "tooltip": "Files in category "Files with unknown source", "Files with unknown copyright status", or "Files with no copyright tag" that have been tagged with a template that places them in the category for more than seven days, regardless of when uploaded. Note, users sometimes specify their source in the upload summary, so be sure to check the circumstances of the file.",
+    "value": "unksource",
+  },
+  {
+    "hideWhenUser": true,
+    "label": "F5: Unused non-free copyrighted file",
+    "tooltip": "Files that are not under a free license or in the public domain that are not used in any article, whose only use is in a deleted article, and that are very unlikely to be used on any other article. Reasonable exceptions may be made for files uploaded for an upcoming article. For other unused non-free files, use the "Orphaned non-free use" option in Twinkle's DI tab.",
+    "value": "f5",
+  },
+  {
+    "hideWhenUser": true,
+    "label": "F6: Missing fair-use rationale",
+    "tooltip": "Any file without a fair use rationale may be deleted seven days after it is uploaded.  Boilerplate fair use templates do not constitute a fair use rationale.  Files uploaded before 2006-05-04 should not be deleted immediately; instead, the uploader should be notified that a fair-use rationale is needed.  Files uploaded after 2006-05-04 can be tagged using the "No non-free use rationale" option in Twinkle's DI module. Such files can be found in the dated subcategories of Category:Files with no non-free use rationale.",
+    "value": "norat",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "F7: Fair-use media from a commercial image agency which is not the subject of sourced commentary",
+    "subgroup": {
+      "label": "Optional explanation:",
+      "name": "badfairuse_rationale",
+      "size": 60,
+      "type": "input",
+    },
+    "tooltip": "Non-free images or media from a commercial source (e.g., Associated Press, Getty), where the file itself is not the subject of sourced commentary, are considered an invalid claim of fair use and fail the strict requirements of WP:NFCC. For cases that require a waiting period (invalid or otherwise disputed rationales or replaceable images), use the options on Twinkle's DI tab.",
+    "value": "badfairuse",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "F8: File available as an identical or higher-resolution copy on Wikimedia Commons",
+    "subgroup": {
+      "label": "Filename on Commons:",
+      "name": "commons_filename",
+      "tooltip": "This can be left blank if the file has the same name on Commons as here. The "File:" prefix is optional.",
+      "type": "input",
+      "value": "Macbeth, King of Scotland",
+    },
+    "tooltip": "Provided the following conditions are met: 1: The file format of both images is the same. 2: The file's license and source status is beyond reasonable doubt, and the license is undoubtedly accepted at Commons. 3: All information on the file description page is present on the Commons file description page. That includes the complete upload history with links to the uploader's local user pages. 4: The file is not protected, and the file description page does not contain a request not to move it to Commons. 5: If the file is available on Commons under a different name than locally, all local references to the file must be updated to point to the title used at Commons. 6: For {{c-uploaded}} files: They may be speedily deleted as soon as they are off the Main Page",
+    "value": "commons",
+  },
+  {
+    "label": "F9: Unambiguous copyright infringement",
+    "subgroup": [
+      {
+        "label": "URL of the copyvio, including the "http://".  If the copyvio is of a non-internet source and you cannot provide a URL, you must use the deletion rationale box.",
+        "name": "imgcopyvio_url",
+        "size": 60,
+        "type": "input",
+      },
+      {
+        "label": "Deletion rationale for non-internet copyvios:",
+        "name": "imgcopyvio_rationale",
+        "size": 60,
+        "type": "input",
+      },
+    ],
+    "tooltip": "The file was copied from a website or other source that does not have a license compatible with Wikipedia, and the uploader neither claims fair use nor makes a credible assertion of permission of free use. Sources that do not have a license compatible with Wikipedia include stock photo libraries such as Getty Images or Corbis. Non-blatant copyright infringements should be discussed at Wikipedia:Files for deletion",
+    "value": "imgcopyvio",
+  },
+  {
+    "hideWhenUser": true,
+    "label": "F11: No evidence of permission",
+    "tooltip": "If an uploader has specified a license and has named a third party as the source/copyright holder without providing evidence that this third party has in fact agreed, the item may be deleted seven days after notification of the uploader",
+    "value": "nopermission",
+  },
+  {
+    "label": "G8: File description page with no corresponding file",
+    "tooltip": "This is only for use when the file doesn't exist at all. Corrupt files, and local description pages for files on Commons, should use F2; implausible redirects should use R3; and broken Commons redirects should use R4.",
+    "value": "imagepage",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 4`] = `
+[
+  {
+    "label": "A1: No context. Articles lacking sufficient context to identify the subject of the article.",
+    "tooltip": "Example: "He is a funny man with a red car. He makes people laugh." This applies only to very short articles. Context is different from content, treated in A3, below.",
+    "value": "nocontext",
+  },
+  {
+    "label": "A2: Foreign language articles that exist on another Wikimedia project",
+    "subgroup": {
+      "label": "Interwiki link to the article on the foreign-language wiki:",
+      "name": "foreign_source",
+      "tooltip": "For example, fr:Bonjour",
+      "type": "input",
+    },
+    "tooltip": "If the article in question does not exist on another project, the template {{notenglish}} should be used instead. All articles in a non-English language that do not meet this criteria (and do not meet any other criteria for speedy deletion) should be listed at Pages Needing Translation (PNT) for review and possible translation",
+    "value": "foreign",
+  },
+  {
+    "label": "A3: No content whatsoever",
+    "tooltip": "Any article consisting only of links elsewhere (including hyperlinks, category tags and "see also" sections), a rephrasing of the title, and/or attempts to correspond with the person or group named by its title. This does not include disambiguation pages",
+    "value": "nocontent",
+  },
+  {
+    "hideWhenSingle": true,
+    "label": "A7: No indication of importance (people, groups, companies, web content, individual animals, or organized events)",
+    "tooltip": "An article about a real person, group of people, band, club, company, web content, individual animal, tour, or party that does not assert the importance or significance of its subject. If controversial, or if a previous AfD has resulted in the article being kept, the article should be nominated for AfD instead",
+    "value": "a7",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (person)",
+    "tooltip": "An article about a real person that does not assert the importance or significance of its subject. If controversial, or if there has been a previous AfD that resulted in the article being kept, the article should be nominated for AfD instead",
+    "value": "person",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (musician(s) or band)",
+    "tooltip": "Article about a band, singer, musician, or musical ensemble that does not assert the importance or significance of the subject",
+    "value": "band",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (club, society or group)",
+    "tooltip": "Article about a club, society or group that does not assert the importance or significance of the subject",
+    "value": "club",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (company or organization)",
+    "tooltip": "Article about a company or organization that does not assert the importance or significance of the subject",
+    "value": "corp",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (website or web content)",
+    "tooltip": "Article about a web site, blog, online forum, webcomic, podcast, or similar web content that does not assert the importance or significance of its subject",
+    "value": "web",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (individual animal)",
+    "tooltip": "Article about an individual animal (e.g. pet) that does not assert the importance or significance of its subject",
+    "value": "animal",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "A7: No indication of importance (organized event)",
+    "tooltip": "Article about an organized event (tour, function, meeting, party, etc.) that does not assert the importance or significance of its subject",
+    "value": "event",
+  },
+  {
+    "label": "A9: Unremarkable musical recording where artist's article doesn't exist",
+    "tooltip": "An article about a musical recording which does not indicate why its subject is important or significant, and where the artist's article has never existed or has been deleted",
+    "value": "a9",
+  },
+  {
+    "label": "A10: Recently created article that duplicates an existing topic",
+    "subgroup": {
+      "label": "Article that is duplicated:",
+      "name": "a10_article",
+      "type": "input",
+    },
+    "tooltip": "A recently created article with no relevant page history that does not aim to expand upon, detail or improve information within any existing article(s) on the subject, and where the title is not a plausible redirect. This does not include content forks, split pages or any article that aims at expanding or detailing an existing one.",
+    "value": "a10",
+  },
+  {
+    "label": "A11: Obviously made up by creator, and no claim of significance",
+    "tooltip": "An article which plainly indicates that the subject was invented/coined/discovered by the article's creator or someone they know personally, and does not credibly indicate why its subject is important or significant",
+    "value": "madeup",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 5`] = `
+[
+  {
+    "label": "C1: Empty categories",
+    "tooltip": "Categories that have been unpopulated for at least seven days. This does not apply to categories being discussed at WP:CFD, disambiguation categories, and certain other exceptions. If the category isn't relatively new, it possibly contained articles earlier, and deeper investigation is needed",
+    "value": "catempty",
+  },
+  {
+    "label": "C4: Permanently unused maintenance categories",
+    "subgroup": {
+      "label": "Optional explanation:",
+      "name": "c4_rationale",
+      "size": 60,
+      "type": "input",
+    },
+    "tooltip": "Unused maintenance categories, such as empty dated maintenance categories for dates in the past, tracking categories no longer used by a template after a rewrite, or empty subcategories of Category:Wikipedia sockpuppets or Category:Suspected Wikipedia sockpuppets. Empty maintenance categories are not necessarily unused—this criterion is for categories which will always be empty, not just currently empty.",
+    "value": "c4",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 6`] = `
+[
+  {
+    "label": "T5: Unused template subpages",
+    "tooltip": "Unused subpages of templates and Lua modules. This does not apply to /testcases and /sandbox subpages, or subpages of Module:Sandbox.",
+    "value": "t5",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 7`] = `
+[
+  {
+    "hideSubgroupWhenMultiple": true,
+    "label": "U1: User request",
+    "subgroup": null,
+    "tooltip": "Personal subpages, upon request by their user. In some rare cases there may be administrative need to retain the page. Also, sometimes, main user pages may be deleted as well. See Wikipedia:User page for full instructions and guidelines",
+    "value": "userreq",
+  },
+  {
+    "label": "U2: Nonexistent user",
+    "tooltip": "User pages of users that do not exist (Check Special:Listusers)",
+    "value": "nouser",
+  },
+  {
+    "hideWhenRedirect": true,
+    "label": "U5: A non-contributor misusing Wikipedia as a web host",
+    "tooltip": "Pages in userspace consisting of writings, information, discussions, or activities not closely related to Wikipedia's goals, where the owner has made few or no edits outside of user pages, except for plausible drafts and pages adhering to WP:UPYES. It applies regardless of the age of the page in question.",
+    "value": "notwebhost",
+  },
+  {
+    "hideWhenMultiple": true,
+    "hideWhenRedirect": true,
+    "label": "G11: Promotional user page under a promotional user name",
+    "tooltip": "A promotional user page, with a username that promotes or implies affiliation with the thing being promoted. Note that simply having a page on a company or product in one's userspace does not qualify it for deletion. If a user page is spammy but the username is not, then consider tagging with regular G11 instead.",
+    "value": "spamuser",
+  },
+  {
+    "hideWhenMultiple": true,
+    "hideWhenRedirect": true,
+    "label": "G13: AfC draft submission or a blank draft, stale by over 6 months",
+    "tooltip": "Any rejected or unsubmitted AfC draft submission or a blank draft, that has not been edited in over 6 months (excluding bot edits).",
+    "value": "afc",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 8`] = `
+[
+  {
+    "hideInNamespaces": [
+      2,
+    ],
+    "label": "G1: Patent nonsense. Pages consisting purely of incoherent text or gibberish with no meaningful content or history.",
+    "tooltip": "This does not include poor writing, partisan screeds, obscene remarks, vandalism, fictional material, material not in English, poorly translated material, implausible theories, or hoaxes. In short, if you can understand it, G1 does not apply.",
+    "value": "nonsense",
+  },
+  {
+    "hideInNamespaces": [
+      2,
+    ],
+    "label": "G2: Test page",
+    "tooltip": "A page created to test editing or other Wikipedia functions. Pages in the User namespace are not included, nor are valid but unused or duplicate templates.",
+    "value": "test",
+  },
+  {
+    "label": "G3: Pure vandalism",
+    "tooltip": "Plain pure vandalism (including redirects left behind from pagemove vandalism)",
+    "value": "vandalism",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G3: Blatant hoax",
+    "tooltip": "Blatant and obvious hoax, to the point of vandalism",
+    "value": "hoax",
+  },
+  {
+    "label": "G4: Recreation of material deleted via a deletion discussion",
+    "subgroup": {
+      "label": "Page where the deletion discussion took place:",
+      "name": "repost_xfd",
+      "size": 60,
+      "tooltip": "Must start with "Wikipedia:"",
+      "type": "input",
+    },
+    "tooltip": "A copy, by any title, of a page that was deleted via an XfD process or Deletion review, provided that the copy is substantially identical to the deleted version. This clause does not apply to content that has been "userfied", to content undeleted as a result of Deletion review, or if the prior deletions were proposed or speedy deletions, although in this last case, other speedy deletion criteria may still apply",
+    "value": "repost",
+  },
+  {
+    "label": "G5: Created by a banned or blocked user",
+    "subgroup": {
+      "label": "Username of banned user (if available):",
+      "name": "banned_user",
+      "tooltip": "Should not start with "User:"",
+      "type": "input",
+    },
+    "tooltip": "Pages created by banned or blocked users in violation of their ban or block, and which have no substantial edits by others",
+    "value": "banned",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: Error",
+    "tooltip": "A page that was obviously created in error, or a redirect left over from moving a page that was obviously created at the wrong title.",
+    "value": "error",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: Move",
+    "subgroup": [
+      {
+        "label": "Page to be moved here:",
+        "name": "move_page",
+        "type": "input",
+      },
+      {
+        "label": "Reason:",
+        "name": "move_reason",
+        "size": 60,
+        "type": "input",
+      },
+    ],
+    "tooltip": "Making way for an uncontroversial move like reversing a redirect",
+    "value": "move",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: XfD",
+    "subgroup": {
+      "label": "Page where the deletion discussion was held:",
+      "name": "xfd_fullvotepage",
+      "size": 40,
+      "tooltip": "Must start with "Wikipedia:"",
+      "type": "input",
+    },
+    "tooltip": "A deletion discussion (at AfD, FfD, RfD, TfD, CfD, or MfD) was closed as "delete", but the page wasn't actually deleted.",
+    "value": "xfd",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: AfC move",
+    "subgroup": {
+      "label": "Draft to be moved here:",
+      "name": "draft_page",
+      "type": "input",
+    },
+    "tooltip": "Making way for acceptance of a draft submitted to AfC",
+    "value": "afc-move",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: Copy-and-paste page move",
+    "subgroup": {
+      "label": "Original page that was copy-pasted here:",
+      "name": "copypaste_sourcepage",
+      "type": "input",
+    },
+    "tooltip": "This only applies for a copy-and-paste page move of another page that needs to be temporarily deleted to make room for a clean page move.",
+    "value": "copypaste",
+  },
+  {
+    "label": "G6: Housekeeping and non-controversial cleanup",
+    "subgroup": {
+      "label": "Rationale:",
+      "name": "g6_rationale",
+      "size": 60,
+      "type": "input",
+    },
+    "tooltip": "Other routine maintenance tasks",
+    "value": "g6",
+  },
+  {
+    "hideSubgroupWhenSysop": true,
+    "label": "G7: Author requests deletion, or author blanked",
+    "subgroup": {
+      "label": "Optional explanation:",
+      "name": "author_rationale",
+      "size": 60,
+      "tooltip": "Perhaps linking to where the author requested this deletion.",
+      "type": "input",
+    },
+    "tooltip": "Any page for which deletion is requested by the original author in good faith, provided the page's only substantial content was added by its author. If the author blanks the page, this can also be taken as a deletion request.",
+    "value": "author",
+  },
+  {
+    "hideSubgroupWhenSysop": true,
+    "label": "G8: Pages dependent on a non-existent or deleted page",
+    "subgroup": {
+      "label": "Optional explanation:",
+      "name": "g8_rationale",
+      "size": 60,
+      "type": "input",
+    },
+    "tooltip": "such as talk pages with no corresponding subject page; subpages with no parent page; file pages without a corresponding file; redirects to non-existent targets; or categories populated by deleted or retargeted templates. This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.",
+    "value": "g8",
+  },
+  {
+    "hideInNamespaces": [
+      0,
+      6,
+      8,
+    ],
+    "hideWhenMultiple": true,
+    "label": "G8: Subpages with no parent page",
+    "tooltip": "This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.",
+    "value": "subpage",
+  },
+  {
+    "label": "G10: Attack page",
+    "tooltip": "Pages that serve no purpose but to disparage or threaten their subject or some other entity (e.g., "John Q. Doe is an imbecile"). This includes a biography of a living person that is negative in tone and unsourced, where there is no NPOV version in the history to revert to. Administrators deleting such pages should not quote the content of the page in the deletion summary!",
+    "value": "attack",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G10: Wholly negative, unsourced BLP",
+    "tooltip": "A biography of a living person that is entirely negative in tone and unsourced, where there is no neutral version in the history to revert to.",
+    "value": "negublp",
+  },
+  {
+    "label": "G11: Unambiguous advertising or promotion",
+    "tooltip": "Pages which exclusively promote a company, product, group, service, or person and which would need to be fundamentally rewritten in order to become encyclopedic. Note that an article about a company or a product which describes its subject from a neutral point of view does not qualify for this criterion; an article that is blatant advertising should have inappropriate content as well",
+    "value": "spam",
+  },
+  {
+    "label": "G12: Unambiguous copyright infringement",
+    "subgroup": [
+      {
+        "label": "URL (if available):",
+        "name": "copyvio_url",
+        "size": 60,
+        "tooltip": "If the material was copied from an online source, put the URL here, including the "http://" or "https://" protocol.",
+        "type": "input",
+      },
+      {
+        "label": "Additional URL:",
+        "name": "copyvio_url2",
+        "size": 60,
+        "tooltip": "Optional. Should begin with "http://" or "https://"",
+        "type": "input",
+      },
+      {
+        "label": "Additional URL:",
+        "name": "copyvio_url3",
+        "size": 60,
+        "tooltip": "Optional. Should begin with "http://" or "https://"",
+        "type": "input",
+      },
+    ],
+    "tooltip": "Either: (1) Material was copied from another website that does not have a license compatible with Wikipedia, or is photography from a stock photo seller (such as Getty Images or Corbis) or other commercial content provider; (2) There is no non-infringing content in the page history worth saving; or (3) The infringement was introduced at once by a single person rather than created organically on wiki and then copied by another website such as one of the many Wikipedia mirrors",
+    "value": "copyvio",
+  },
+  {
+    "hideWhenRedirect": true,
+    "label": "G13: Page in draft namespace or userspace AfC submission, stale by over 6 months",
+    "showInNamespaces": [
+      2,
+      118,
+    ],
+    "tooltip": "Any rejected or unsubmitted AfC submission in userspace or any non-redirect page in draft namespace, that has not been edited for more than 6 months. Blank drafts in either namespace are also included.",
+    "value": "afc",
+  },
+  {
+    "label": "G14: Unnecessary disambiguation page",
+    "tooltip": "This only applies for orphaned disambiguation pages which either: (1) disambiguate only one existing Wikipedia page and whose title ends in "(disambiguation)" (i.e., there is a primary topic); or (2) disambiguate no (zero) existing Wikipedia pages, regardless of its title.  It also applies to orphan "Foo (disambiguation)" redirects that target pages that are not disambiguation or similar disambiguation-like pages (such as set index articles or lists)",
+    "value": "disambig",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 9`] = `
+[
+  {
+    "label": "R2: Redirect from mainspace to any other namespace except the Category:, Template:, Wikipedia:, Help: and Portal: namespaces",
+    "showInNamespaces": [
+      0,
+    ],
+    "tooltip": "This does not include the pseudo-namespace shortcuts. If this was the result of a page move, consider waiting a day or two before deleting the redirect",
+    "value": "rediruser",
+  },
+  {
+    "label": "R3: Recently created redirect from an implausible typo or misnomer",
+    "tooltip": "However, redirects from common misspellings or misnomers are generally useful, as are redirects in other languages",
+    "value": "redirtypo",
+  },
+  {
+    "label": "R4: File namespace redirect with a name that matches a Commons page",
+    "showInNamespaces": [
+      6,
+    ],
+    "tooltip": "The redirect should have no incoming links (unless the links are cleary intended for the file or redirect at Commons).",
+    "value": "redircom",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G6: Redirect to malplaced disambiguation page",
+    "tooltip": "This only applies for redirects to disambiguation pages ending in (disambiguation) where a primary topic does not exist.",
+    "value": "movedab",
+  },
+  {
+    "hideWhenMultiple": true,
+    "label": "G8: Redirects to non-existent targets",
+    "tooltip": "This excludes any page that is useful to the project, and in particular: deletion discussions that are not logged elsewhere, user and user talk pages, talk page archives, plausible redirects that can be changed to valid targets, and file pages or talk pages for files that exist on Wikimedia Commons.",
+    "value": "redirnone",
+  },
+  {
+    "label": "X3: Redirects with no space before a parenthetical disambiguation",
+    "tooltip": "This excludes terms that can plausibly be searched for without spaces, or if the redirect contains substantive page history (e.g. from a merge).",
+    "value": "x3",
+  },
+]
+`;
+
+exports[`modules/twinkleblock Twinkle.speedy global variables Should match snapshot 10`] = `
+{
+  "a10": "a10",
+  "a7": "a7",
+  "a9": "a9",
+  "afc": "g13",
+  "afc-move": "g6",
+  "animal": "a7",
+  "attack": "g10",
+  "author": "g7",
+  "badfairuse": "f7",
+  "band": "a7",
+  "banned": "g5",
+  "c4": "c4",
+  "catempty": "c1",
+  "club": "a7",
+  "commons": "f8",
+  "copypaste": "g6",
+  "copyvio": "g12",
+  "corp": "a7",
+  "disambig": "g14",
+  "error": "g6",
+  "event": "a7",
+  "f5": "f5",
+  "foreign": "a2",
+  "fpcfail": "f2",
+  "g6": "g6",
+  "g8": "g8",
+  "hoax": "g3",
+  "imagepage": "g8",
+  "imgcopyvio": "f9",
+  "madeup": "a11",
+  "move": "g6",
+  "movedab": "g6",
+  "negublp": "g10",
+  "nocontent": "a3",
+  "nocontext": "a1",
+  "noimage": "f2",
+  "noncom": "f3",
+  "nonsense": "g1",
+  "nopermission": "f11",
+  "norat": "f6",
+  "notwebhost": "u5",
+  "nouser": "u2",
+  "person": "a7",
+  "reason": "db",
+  "redircom": "r4",
+  "redirnone": "g8",
+  "redirtypo": "r3",
+  "rediruser": "r2",
+  "redundantimage": "f1",
+  "repost": "g4",
+  "spam": "g11",
+  "spamuser": "g11",
+  "subpage": "g8",
+  "t5": "t5",
+  "talk": "g8",
+  "test": "g2",
+  "unfree": "f5",
+  "unksource": "f4",
+  "userreq": "u1",
+  "vandalism": "g3",
+  "web": "a7",
+  "x3": "x3",
+  "xfd": "g6",
+}
+`;

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -9,6 +9,7 @@ mw.config.set({
 require('../morebits.js');
 require('../twinkle.js');
 require('../modules/twinkleblock.js');
+require('../modules/twinklespeedy.js');
 require('../modules/twinkletag.js');
 require('../modules/twinklewarn.js');
 require('../modules/twinklexfd.js');

--- a/tests/twinklespeedy.test.js
+++ b/tests/twinklespeedy.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+describe('modules/twinkleblock', () => {
+	describe('Twinkle.speedy global variables', () => {
+		test('Should match snapshot', () => {
+			expect(Twinkle.speedy.customRationale).toMatchSnapshot();
+			expect(Twinkle.speedy.talkList).toMatchSnapshot();
+			expect(Twinkle.speedy.fileList).toMatchSnapshot();
+			expect(Twinkle.speedy.articleList).toMatchSnapshot();
+			expect(Twinkle.speedy.categoryList).toMatchSnapshot();
+			expect(Twinkle.speedy.templateList).toMatchSnapshot();
+			expect(Twinkle.speedy.userList).toMatchSnapshot();
+			expect(Twinkle.speedy.generalList).toMatchSnapshot();
+			expect(Twinkle.speedy.redirectList).toMatchSnapshot();
+			expect(Twinkle.speedy.normalizeHash).toMatchSnapshot();
+		});
+	});
+});


### PR DESCRIPTION
related #2199 refactor CSD code to make it easy to add CSDs

First of several patches. End goal is to make it so that to add/edit/remove a CSD, you only have to edit one spot in the code, instead of a bunch of different spots. This spot is in JSON format.

- move "lists" (e.g. fileList, redirectList, etc.) into Twinkle.speedy.data
- move normalizeHash into Twinkle.speedy.data
- add snapshot tests (this will ensure we don't break anything with our refactoring. may remove later)
- remove `"unfree": "f5"` from snapshot since Template:Db-unfree is a disambiguation page
- update readme to reflect these changes
- mention `Twinkle.speedy.getParameters()` in readme
- turn off eslint max-len for jest tests