### PR TITLE
warn: change misleading {{Uw-login}} label and summary

### DIFF
--- a/src/modules/twinklewarn.js
+++ b/src/modules/twinklewarn.js
@@ -1354,8 +1354,8 @@ Twinkle.warn.messages = {
 			summary: 'Warning: Making legal threats'
 		},
 		'uw-login': {
-			label: 'Editing while logged out',
-			summary: 'Warning: Editing while logged out'
+			label: 'Making controversial edits while logged out',
+			summary: 'Warning: Making controversial edits while logged out'
 		},
 		'uw-multipleTAs': {
 			label: 'Usage of multiple temporary accounts',


### PR DESCRIPTION
Fixes #2359. test: https://en.wikipedia.org/w/index.php?title=User_talk:Sandbox_for_user_warnings&diff=prev&oldid=1354839205
_(finally got these version control things working properly : )_