### PR TITLE
warn: add {{uw-orphantalk}}

### DIFF
--- a/modules/twinklewarn.js
+++ b/modules/twinklewarn.js
@@ -1165,6 +1165,10 @@ Twinkle.warn.messages = {
 			label: 'We use consensus, not voting',
 			summary: 'Notice: We use consensus, not voting'
 		},
+		'uw-orphantalk': {
+			label: 'Talk page created with no article',
+			summary: 'Notice: Talk page created with no article'
+		},
 		'uw-plagiarism': {
 			label: 'Copying from public domain sources without attribution',
 			summary: 'Notice: Copying from public domain sources without attribution'


### PR DESCRIPTION
This adds a warning for following-up on a G8 deletion of a mainspace talk page created that had no article. It's intended for the circumstance where there wasn't enough content to justify for example moving to draftspace, but you want to let the editor know why it was marked for deletion.

This is intentionally not done as part of notifying a user of a CSD because 1) from what I can tell there's some hardcoding there to use the much more aggressive db-reason-notice styled templates and 2) because personal preference in how I've used this warning template since I've added it to my config.